### PR TITLE
[4/4] Retain a released hole in an enclosing aggregate force

### DIFF
--- a/include/verilated_force.h
+++ b/include/verilated_force.h
@@ -47,31 +47,6 @@ struct VlForceTypeInfo final {
     using Type = VlForceBaseType<T>;
     static constexpr bool bitwise
         = std::is_integral<Type>::value || std::is_enum<Type>::value || VlIsVlWide<Type>::value;
-    static constexpr bool unpackedArray = false;
-};
-
-template <typename T>
-struct VlForceArrayIndexer final {
-    static constexpr std::size_t size = 1;
-
-    static T& elem(T& value, std::size_t) { return value; }
-};
-
-template <typename T, std::size_t N>
-struct VlForceArrayIndexer<VlUnpacked<T, N>> final {
-    static constexpr std::size_t size = N * VlForceArrayIndexer<T>::size;
-
-    static auto& elem(VlUnpacked<T, N>& array, std::size_t index) {
-        constexpr std::size_t subSize = VlForceArrayIndexer<T>::size;
-        return VlForceArrayIndexer<T>::elem(array[index / subSize], index % subSize);
-    }
-};
-
-template <typename T, std::size_t N>
-struct VlForceTypeInfo<VlUnpacked<T, N>> final {
-    using Type = VlUnpacked<T, N>;
-    static constexpr bool bitwise = false;
-    static constexpr bool unpackedArray = true;
 };
 
 template <typename T, bool = std::is_enum<T>::value>
@@ -101,13 +76,14 @@ using VlForceStorageType = typename VlForceStorageTypeOf<VlForceBaseType<T>>::ty
 class VlForceVec final {
 private:
     struct Entry final {
-        int m_lsb;  // Inclusive lower bit for scalar path or element index for unpacked
-        int m_msb;  // Inclusive upper bit for scalar path or element index for unpacked
+        int m_lsb;  // Inclusive lower bit for scalar path or slot index for slot-tracked
+        int m_msb;  // Inclusive upper bit for scalar path or slot index for slot-tracked
         int m_rhsLsb;  // Destination index that maps to RHS index 0
-        const void* m_rhsDatap;  // Pointer to RHS storage
+        const void* m_rhsDatap;  // Pointer to RHS storage (bitwise variables only)
         int m_bitLsb = 0;
         int m_bitMsb = 0;
         int m_elemWidth = 0;
+        int m_id = -1;  // Force statement id for slot-tracked variables, else -1
     };
 
     std::vector<Entry> m_entries;  // Sorted by msb, non-overlapping
@@ -117,7 +93,8 @@ private:
                                    [](const Entry& e, int bit) { return e.m_msb < bit; });
         while (it != m_entries.end() && it->m_lsb <= msb) {
             if (it->m_lsb < lsb && it->m_msb > msb) {
-                const Entry right{msb + 1, it->m_msb, it->m_rhsLsb, it->m_rhsDatap};
+                Entry right = *it;  // Splits keep the owning force's identity on both halves
+                right.m_lsb = msb + 1;
                 it->m_msb = lsb - 1;
                 return m_entries.insert(++it, right);
             }
@@ -135,11 +112,48 @@ private:
         return it;
     }
 
-    std::size_t trimElementBitRange(int elem, int bitLsb, int bitMsb) {
+    // Split any entry spanning more slots than [elem, elem] so that per-bit trimming below
+    // never leaves the vector unsorted, and so the split-off slot can carry a bit range
+    void isolateSlot(int elem, int elemWidth) {
+        auto it = std::lower_bound(m_entries.begin(), m_entries.end(), elem,
+                                   [](const Entry& e, int idx) { return e.m_msb < idx; });
+        if (it == m_entries.end() || it->m_lsb > elem) return;
+        if (it->m_lsb == elem && it->m_msb == elem) {
+            if (it->m_elemWidth == 0) {  // Owned whole; make that an explicit full bit range
+                it->m_bitLsb = 0;
+                it->m_bitMsb = elemWidth - 1;
+                it->m_elemWidth = elemWidth;
+            }
+            return;
+        }
+        Entry mid = *it;
+        mid.m_lsb = mid.m_msb = elem;
+        if (mid.m_elemWidth == 0) {  // Owned whole; make that an explicit full bit range
+            mid.m_bitLsb = 0;
+            mid.m_bitMsb = elemWidth - 1;
+            mid.m_elemWidth = elemWidth;
+        }
+        const Entry orig = *it;
+        auto at = m_entries.erase(it);
+        if (orig.m_msb > elem) {
+            Entry right = orig;
+            right.m_lsb = elem + 1;
+            at = m_entries.insert(at, right);
+        }
+        at = m_entries.insert(at, mid);
+        if (orig.m_lsb < elem) {
+            Entry left = orig;
+            left.m_msb = elem - 1;
+            m_entries.insert(at, left);
+        }
+    }
+
+    std::size_t trimElementBitRange(int elem, int bitLsb, int bitMsb, int elemWidth) {
+        isolateSlot(elem, elemWidth);
         auto it = std::lower_bound(m_entries.begin(), m_entries.end(), elem,
                                    [](const Entry& e, int idx) { return e.m_msb < idx; });
         while (it != m_entries.end() && it->m_lsb <= elem) {
-            if (it->m_elemWidth == 0 || it->m_bitMsb < bitLsb || it->m_bitLsb > bitMsb) {
+            if (it->m_bitMsb < bitLsb || it->m_bitLsb > bitMsb) {
                 ++it;
                 continue;
             }
@@ -161,12 +175,8 @@ private:
             }
             it = m_entries.erase(it);
         }
-        auto ins = std::lower_bound(m_entries.begin(), m_entries.end(), elem,
-                                    [](const Entry& e, int idx) { return e.m_msb < idx; });
-        while (ins != m_entries.end() && ins->m_lsb <= elem
-               && (ins->m_elemWidth == 0 || ins->m_bitLsb <= bitLsb)) {
-            ++ins;
-        }
+        const auto ins = std::lower_bound(m_entries.begin(), m_entries.end(), elem,
+                                          [](const Entry& e, int idx) { return e.m_msb < idx; });
         return static_cast<std::size_t>(ins - m_entries.begin());
     }
 
@@ -231,22 +241,6 @@ private:
         return *static_cast<const VlForceBaseType<T>*>(entry.m_rhsDatap);
     }
 
-    template <typename Elem>
-    static typename std::enable_if<!VlIsVlWide<Elem>::value, Elem>::type
-    blendElem(Elem cur, const Entry& e) {
-        const Entry bitEntry{e.m_bitLsb, e.m_bitMsb, e.m_rhsLsb, e.m_rhsDatap, 0, 0, 0};
-        return applyEntry(cur, bitEntry);
-    }
-
-    template <typename Elem>
-    static typename std::enable_if<VlIsVlWide<Elem>::value, Elem>::type blendElem(Elem cur,
-                                                                                  const Entry& e) {
-        Elem res = cur;
-        const Entry bitEntry{e.m_bitLsb, e.m_bitMsb, e.m_rhsLsb, e.m_rhsDatap, 0, 0, 0};
-        applyEntry(res, bitEntry, e.m_bitLsb, e.m_bitMsb, 0);
-        return res;
-    }
-
     template <typename T>
     typename std::enable_if<VlIsVlWide<T>::value>::type applyEntries(T& val) const {
         for (const auto& entry : m_entries) {
@@ -276,47 +270,7 @@ public:
     template <typename T>
     T read(const T& val) const {
         T result = val;
-        if VL_CONSTEXPR_CXX17 (VlForceTypeInfo<T>::unpackedArray) {
-            // Handling the case of a nested flattened array using recursion
-            using ElemRef
-                = decltype(VlForceArrayIndexer<T>::elem(result, static_cast<std::size_t>(0)));
-            using Elem = VlForceBaseType<ElemRef>;
-            for (const auto& entry : m_entries) {
-                const int startIdx = entry.m_lsb;
-                const int endIdx = entry.m_msb;
-                for (int idx = startIdx; idx <= endIdx; idx++) {
-                    const std::size_t uidx = static_cast<std::size_t>(idx);
-                    Elem& dst = VlForceArrayIndexer<T>::elem(result, uidx);
-                    if (entry.m_elemWidth == 0) {
-                        const Elem* const rhsBasep = static_cast<const Elem*>(entry.m_rhsDatap);
-                        const int rhsIndex = idx - entry.m_rhsLsb;
-                        dst = rhsBasep[rhsIndex];
-                    } else {
-                        dst = blendElem<Elem>(dst, entry);
-                    }
-                }
-            }
-            return result;
-        }
         applyEntries(result);
-        return result;
-    }
-
-    template <typename T>
-    T readIndex(T origVal, int index) const {
-        if (m_entries.empty()) return origVal;
-
-        T result = origVal;
-        for (auto it = std::lower_bound(m_entries.begin(), m_entries.end(), index,
-                                        [](const Entry& e, int idx) { return e.m_msb < idx; });
-             it != m_entries.end() && it->m_lsb <= index; ++it) {
-            if (it->m_elemWidth == 0) {
-                const int rhsIndex = index - it->m_rhsLsb;
-                result = static_cast<const T*>(it->m_rhsDatap)[rhsIndex];
-            } else {
-                result = blendElem<T>(result, *it);
-            }
-        }
         return result;
     }
 
@@ -342,35 +296,87 @@ public:
         return result;
     }
 
+    // Preconditions (lsb <= msb, rhsDatap non-null, rhsLsb <= lsb) are checked in V3Force
+    // where the call is generated and a source location is available.
     void addForce(int lsb, int msb, const void* rhsDatap, int rhsLsb) {
-        assert(lsb <= msb);
-        assert(rhsDatap);
-        assert(rhsLsb <= lsb);
-
         auto it = trimEntries(lsb, msb);
         m_entries.insert(it, {lsb, msb, rhsLsb, rhsDatap});
     }
 
-    void addForce(int lsb, int msb, const void* rhsDatap, int rhsLsb, int bitLsb, int bitMsb,
-                  int elemWidth) {
-        assert(lsb == msb);
-        assert(rhsDatap);
-        assert(elemWidth > 0);
-        assert(0 <= bitLsb && bitLsb <= bitMsb && bitMsb < elemWidth);
-        const std::size_t at = trimElementBitRange(lsb, bitLsb, bitMsb);
-        m_entries.insert(m_entries.begin() + at,
-                         Entry{lsb, msb, rhsLsb, rhsDatap, bitLsb, bitMsb, elemWidth});
+    // Register a force on a slot-tracked variable.  The value lives in the force's own
+    // typed shadow variable; entries only record which force owns which slots.
+    void addForceAt(int id, int lsb, int msb) {
+        auto it = trimEntries(lsb, msb);
+        Entry entry{lsb, msb, 0, nullptr};
+        entry.m_id = id;
+        m_entries.insert(it, entry);
     }
 
-    void release(int lsb, int msb) {
-        assert(lsb <= msb);
-        trimEntries(lsb, msb);
+    // Register a force of a bit range within one slot of a slot-tracked variable
+    void addForceAt(int id, int slot, int bitLsb, int bitMsb, int elemWidth) {
+        const std::size_t at = trimElementBitRange(slot, bitLsb, bitMsb, elemWidth);
+        Entry entry{slot, slot, 0, nullptr, bitLsb, bitMsb, elemWidth};
+        entry.m_id = id;
+        m_entries.insert(m_entries.begin() + at, entry);
     }
 
-    void release(int lsb, int msb, int bitLsb, int bitMsb) {
-        assert(lsb == msb);
-        assert(bitLsb <= bitMsb);
-        trimElementBitRange(lsb, bitLsb, bitMsb);
+    void release(int lsb, int msb) { trimEntries(lsb, msb); }
+
+    void release(int lsb, int msb, int bitLsb, int bitMsb, int elemWidth) {
+        trimElementBitRange(lsb, bitLsb, bitMsb, elemWidth);
+    }
+
+    // True when force 'id' owns anything in the slot range
+    bool ownsAny(int id, int lsb, int msb) const {
+        auto it = std::lower_bound(m_entries.begin(), m_entries.end(), lsb,
+                                   [](const Entry& e, int bit) { return e.m_msb < bit; });
+        for (; it != m_entries.end() && it->m_lsb <= msb; ++it) {
+            if (it->m_id == id) return true;
+        }
+        return false;
+    }
+
+    bool ownsSlot(int id, int slot) const { return ownsAny(id, slot, slot); }
+
+    // Blend the bits of 'rhsVal' that force 'id' currently owns at 'slot' into 'cur'.
+    // Yields 'cur' unchanged when the force owns nothing there.
+    template <typename T>
+    typename std::enable_if<!VlIsVlWide<T>::value, T>::type blendOwned(T cur, QData rhsVal, int id,
+                                                                       int slot) const {
+        using U = VlForceStorageType<T>;
+        U result = static_cast<U>(cur);
+        auto it = std::lower_bound(m_entries.begin(), m_entries.end(), slot,
+                                   [](const Entry& e, int idx) { return e.m_msb < idx; });
+        for (; it != m_entries.end() && it->m_lsb <= slot; ++it) {
+            if (it->m_id != id) continue;
+            if (it->m_elemWidth == 0) return static_cast<T>(rhsVal);  // Owns the whole slot
+            const int width = it->m_bitMsb - it->m_bitLsb + 1;
+            const U mask = static_cast<U>(static_cast<U>(VL_MASK_Q(width)) << it->m_bitLsb);
+            result = static_cast<U>((result & ~mask) | (static_cast<U>(rhsVal) & mask));
+        }
+        return static_cast<T>(result);
+    }
+
+    template <typename T>
+    typename std::enable_if<VlIsVlWide<T>::value, T>::type blendOwned(T cur, const T& rhsVal,
+                                                                      int id, int slot) const {
+        T result = cur;
+        auto it = std::lower_bound(m_entries.begin(), m_entries.end(), slot,
+                                   [](const Entry& e, int idx) { return e.m_msb < idx; });
+        for (; it != m_entries.end() && it->m_lsb <= slot; ++it) {
+            if (it->m_id != id) continue;
+            if (it->m_elemWidth == 0) return rhsVal;  // Owns the whole slot
+            for (int word = VL_BITWORD_E(it->m_bitLsb); word <= VL_BITWORD_E(it->m_bitMsb);
+                 ++word) {
+                const int wordLsb = word * VL_EDATASIZE;
+                const int segLsb = std::max(it->m_bitLsb, wordLsb);
+                const int segMsb = std::min(it->m_bitMsb, wordLsb + VL_EDATASIZE - 1);
+                const int width = segMsb - segLsb + 1;
+                const EData mask = static_cast<EData>(VL_MASK_Q(width)) << (segLsb - wordLsb);
+                result[word] = (result[word] & ~mask) | (rhsVal[word] & mask);
+            }
+        }
+        return result;
     }
 
     void touch() {}

--- a/src/V3AstAttr.h
+++ b/src/V3AstAttr.h
@@ -881,8 +881,11 @@ public:
         EVENT_IS_FIRED,
         EVENT_IS_TRIGGERED,
         FORCE_ADD,
+        FORCE_ADD_AT,
+        FORCE_BLEND_OWNED,
+        FORCE_OWNS_ANY,
+        FORCE_OWNS_SLOT,
         FORCE_READ,
-        FORCE_READ_INDEX,
         FORCE_READ_SEL,
         FORCE_RELEASE,
         FORCE_TOUCH,
@@ -1035,8 +1038,11 @@ inline std::ostream& operator<<(std::ostream& os, const VCMethod& rhs) {
            {EVENT_IS_FIRED, "isFired", true}, \
            {EVENT_IS_TRIGGERED, "isTriggered", true}, \
            {FORCE_ADD, "addForce", false}, \
+           {FORCE_ADD_AT, "addForceAt", false}, \
+           {FORCE_BLEND_OWNED, "blendOwned", true}, \
+           {FORCE_OWNS_ANY, "ownsAny", true}, \
+           {FORCE_OWNS_SLOT, "ownsSlot", true}, \
            {FORCE_READ, "read", true}, \
-           {FORCE_READ_INDEX, "readIndex", true}, \
            {FORCE_READ_SEL, "readSel", true}, \
            {FORCE_RELEASE, "release", false}, \
            {FORCE_TOUCH, "touch", false}, \

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -2738,7 +2738,14 @@ public:
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override {
-        // Not a union
+        // A packed union member can carry dirty upper bits.  An unpacked-typed member
+        // has no pad bits at all, so there is nothing to clean, and masking it would
+        // apply a bitwise operation to an unpacked value.
+        if (VN_IS(dtypep()->skipRefp(), UnpackArrayDType)) return true;
+        if (const AstNodeUOrStructDType* const sdtypep
+            = VN_CAST(dtypep()->skipRefp(), NodeUOrStructDType)) {
+            if (!sdtypep->packed()) return true;
+        }
         return VN_IS(fromp()->dtypep()->skipRefp(), StructDType);
     }
     bool sameNode(const AstNode* samep) const override {

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -15,20 +15,37 @@
 //*************************************************************************
 //  V3Force's Transformations:
 //
+//  Every force target on a variable is given a slot in that variable's VlForceVec.  A plain
+//  bitwise variable is addressed by bit range, so a slot is a bit.  Anything else is addressed
+//  by leaf: an aggregate is laid out depth first, and a leaf's slot is the member offsets its
+//  path crosses plus each element index times that element's own slot count.  One numbering
+//  covers 's.arr[2]', 's.scalar' and 'sa[0].arr[2]' alike, and a run-time element index
+//  computes its slot with the same arithmetic.
+//
 //  For each forceable var/net "<name>":
 //    - Create <name>__VforceVec (VlForceVec) to track active force ranges
 //    - Create <name>__VforceRHS<ID> vars to hold RHS shadow values
 //    - Add continuous assignments: <name>__VforceRHS<ID> = RHS
 //
-//  For each `force <name>[range] = <RHS>` with ID:
-//    - <name>__VforceVec.addForce(lsb, msb, &__VforceRHS, rhsLsb)
+//  For each `force <name><path> = <RHS>` with ID:
+//    - <name>__VforceVec.addForce(slot_lsb, slot_msb, &__VforceRHS, rhsLsb)
 //
-//  For each `release <name>[range]`:
-//    - If not continuously driven: <name> = VlForceVec::read(<name>, __VforceVec)
-//    - <name>__VforceVec.release(lsb, msb)
+//  For each `release <name><path>`:
+//    - If not continuously driven: <name><path> = VlForceVec::read(<name><path>, __VforceVec)
+//    - <name>__VforceVec.release(slot_lsb, slot_msb)
 //
-//  For each read of <name>:
-//    - Replace with: VlForceVec::read(<name>, __VforceVec)
+//  For each read of <name><path>:
+//    - Replace with: VlForceVec::read(<name><path>, __VforceVec, slot)
+//
+//  Slot-tracked variables register only ownership: VlForceVec records which force id owns
+//  which slots, and every value lives in that force's own typed shadow (__VforceRHS<ID>).
+//  A read of a leaf compiles to a chain over the forces that can reach it, outermost target
+//  first, each consulting ownership at run time (blendOwned/ownsSlot); a read no force can
+//  reach stays a plain read.  A whole-variable or intermediate-aggregate read goes through a
+//  <name>__VforceSlotRd shadow, rebuilt as a raw copy plus one guarded write per force, with
+//  raw put back where an inner force or release has punched a hole out of an enclosing one.
+//  A force naming a whole aggregate is one entry covering its slot range, so generated code
+//  scales with the number of force statements, never with data size.
 //
 //*************************************************************************
 
@@ -37,6 +54,7 @@
 #include "V3Force.h"
 
 #include "V3AstUserAllocator.h"
+#include "V3EmitCBase.h"
 #include "V3Stats.h"
 #include "V3UniqueNames.h"
 
@@ -54,17 +72,17 @@ public:
     struct ForceInfo final : ForceRange {
         // MEMBERS
         int m_forceId = 0;  // Unique (per signal) variable of this force assignment
-        bool m_hasArraySel = false;  // If this has an array select on LHS
         AstVarScope* m_rhsVarVscp = nullptr;  // Scope of the var containing RHSID
         AstNodeExpr* m_rhsExprp = nullptr;  // Expression on RHS of this force assignment
+        AstNodeExpr* m_lhsPathp = nullptr;  // Copy of the target path, owned here
 
         ForceInfo() = default;
         ForceInfo(int rangeLsb, int rangeMsb, int padLsb, int padMsb, int forceId,
-                  bool hasArraySel, AstVarScope* rhsVarVscp, AstNodeExpr* rhsExprp)
+                  AstVarScope* rhsVarVscp, AstNodeExpr* rhsExprp, AstNodeExpr* lhsPathp)
             : m_forceId{forceId}
-            , m_hasArraySel{hasArraySel}
             , m_rhsVarVscp{rhsVarVscp}
-            , m_rhsExprp{rhsExprp} {
+            , m_rhsExprp{rhsExprp}
+            , m_lhsPathp{lhsPathp} {
             m_rangeLsb = rangeLsb;
             m_rangeMsb = rangeMsb;
             m_padLsb = padLsb;
@@ -72,53 +90,36 @@ public:
         }
     };
 
+    // Above this many forces reaching one read or release, per-site compiled chains
+    // are routed through the variable's shared shadow function instead, so generated
+    // code stays linear in force statements plus sites
+    static constexpr int FORCE_CHAIN_MAX = 8;
+
     struct VarForceInfo final {
         AstVarScope* m_forceVecVscp = nullptr;
-        AstVarScope* m_forceRdVscp = nullptr;
+        AstVarScope* m_forceRdVscp = nullptr;  // __VforceRd: externally forceable merged value
+        AstVarScope* m_slotRdVscp = nullptr;  // __VforceSlotRd: code-forced merged value
         AstVarScope* m_forceEnVscp = nullptr;
         AstVarScope* m_forceValVscp = nullptr;
         AstVarScope* m_varVscp = nullptr;
         AstVar* m_varp = nullptr;
         AstScope* m_scopep = nullptr;
         std::unordered_map<AstAssignForce*, ForceInfo> m_forces;
-        std::unordered_map<string, int> m_forcePathToIndex;
-        int m_nextForcePathIndex = 1;  // Start at 1 so 0 can be the base path (whole signal)
+        // Statements identical to an earlier force (same path, range and right-hand
+        // side) share its ForceInfo: each execution re-establishes the same ownership
+        // and value, so one id, one shadow and one read arm serve them all
+        std::unordered_map<AstAssignForce*, AstAssignForce*> m_forceAliases;
+        // Shared per-variable shadow rebuild functions, created on first use, so each
+        // procedural refresh site is one call however many forces the variable has
+        mutable AstCFunc* m_slotRdRefreshFuncp = nullptr;
+        mutable AstCFunc* m_forceRdRefreshFuncp = nullptr;
+        mutable bool m_forceRdRefreshNeedsVec = false;
 
-    private:
-        static void buildForcePathKeyRecurse(AstNodeExpr* nodep, string& out) {
-            if (VN_IS(nodep, VarRef)) return;
-            if (const AstSel* const selp = VN_CAST(nodep, Sel)) {
-                buildForcePathKeyRecurse(selp->fromp(), out);
-                out += "|S" + cvtToStr(selp->lsbConst()) + ":" + cvtToStr(selp->widthConst());
-                return;
-            }
-            if (AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
-                AstNodeExpr* const fromp = selp->fromp();
-                buildForcePathKeyRecurse(fromp, out);
-                out += "|T" + selp->name();
-                return;
-            }
-            nodep->v3fatalSrc("Unsupported: opaque force path selector "
-                              << nodep->prettyTypeName());
-        }
-
-        static string forcePathKey(AstNodeExpr* nodep) {
-            string out;
-            buildForcePathKeyRecurse(nodep, out);
-            return out;
-        }
-
-    public:
-        int getOrCreateForcePathIndex(AstNodeExpr* nodep) {
-            const auto pair
-                = m_forcePathToIndex.emplace(forcePathKey(nodep), m_nextForcePathIndex);
-            if (pair.second) ++m_nextForcePathIndex;
-            return pair.first->second;
-        }
-
-        int findForcePathIndex(AstNodeExpr* nodep) const {
-            const auto it = m_forcePathToIndex.find(forcePathKey(nodep));
-            return it != m_forcePathToIndex.end() ? it->second : -1;
+        // The variable's whole merged value, whichever shadow holds it: the externally
+        // forceable __VforceRd (which also overlays the public enable/value) or the
+        // code-force-only __VforceSlotRd.  Null when the variable keeps no whole-value shadow.
+        AstVarScope* wholeReadShadowVscp() const {
+            return m_slotRdVscp ? m_slotRdVscp : m_forceRdVscp;
         }
     };
 
@@ -128,14 +129,11 @@ public:
         AstVar* m_valVarp = nullptr;
     };
 
-    struct ArraySelInfo final {
-        std::vector<AstArraySel*> m_sels;
-        bool m_hasBitSel = false;
-    };
-
-    struct ForceRangeInfo final : ForceRange {
-        bool m_hasArraySel = false;
-        ArraySelInfo m_arrayInfo;
+    // Slot ordinal of a leaf within its base variable, split into the part known at
+    // verilation time and the part a run-time element index contributes.
+    struct ForceOrdinal final {
+        int m_constOffset = 0;
+        AstNodeExpr* m_exprp = nullptr;  // Null when every element index is constant
     };
 
 private:
@@ -165,6 +163,17 @@ public:
     ForceState(bool doingAssign, ForceHelperVarsByVar& forceHelperVarsByVar)
         : m_forceHelperVarsByVar{forceHelperVarsByVar}
         , m_doingAssign{doingAssign} {}
+    ~ForceState() {
+        // The target paths are copies kept for building shadow updates, and are never
+        // linked into the tree, so this owns them
+        for (VarForceInfo& info : m_varInfos) {
+            for (auto& pair : info.m_forces) {
+                if (AstNodeExpr* const pathp = pair.second.m_lhsPathp) {
+                    VL_DO_DANGLING(pathp->deleteTree(), pathp);
+                }
+            }
+        }
+    }
     VL_UNCOPYABLE(ForceState);
 
     // STATIC METHODS
@@ -185,6 +194,14 @@ public:
         return new AstConst{nodep->fileline(), mask};
     }
 
+    // The bitwise force-read blend (en & val) | (~en & orig).  'enp' is consumed twice,
+    // once directly and once cloned for the complement; 'valp' and 'origp' are consumed once.
+    static AstNodeExpr* makeEnValBlend(FileLine* flp, AstNodeExpr* enp, AstNodeExpr* valp,
+                                       AstNodeExpr* origp) {
+        return new AstOr{flp, new AstAnd{flp, enp, valp},
+                         new AstAnd{flp, new AstNot{flp, enp->cloneTreePure(false)}, origp}};
+    }
+
     static AstNodeExpr* zeroPadToBaseWidth(AstNodeExpr* exprp, int baseWidth, int padLsb,
                                            int padMsb) {
         if (baseWidth <= 0) return exprp;
@@ -201,6 +218,97 @@ public:
 
     static bool isUnpackedArrayDType(const AstNodeDType* dtypep) {
         return VN_IS(dtypep->skipRefp(), UnpackArrayDType);
+    }
+
+    // Force tracking gives every separately forceable leaf of a variable its own slot in that
+    // variable's VlForceVec.  An aggregate is laid out depth first, so a leaf's slot is the sum
+    // of a fixed offset per member crossed and the element index times the element's own slot
+    // count.  That keeps 's.arr[2]', 's.scalar' and 'sa[0].arr[2]' in one numbering that cannot
+    // collide, and lets a run-time element index be computed with the same arithmetic.
+    static int forceSlots(const AstNodeDType* dtypep) {
+        // Every caller operates on a variable already screened by forceSlotsOverflow, so the
+        // count fits in int; share the recursion with the 64-bit overflow-checking version
+        return static_cast<int>(forceSlots64(dtypep));
+    }
+
+    // The leaf count computed in 64 bits, so a variable whose leaves would overflow the
+    // int slot arithmetic can be rejected rather than silently miscompiled.  Saturates at
+    // one past INT_MAX; only a multi-gigabyte array can reach that.
+    static int64_t forceSlots64(const AstNodeDType* dtypep) {
+        constexpr int64_t k_cap = static_cast<int64_t>(std::numeric_limits<int>::max()) + 1;
+        dtypep = dtypep->skipRefp();
+        if (const AstUnpackArrayDType* const arrayp = VN_CAST(dtypep, UnpackArrayDType)) {
+            const int64_t sub = forceSlots64(arrayp->subDTypep());
+            const int64_t product = static_cast<int64_t>(arrayp->declRange().elements()) * sub;
+            return product > k_cap ? k_cap : product;
+        }
+        if (const AstNodeUOrStructDType* const structp = VN_CAST(dtypep, NodeUOrStructDType)) {
+            if (structp->packed()) return 1;
+            int64_t slots = 0;
+            for (AstMemberDType* memberp = structp->membersp(); memberp;
+                 memberp = VN_AS(memberp->nextp(), MemberDType)) {
+                slots += forceSlots64(memberp->dtypep());
+                if (slots > k_cap) return k_cap;
+            }
+            return slots ? slots : 1;
+        }
+        return 1;
+    }
+
+    // True when the variable has more force slots than the int slot arithmetic can hold
+    static bool forceSlotsOverflow(const AstNodeDType* dtypep) {
+        return forceSlots64(dtypep) > std::numeric_limits<int>::max();
+    }
+
+    // Why a force statement cannot be registered, or nullptr if it can.  Discovery warns
+    // on it and Convert drops the statement on it, so both consult this one predicate and
+    // cannot fall out of step.
+    static const char* forceUnsupportedReason(AstAssignForce* nodep) {
+        AstNodeExpr* const lhsp = nodep->lhsp();
+        if (forceSlotsOverflow(getOneVarRef(lhsp)->varp()->dtypep())) {
+            return "Force of a variable with 2^31 or more elements";
+        }
+        // An aggregate target's value lives in a shadow typed as the target, whose leaf reads
+        // index members/elements out of it, so a differently-typed right-hand side cannot fill
+        // it.  A one-leaf unpacked struct or one-element unpacked array is such a target too,
+        // though its slot count is one, so the test is the typed-shadow shape, not the count
+        if (targetHasTypedShadow(lhsp)
+            && !lhsp->dtypep()->skipRefp()->similarDType(nodep->rhsp()->dtypep()->skipRefp())) {
+            return "Force of an unpacked aggregate from an expression of a different type";
+        }
+        return nullptr;
+    }
+
+    // A force target whose value is held in a shadow typed as the target itself, an unpacked
+    // struct/union or an unpacked array of any leaf count, rather than as a flat bit vector.
+    // Its leaf reads index members/elements out of that shadow.  Mirrors usesForceSlots, which
+    // classifies whole variables, applied to a possibly-narrower force target.
+    static bool targetHasTypedShadow(AstNodeExpr* lhsp) {
+        return forceSlots(lhsp->dtypep()) > 1 || !isBitwiseDType(lhsp)
+               || isUnpackedArrayDType(lhsp->dtypep());
+    }
+
+    // True when this variable's VlForceVec is indexed by leaf slot rather than by bit
+    static bool usesForceSlots(AstVar* varp) {
+        // An unpacked array is a VlUnpacked in C++ whatever its length, so a one-element
+        // array must take the slot path too: its basicp() delegates through to the element
+        // and would otherwise route it to the scalar bit path, emitting uncompilable code
+        return forceSlots(varp->dtypep()) > 1 || !isBitwiseDType(varp)
+               || isUnpackedArrayDType(varp->dtypep());
+    }
+
+    static int memberSlotOffset(const AstNodeDType* fromDtypep, const string& name) {
+        const AstNodeUOrStructDType* const structp
+            = VN_CAST(fromDtypep->skipRefp(), NodeUOrStructDType);
+        UASSERT_OBJ(structp, fromDtypep, "Member select is not on a struct or union");
+        int offset = 0;
+        for (AstMemberDType* memberp = structp->membersp(); memberp;
+             memberp = VN_AS(memberp->nextp(), MemberDType)) {
+            if (memberp->name() == name) return offset;
+            offset += forceSlots(memberp->dtypep());
+        }
+        structp->v3fatalSrc("Member '" << name << "' not found in struct or union");
+        return 0;
     }
 
     static bool isBitwiseDType(AstNode* nodep) {
@@ -220,6 +328,15 @@ public:
 
     static bool isNotReplaceable(const AstVarRef* const nodep) { return nodep->user1(); }
     static void markNonReplaceable(AstVarRef* const nodep) { nodep->user1SetOnce(); }
+
+    // Mark every variable reference in a cloned path as reading (or writing) the raw storage:
+    // set its access and keep the force read-replacer from rewriting it.
+    static void markRawRead(AstNode* nodep) {
+        nodep->foreach([](AstVarRef* const refp) {
+            refp->access(VAccess::READ);
+            markNonReplaceable(refp);
+        });
+    }
 
     static std::vector<ForceInfo*> forceInfosInIdOrder(VarForceInfo& info) {
         std::vector<ForceInfo*> forceps;
@@ -241,14 +358,19 @@ public:
         return forceps;
     }
 
-    static bool isOpaquePathSelector(const AstNode* nodep) {
-        return VN_IS(nodep, Sel) || VN_IS(nodep, NodeSel) || VN_IS(nodep, StructSel);
-    }
-
-    static bool isOutermostOpaquePathSelector(const AstNode* nodep) {
-        if (!isOpaquePathSelector(nodep)) return false;
+    // True when an enclosing selector reaches this node through its 'from' side, so that
+    // selector names a longer path and covers this node.  A node used as an index instead is
+    // a read of its own, as in 'mem[mem[0]]', and this is false for it.
+    static bool isPathFromOfSelector(const AstNode* nodep) {
         const AstNode* const backp = nodep->backp();
-        return !backp || !isOpaquePathSelector(backp);
+        if (!backp) return false;
+        if (const AstSel* const selp = VN_CAST(backp, Sel)) return selp->fromp() == nodep;
+        if (const AstArraySel* const selp = VN_CAST(backp, ArraySel))
+            return selp->fromp() == nodep;
+        if (const AstStructSel* const selp = VN_CAST(backp, StructSel)) {
+            return selp->fromp() == nodep;
+        }
+        return false;
     }
 
     static AstVarRef* getOneVarRef(AstNodeExpr* forceStmtp) {
@@ -294,12 +416,8 @@ public:
         return headp;
     }
 
-    ForceRangeInfo getForceRangeInfo(AstNodeExpr* lhsp, AstVar* varp,
-                                     bool requireConstRangeSelect) {
-        ForceRangeInfo info;
-        info.m_arrayInfo = getArraySelInfo(lhsp);
-        info.m_hasArraySel = !info.m_arrayInfo.m_sels.empty();
-
+    ForceRange getForceRangeInfo(AstNodeExpr* lhsp, AstVar* varp, bool requireConstRangeSelect) {
+        ForceRange info;
         info.m_padMsb = isBitwiseDType(varp) ? (varp->width() - 1) : 0;
 
         if (const AstSel* const outerSelp = VN_CAST(lhsp, Sel)) {
@@ -318,31 +436,15 @@ public:
 
         info.m_rangeLsb = info.m_padLsb;
         info.m_rangeMsb = info.m_padMsb;
-        if (info.m_hasArraySel) {
-            // Unpacked array selections are tracked as a single flattened element index
-            // inside VlForceVec, regardless of how many unpacked dimensions the source uses.
-            std::vector<int> indices;
-            indices.reserve(info.m_arrayInfo.m_sels.size());
-            for (AstArraySel* const selp : info.m_arrayInfo.m_sels) {
-                UASSERT_OBJ(VN_IS(selp->bitp(), Const), selp,
-                            "Unsupported: force on non-constant array select");
-                indices.push_back(VN_AS(selp->bitp(), Const)->toSInt());
-            }
-            info.m_rangeLsb = flattenIndex(indices, arraySelDimSizes(info.m_arrayInfo));
-
-            info.m_rangeMsb = info.m_rangeLsb;
-        } else if (isUnpackedArrayDType(varp->dtypep())) {
-            lhsp->v3fatalSrc("Whole unpacked-array force/release should have been lowered via "
-                             "element selections");
-        }
-        if (!isBitwiseDType(varp) && !info.m_hasArraySel && !VN_IS(lhsp, VarRef)) {
-            // Non-bitwise member/struct paths cannot use a real bit range, so map each distinct
-            // source path onto a synthetic index in VlForceVec and use that index consistently
-            // for force, release, and readback.
-            VarForceInfo& varInfo = getOrCreateVarInfo(getOneVarRef(lhsp)->varScopep());
-            const int index = varInfo.getOrCreateForcePathIndex(lhsp);
-            info.m_rangeLsb = index;
-            info.m_rangeMsb = index;
+        if (usesForceSlots(varp)) {
+            // An aggregate addresses VlForceVec by leaf slot rather than by bit, so the whole
+            // member and element path decides the slot.  A whole-aggregate target covers every
+            // slot it contains; those are lowered to per-leaf targets before this point, so what
+            // arrives here selects one leaf.
+            const ForceOrdinal ordinal = forceOrdinal(lhsp->fileline(), lhsp);
+            UASSERT_OBJ(!ordinal.m_exprp, lhsp, "Unsupported: force on non-constant array select");
+            info.m_rangeLsb = ordinal.m_constOffset;
+            info.m_rangeMsb = info.m_rangeLsb + forceSlots(lhsp->dtypep()) - 1;
         }
         return info;
     }
@@ -399,15 +501,25 @@ public:
         if (VN_IS(varp->dtypeSkipRefp(), UnpackArrayDType)) {
             return createForceRdUpdateStmtUnpacked(varInfo);
         }
+        if (usesForceSlots(varp)) {
+            // An externally forceable aggregate enables its whole value at once, while code
+            // may force single leaves.  Merge each leaf's slot first, then let the external
+            // force override the whole value.
+            AstNodeStmt* const stmtsp = createSlotRdUpdateStmt(varInfo, varInfo.m_forceRdVscp);
+            AstNodeExpr* const rdReadp = new AstVarRef{flp, varInfo.m_forceRdVscp, VAccess::READ};
+            stmtsp->addNext(new AstAssign{
+                flp, new AstVarRef{flp, varInfo.m_forceRdVscp, VAccess::WRITE},
+                new AstCond{flp, new AstVarRef{flp, varInfo.m_forceEnVscp, VAccess::READ},
+                            new AstVarRef{flp, varInfo.m_forceValVscp, VAccess::READ}, rdReadp}});
+            return stmtsp;
+        }
         AstNodeExpr* readExprp = nullptr;
         AstVarRef* const baseRefp = new AstVarRef{flp, varInfo.m_varVscp, VAccess::READ};
         markNonReplaceable(baseRefp);
         AstNodeExpr* const enRefp = new AstVarRef{flp, varInfo.m_forceEnVscp, VAccess::READ};
         AstNodeExpr* const valRefp = new AstVarRef{flp, varInfo.m_forceValVscp, VAccess::READ};
         if (isBitwiseDType(varp)) {
-            readExprp = new AstOr{
-                flp, new AstAnd{flp, enRefp, valRefp},
-                new AstAnd{flp, new AstNot{flp, enRefp->cloneTreePure(false)}, baseRefp}};
+            readExprp = makeEnValBlend(flp, enRefp, valRefp, baseRefp);
         } else {
             readExprp = new AstCond{flp, enRefp, valRefp, baseRefp};
         }
@@ -421,22 +533,24 @@ public:
         AstVar* const varp = varInfo.m_varVscp->varp();
         AstUnpackArrayDType* const arrDtypep = VN_AS(varp->dtypep()->skipRefp(), UnpackArrayDType);
         const std::vector<AstUnpackArrayDType*> dims = arrDtypep->unpackDimensions();
-        return foreachUnpackedLeaf(
+        // Merge the code forces this variable's slots carry into the read shadow first, so a
+        // procedural 'force' of an element is visible through the externally forceable read;
+        // then overlay the per-element external enable and value on top of that merged value.
+        AstNodeStmt* const stmtsp = createSlotRdUpdateStmt(varInfo, varInfo.m_forceRdVscp);
+        stmtsp->addNext(foreachUnpackedLeaf(
             dims, [&](const std::vector<int>& idx, int /*flat*/) -> AstNodeStmt* {
-                AstVarRef* const baseRefp = new AstVarRef{flp, varInfo.m_varVscp, VAccess::READ};
-                markNonReplaceable(baseRefp);
-                AstNodeExpr* const baseSelp = buildNestedArraySel(flp, baseRefp, idx);
+                AstNodeExpr* const baseSelp = buildNestedArraySel(
+                    flp, new AstVarRef{flp, varInfo.m_forceRdVscp, VAccess::READ}, idx);
                 AstNodeExpr* const enSelp = buildNestedArraySel(
                     flp, new AstVarRef{flp, varInfo.m_forceEnVscp, VAccess::READ}, idx);
                 AstNodeExpr* const valSelp = buildNestedArraySel(
                     flp, new AstVarRef{flp, varInfo.m_forceValVscp, VAccess::READ}, idx);
-                AstNodeExpr* const readExprp = new AstOr{
-                    flp, new AstAnd{flp, enSelp, valSelp},
-                    new AstAnd{flp, new AstNot{flp, enSelp->cloneTreePure(false)}, baseSelp}};
+                AstNodeExpr* const readExprp = makeEnValBlend(flp, enSelp, valSelp, baseSelp);
                 AstNodeExpr* const rdLhsSelp = buildNestedArraySel(
                     flp, new AstVarRef{flp, varInfo.m_forceRdVscp, VAccess::WRITE}, idx);
                 return new AstAssign{flp, rdLhsSelp, readExprp};
-            });
+            }));
+        return stmtsp;
     }
 
     VarForceInfo& getOrCreateVarInfo(AstVarScope* vscp) {
@@ -518,11 +632,27 @@ public:
     }
     void addForceAssignment(AstVar* varp, AstVarScope* vscp, AstNodeExpr* rhsExprp,
                             AstAssignForce* forceStmtp, int rangeLsb, int rangeMsb, int padLsb,
-                            int padMsb, bool hasArraySel) {
+                            int padMsb, AstNodeExpr* lhsPathp) {
         v3Global.setUsesForce();
         varp->setForcedByCode();
 
         VarForceInfo& info = getOrCreateVarInfo(vscp);
+        for (auto& it : info.m_forces) {
+            const ForceInfo& other = it.second;
+            if (other.m_rangeLsb != rangeLsb || other.m_rangeMsb != rangeMsb) continue;
+            if (other.m_padLsb != padLsb || other.m_padMsb != padMsb) continue;
+            if (!other.m_rhsExprp || !other.m_rhsExprp->sameTree(rhsExprp)) continue;
+            if (!!other.m_lhsPathp != !!lhsPathp) continue;
+            if (lhsPathp) {
+                lhsPathp->foreach([](AstVarRef* const refp) { refp->access(VAccess::READ); });
+                if (!other.m_lhsPathp->sameTree(lhsPathp)) continue;
+            }
+            info.m_forceAliases.emplace(forceStmtp, it.first);
+            VL_DO_DANGLING(rhsExprp->deleteTree(), rhsExprp);
+            if (lhsPathp) VL_DO_DANGLING(lhsPathp->deleteTree(), lhsPathp);
+            UINFO(3, "Aliased identical force statement for " << varp->name() << "\n");
+            return;
+        }
         const int forceId = info.m_forces.size();
         FileLine* const flp = varp->fileline();
         AstScope* const scopep = vscp->scopep();
@@ -544,9 +674,14 @@ public:
             scopep->addVarsp(info.m_forceVecVscp);
         }
 
-        auto pair = info.m_forces.emplace(forceStmtp,
-                                          ForceInfo{rangeLsb, rangeMsb, padLsb, padMsb, forceId,
-                                                    hasArraySel, nullptr, rhsExprp});
+        // The stored path is only ever used to build reads and rebased writes, and it came
+        // from a force left-hand side, so drop the write access its references carry
+        if (lhsPathp) {
+            lhsPathp->foreach([](AstVarRef* const refp) { refp->access(VAccess::READ); });
+        }
+        auto pair
+            = info.m_forces.emplace(forceStmtp, ForceInfo{rangeLsb, rangeMsb, padLsb, padMsb,
+                                                          forceId, nullptr, rhsExprp, lhsPathp});
         ForceInfo& finfo = pair.first->second;
         if (doingAssign()) {
             std::vector<AstVar*> depVarps;
@@ -565,79 +700,202 @@ public:
                                    << rangeLsb << "]\n");
     }
 
-    static void collectArraySelInfo(AstNodeExpr* exprp, ArraySelInfo& info) {
-        if (const auto* const selp = VN_CAST(exprp, Sel)) {
-            info.m_hasBitSel = true;
-            collectArraySelInfo(selp->fromp(), info);
-        } else if (auto* const selp = VN_CAST(exprp, ArraySel)) {
-            collectArraySelInfo(selp->fromp(), info);
-            info.m_sels.push_back(selp);
+    static void collectArraySels(AstNodeExpr* exprp, std::vector<AstArraySel*>& out) {
+        if (auto* const selp = VN_CAST(exprp, ArraySel)) {
+            collectArraySels(selp->fromp(), out);
+            out.push_back(selp);
         } else if (const auto* const memberp = VN_CAST(exprp, StructSel)) {
-            collectArraySelInfo(memberp->fromp(), info);
+            collectArraySels(memberp->fromp(), out);
         }
     }
 
-    static ArraySelInfo getArraySelInfo(AstNodeExpr* exprp) {
-        ArraySelInfo info;
-        collectArraySelInfo(exprp, info);
-        return info;
+    static std::vector<AstArraySel*> arraySelsOf(AstNodeExpr* exprp) {
+        std::vector<AstArraySel*> out;
+        collectArraySels(exprp, out);
+        return out;
     }
 
-    static std::vector<int> arraySelDimSizes(const ArraySelInfo& info) {
-        std::vector<int> dims;
-        dims.reserve(info.m_sels.size());
-        for (AstArraySel* const selp : info.m_sels) {
-            AstNodeDType* const dtypep = selp->fromp()->dtypep()->skipRefp();
-            const AstUnpackArrayDType* const arrayp = VN_CAST(dtypep, UnpackArrayDType);
-            UASSERT_OBJ(arrayp, selp, "Array select is not on unpacked array");
-            dims.push_back(arrayp->declRange().elements());
+    struct SlotRange final {
+        int m_lo = 0;
+        int m_hi = 0;
+    };
+
+    // Strip any trailing bit or part selects to reach the leaf they address
+    static AstNodeExpr* stripToLeaf(AstNodeExpr* nodep) {
+        while (AstSel* const selp = VN_CAST(nodep, Sel)) nodep = selp->fromp();
+        return nodep;
+    }
+
+    // Everything the member/element route of a force or read target means, computed in one
+    // descent so the facets can never disagree.  A trailing bit or part select contributes
+    // nothing here (it stays inside one leaf); each aggregate selector adds its slot offset,
+    // and a run-time element index is interpreted three ways at once: it widens the static
+    // slot range to the whole array (m_range), leaves the constant ordinal offset alone, and,
+    // when a fileline is supplied, builds the run-time slot expression (m_ordinal.m_exprp).
+    struct ForcePath final {
+        AstNodeExpr* m_leafp = nullptr;  // Path with trailing bit/part selects stripped
+        int m_depth = 0;  // Count of member and element selectors
+        SlotRange m_range;  // Static slot range, run-time index widened, leaf included
+        ForceOrdinal m_ordinal;  // Constant slot offset plus optional run-time index expr
+    };
+
+    static void analyzePathRecurse(AstNodeExpr* nodep, FileLine* flp, ForcePath& out) {
+        if (const AstSel* const selp = VN_CAST(nodep, Sel)) {
+            analyzePathRecurse(selp->fromp(), flp, out);  // bit/part select: no slot effect
+            return;
         }
-        return dims;
-    }
-
-    static int flattenIndex(const std::vector<int>& indices, const std::vector<int>& dimSizes) {
-        UASSERT(indices.size() == dimSizes.size(), "Array index and dimension size mismatch");
-        int index = 0;
-        int stride = 1;
-        for (int i = static_cast<int>(indices.size()) - 1; i >= 0; --i) {
-            index += indices[i] * stride;
-            stride *= dimSizes[i];
-        }
-        return index;
-    }
-
-    static AstNodeExpr* buildFlattenIndexExpr(FileLine* flp, const ArraySelInfo& info) {
-        const std::vector<int> dimSizes = arraySelDimSizes(info);
-        bool allConst = true;
-        for (AstArraySel* const selp : info.m_sels) {
-            if (!VN_IS(selp->bitp(), Const)) {
-                allConst = false;
-                break;
+        if (AstArraySel* const selp = VN_CAST(nodep, ArraySel)) {
+            analyzePathRecurse(selp->fromp(), flp, out);
+            ++out.m_depth;
+            // The element's own slot count is this dimension's stride, so nested dimensions
+            // fall out of the recursion without needing the dimension sizes separately
+            const int stride = forceSlots(selp->dtypep());
+            if (const AstConst* const constp = VN_CAST(selp->bitp(), Const)) {
+                const int off = static_cast<int>(constp->toSInt()) * stride;
+                out.m_range.m_lo += off;
+                out.m_range.m_hi += off;
+                out.m_ordinal.m_constOffset += off;
+                return;
             }
-        }
-        if (allConst) {
-            std::vector<int> constIndices;
-            constIndices.reserve(info.m_sels.size());
-            for (AstArraySel* const selp : info.m_sels) {
-                constIndices.push_back(VN_AS(selp->bitp(), Const)->toSInt());
+            // A read may select the element at run time.  Only a force target has to name a
+            // constant element; 'array[i]' with a variable 'i' is an ordinary read, so its
+            // static range widens to the whole array and its ordinal is a run-time expression.
+            const AstUnpackArrayDType* const arrayp
+                = VN_AS(selp->fromp()->dtypep()->skipRefp(), UnpackArrayDType);
+            out.m_range.m_hi += (arrayp->declRange().elements() - 1) * stride;
+            if (flp) {
+                AstNodeExpr* termp = selp->bitp()->cloneTreePure(false);
+                // V3Width sizes an array index to at most 32 bits, so widening is all that is
+                // needed to keep the arithmetic below width matched.
+                if (termp->width() < 32) termp = new AstExtend{flp, termp, 32};
+                if (stride != 1) termp = new AstMul{flp, termp, makeConst32(flp, stride)};
+                out.m_ordinal.m_exprp = out.m_ordinal.m_exprp
+                                            ? new AstAdd{flp, out.m_ordinal.m_exprp, termp}
+                                            : termp;
             }
-            return makeConst32(flp, flattenIndex(constIndices, dimSizes));
+            return;
         }
-        // A read may select the element at run time, so compute the same flattened index
-        // as flattenIndex() does, but as an expression.  Only a force target has to be a
-        // constant element; 'array[i]' with a variable 'i' is an ordinary read.
-        AstNodeExpr* resultp = nullptr;
-        int stride = 1;
-        for (int i = static_cast<int>(info.m_sels.size()) - 1; i >= 0; --i) {
-            AstNodeExpr* termp = info.m_sels[i]->bitp()->cloneTreePure(false);
-            // V3Width sizes an array index to at most 32 bits, so widening is all that
-            // is needed to keep the arithmetic below width matched.
-            if (termp->width() < 32) termp = new AstExtend{flp, termp, 32};
-            if (stride != 1) termp = new AstMul{flp, termp, makeConst32(flp, stride)};
-            resultp = resultp ? new AstAdd{flp, resultp, termp} : termp;
-            stride *= dimSizes[i];
+        if (const AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            analyzePathRecurse(selp->fromp(), flp, out);
+            ++out.m_depth;
+            const int off = memberSlotOffset(selp->fromp()->dtypep(), selp->name());
+            out.m_range.m_lo += off;
+            out.m_range.m_hi += off;
+            out.m_ordinal.m_constOffset += off;
+            return;
         }
-        return resultp;
+        // An AstVarRef, or anything else, is the base the route is measured from
+    }
+
+    // Analyze a target's member/element route.  Pass a fileline only when the run-time slot
+    // ordinal expression is needed; without one the static facets are still computed.
+    static ForcePath analyzePath(AstNodeExpr* nodep, FileLine* flp = nullptr) {
+        ForcePath out;
+        out.m_leafp = stripToLeaf(nodep);
+        analyzePathRecurse(nodep, flp, out);
+        out.m_range.m_hi += forceSlots(out.m_leafp->dtypep()) - 1;
+        return out;
+    }
+
+    // Slot range a path can address.  A constant path addresses exactly its subtree; a
+    // run-time element index widens to every slot its array can reach.
+    static SlotRange staticSlotRange(AstNodeExpr* nodep) { return analyzePath(nodep).m_range; }
+
+    // Number of member and element selections above the base variable reference
+    static int pathDepth(AstNodeExpr* nodep) { return analyzePath(nodep).m_depth; }
+
+    // Build a copy of 'pathp' with its deepest 'stripDepth' selectors replaced by 'basep',
+    // so a leaf path can be read out of a force's typed shadow, or written into the
+    // whole-value shadow of its variable.  'pathp' is only read; 'basep' is consumed.
+    static AstNodeExpr* rebaseSuffixOnto(AstNodeExpr* pathp, int stripDepth, AstNodeExpr* basep) {
+        if (pathDepth(pathp) == stripDepth) return basep;
+        FileLine* const flp = pathp->fileline();
+        if (AstArraySel* const selp = VN_CAST(pathp, ArraySel)) {
+            return new AstArraySel{flp, rebaseSuffixOnto(selp->fromp(), stripDepth, basep),
+                                   selp->bitp()->cloneTreePure(false)};
+        }
+        if (const AstStructSel* const selp = VN_CAST(pathp, StructSel)) {
+            AstStructSel* const newp = new AstStructSel{
+                flp, rebaseSuffixOnto(selp->fromp(), stripDepth, basep), selp->name()};
+            newp->dtypep(selp->dtypep());
+            return newp;
+        }
+        pathp->v3fatalSrc("Unsupported selector in force path rebase");
+        return nullptr;
+    }
+
+    // The force target path with any trailing bit or part selects stripped
+    static AstNodeExpr* forceLeafPath(const ForceInfo* finfop) {
+        return stripToLeaf(finfop->m_lhsPathp);
+    }
+
+    static bool isBitSelForce(const ForceInfo* finfop) { return VN_IS(finfop->m_lhsPathp, Sel); }
+
+    // The leaf's structural identity within its variable: member selections by name,
+    // element selections position-blind.  Two paths with different signatures can never
+    // address the same slot, whatever their indices.  Callers pass a leaf reached through
+    // stripToLeaf, so no trailing bit or part select survives to reach here.
+    static string pathSignature(AstNodeExpr* nodep) {
+        if (const AstArraySel* const selp = VN_CAST(nodep, ArraySel)) {
+            return pathSignature(selp->fromp()) + "[]";
+        }
+        if (const AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            return pathSignature(selp->fromp()) + "." + selp->name();
+        }
+        return "";
+    }
+
+    // True when 'outerSig' is a proper prefix of 'innerSig' ending at a selector boundary, so
+    // the outer path names an aggregate that structurally contains the inner leaf (e.g. "[]"
+    // encloses "[].a", "" encloses "[].a").  Signatures are position-blind, so this holds for a
+    // run-time element index too, where the static slot range cannot prove containment.
+    static bool signatureEncloses(const string& outerSig, const string& innerSig) {
+        if (outerSig.size() >= innerSig.size()) return false;
+        if (innerSig.compare(0, outerSig.size(), outerSig) != 0) return false;
+        const char next = innerSig[outerSig.size()];
+        return next == '[' || next == '.';
+    }
+
+    // A force encloses 'leafp' when it is not a bit/part-select force and its target path is a
+    // prefix of the leaf's.  Constant indices prove this from slot-range containment; a run-time
+    // element index widens the leaf's static range past containment, so fall back to the
+    // structural signature prefix.  Either way the run-time ownership guard, keyed on the leaf's
+    // own slot ordinal, selects the element the force actually owns.
+    static bool forceEnclosesLeaf(const ForceInfo* finfop, AstNodeExpr* leafp,
+                                  const SlotRange& leafRange) {
+        if (isBitSelForce(finfop)) return false;
+        if (finfop->m_rangeLsb <= leafRange.m_lo && leafRange.m_hi <= finfop->m_rangeMsb) {
+            return true;
+        }
+        return signatureEncloses(pathSignature(forceLeafPath(finfop)), pathSignature(leafp));
+    }
+
+    // Overlapping forces, widest slot range first.  Path-derived ranges on one variable are
+    // always nested or disjoint, so this containment order is what makes an outer force's
+    // whole-path write correct: any inner force that currently owns part of that range
+    // writes after it.
+    std::vector<const ForceInfo*> overlappingForces(const VarForceInfo& varInfo,
+                                                    const SlotRange range) const {
+        std::vector<const ForceInfo*> out;
+        for (const ForceInfo* const finfop : forceInfosInIdOrder(varInfo)) {
+            if (finfop->m_rangeMsb < range.m_lo || finfop->m_rangeLsb > range.m_hi) continue;
+            out.push_back(finfop);
+        }
+        std::stable_sort(out.begin(), out.end(), [](const ForceInfo* ap, const ForceInfo* bp) {
+            return (ap->m_rangeMsb - ap->m_rangeLsb) > (bp->m_rangeMsb - bp->m_rangeLsb);
+        });
+        return out;
+    }
+
+    static ForceOrdinal forceOrdinal(FileLine* flp, AstNodeExpr* nodep) {
+        return analyzePath(nodep, flp).m_ordinal;
+    }
+
+    static AstNodeExpr* buildForceOrdinalExpr(FileLine* flp, AstNodeExpr* nodep) {
+        const ForceOrdinal ordinal = forceOrdinal(flp, nodep);
+        if (!ordinal.m_exprp) return makeConst32(flp, ordinal.m_constOffset);
+        if (!ordinal.m_constOffset) return ordinal.m_exprp;
+        return new AstAdd{flp, ordinal.m_exprp, makeConst32(flp, ordinal.m_constOffset)};
     }
 
     static AstNodeExpr* buildRhsDataExpr(FileLine* flp, const ForceInfo& finfo) {
@@ -647,119 +905,441 @@ public:
 
     void finalizeRhsVars() {
         for (VarForceInfo& info : m_varInfos) {
-            AstVar* const varp = info.m_varp;
             if (info.m_forces.empty()) continue;
-
-            AstScope* const scopep = info.m_scopep;
-            UASSERT_OBJ(scopep, varp, "Missing scope for force RHS vars");
-
-            FileLine* const flp = varp->fileline();
+            UASSERT_OBJ(info.m_scopep, info.m_varp, "Missing scope for force RHS vars");
             const std::vector<ForceInfo*> forceps = forceInfosInIdOrder(info);
+            for (ForceInfo* const finfop : forceps) makeRhsCaptureBlock(info, *finfop);
+            if (usesForceSlots(info.m_varp) && !info.m_forceRdVscp) makeSlotRdShadow(info);
+            if (info.m_forceRdVscp) makeForceRdBlocks(info, forceps);
+        }
+    }
 
-            for (ForceInfo* const finfop : forceps) {
-                ForceInfo& finfo = *finfop;
-                UASSERT_OBJ(finfo.m_rhsExprp, varp, "Missing RHS expression for ForceInfo");
+    // One force's captured value: a public shadow variable holding it, kept current by a
+    // combinational block that re-evaluates the right-hand side.
+    void makeRhsCaptureBlock(VarForceInfo& info, ForceInfo& finfo) {
+        AstVar* const varp = info.m_varp;
+        AstScope* const scopep = info.m_scopep;
+        FileLine* const flp = varp->fileline();
+        UASSERT_OBJ(finfo.m_rhsExprp, varp, "Missing RHS expression for ForceInfo");
 
-                // Create per-force temporary storage for the captured RHS value.
-                AstVar* const rhsVarp = new AstVar{
-                    flp, VVarType::VAR,
-                    varp->name() + (doingAssign() ? "_VassignRHS" : "__VforceRHS")
-                        + std::to_string(finfo.m_forceId) + "__" + scopep->nameDotless(),
-                    finfo.m_rhsExprp->dtypep()};
-                rhsVarp->noSubst(true);
-                rhsVarp->sigPublic(true);
-                rhsVarp->setForcedByCode();
-                varp->addNextHere(rhsVarp);
-                finfo.m_rhsVarVscp = new AstVarScope{flp, scopep, rhsVarp};
-                scopep->addVarsp(finfo.m_rhsVarVscp);
+        AstVar* const rhsVarp
+            = new AstVar{flp, VVarType::VAR,
+                         varp->name() + (doingAssign() ? "_VassignRHS" : "__VforceRHS")
+                             + std::to_string(finfo.m_forceId) + "__" + scopep->nameDotless(),
+                         finfo.m_rhsExprp->dtypep()};
+        rhsVarp->noSubst(true);
+        rhsVarp->sigPublic(true);
+        rhsVarp->setForcedByCode();
+        varp->addNextHere(rhsVarp);
+        finfo.m_rhsVarVscp = new AstVarScope{flp, scopep, rhsVarp};
+        scopep->addVarsp(finfo.m_rhsVarVscp);
 
-                // Build assignments for RHS capture. Public/forceable signals with __VforceRd
-                // already have an explicit force-read update path, so they do not need the
-                // forceVec.touch() ordering edge here.
-                // always_comb begin
-                //   forceRHS[id] = rhsExpr;
-                //   forceVec.touch();  // Only without __VforceRd
-                // end
-                AstAssign* const rhsAssignp = new AstAssign{
-                    flp, new AstVarRef{flp, finfo.m_rhsVarVscp, VAccess::WRITE}, finfo.m_rhsExprp};
-
-                if (!info.m_forceRdVscp) {
-                    // touch() is intentionally a semantic no-op at runtime: it creates an
-                    // explicit use/ordering edge from the RHS-capture logic to the force vector
-                    // so later optimization/scheduling passes keep this update path connected.
-                    AstCMethodHard* const touchCallp = new AstCMethodHard{
-                        flp, new AstVarRef{flp, info.m_forceVecVscp, VAccess::WRITE},
-                        VCMethod::FORCE_TOUCH};
-                    touchCallp->dtypeSetVoid();
-                    AstNodeStmt* const touchStmtp = touchCallp->makeStmt();
-                    rhsAssignp->addNextHere(touchStmtp);
-                }
-
-                // Run both updates in a combinational always block.
-                AstAlways* const alwaysp
-                    = new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr, rhsAssignp};
-                AstSenTree* const senTreep
-                    = new AstSenTree{flp, new AstSenItem{flp, AstSenItem::Combo{}}};
-                AstActive* const activep = new AstActive{flp, "force-rhs-update", senTreep};
-                activep->senTreeStorep(activep->sentreep());
-                activep->addStmtsp(alwaysp);
-                scopep->addBlocksp(activep);
+        // The re-capture tracks later changes of the right-hand side.  A read that reaches
+        // back into the force's own slots stays raw: substituting it would make this block
+        // read its own force's shadow back, a combinational cycle.  A read of a disjoint
+        // sibling leaf of the same variable is not such a cycle, so on a slot-tracked
+        // variable it keeps normal read semantics and sees that sibling's own force.  A
+        // bitwise variable has no per-leaf slots to compare, so every self-reference stays
+        // raw.  The capture at the force statement itself always reads fully substituted.
+        finfo.m_rhsExprp->foreach([&](AstVarRef* const refp) {
+            if (refp->varp() != varp) return;
+            if (usesForceSlots(varp)) {
+                AstNodeExpr* pathp = refp;
+                while (isPathFromOfSelector(pathp)) pathp = VN_AS(pathp->backp(), NodeExpr);
+                const SlotRange r = staticSlotRange(pathp);
+                if (r.m_hi < finfo.m_rangeLsb || r.m_lo > finfo.m_rangeMsb) return;
             }
+            markNonReplaceable(refp);
+        });
+        AstAssign* const rhsAssignp = new AstAssign{
+            flp, new AstVarRef{flp, finfo.m_rhsVarVscp, VAccess::WRITE}, finfo.m_rhsExprp};
 
-            if (info.m_forceRdVscp) {
-                AstActive* const activeInitp = new AstActive{
-                    flp, "force-init",
-                    new AstSenTree{flp, new AstSenItem{flp, AstSenItem::Static{}}}};
-                activeInitp->senTreeStorep(activeInitp->sentreep());
-                AstNodeStmt* initStmtp = nullptr;
-                if (AstUnpackArrayDType* const arrDtypep
-                    = VN_CAST(varp->dtypeSkipRefp(), UnpackArrayDType)) {
-                    const std::vector<AstUnpackArrayDType*> dims = arrDtypep->unpackDimensions();
-                    const int innerWidth = dims.back()->subDTypep()->skipRefp()->width();
-                    initStmtp = foreachUnpackedLeaf(
-                        dims, [&](const std::vector<int>& idx, int /*flat*/) -> AstNodeStmt* {
-                            AstNodeExpr* const lhsp = buildNestedArraySel(
-                                flp, new AstVarRef{flp, info.m_forceEnVscp, VAccess::WRITE}, idx);
-                            return new AstAssign{flp, lhsp, makeZeroConst(varp, innerWidth)};
-                        });
-                } else {
-                    initStmtp = new AstAssign{
-                        flp, new AstVarRef{flp, info.m_forceEnVscp, VAccess::WRITE},
-                        makeZeroConst(varp, info.m_forceEnVscp->width())};
-                }
-                initStmtp->addNext(createForceRdUpdateStmt(info));
-                activeInitp->addStmtsp(new AstInitial{flp, initStmtp});
-                scopep->addBlocksp(activeInitp);
+        if (!info.m_forceRdVscp) {
+            // touch() is a runtime no-op that creates an ordering edge from this capture to
+            // the force vector, so later scheduling keeps the update path connected.  A
+            // forceable signal already has that edge through its __VforceRd update.
+            AstCMethodHard* const touchCallp
+                = new AstCMethodHard{flp, new AstVarRef{flp, info.m_forceVecVscp, VAccess::WRITE},
+                                     VCMethod::FORCE_TOUCH};
+            touchCallp->dtypeSetVoid();
+            rhsAssignp->addNextHere(touchCallp->makeStmt());
+        }
+        scopep->addBlocksp(newComboActive(
+            flp, "force-rhs-update", new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr, rhsAssignp}));
+    }
 
-                AstSenItem* itemsp = nullptr;
-                auto addSenItem = [&](AstVarScope* vscp) {
-                    if (!vscp) return;
-                    AstSenItem* const nextp = new AstSenItem{
-                        flp, VEdgeType::ET_CHANGED, new AstVarRef{flp, vscp, VAccess::READ}};
-                    if (itemsp) {
-                        itemsp->addNext(nextp);
-                    } else {
-                        itemsp = nextp;
-                    }
-                };
-                addSenItem(info.m_forceEnVscp);
-                addSenItem(info.m_forceValVscp);
-                AstVarRef* const origSenRefp = new AstVarRef{flp, info.m_varVscp, VAccess::READ};
-                markNonReplaceable(origSenRefp);
-                AstSenItem* const origItemp
-                    = new AstSenItem{flp, VEdgeType::ET_CHANGED, origSenRefp};
-                if (!itemsp) varp->v3fatalSrc("force-rd-update missing force-enable sen item");
-                itemsp->addNext(origItemp);
-                for (ForceInfo* const finfop : forceps) addSenItem(finfop->m_rhsVarVscp);
+    // The whole-value shadow of a slot-tracked variable, merging every leaf's force, kept
+    // current by a combinational block so a whole-variable read can consult it.
+    void makeSlotRdShadow(VarForceInfo& info) {
+        AstVar* const varp = info.m_varp;
+        AstScope* const scopep = info.m_scopep;
+        FileLine* const flp = varp->fileline();
+        // The scope is part of the name, as for the force vector and RHS shadows: the
+        // variable is shared across instances of its module or interface, so an unqualified
+        // name collides between instances (a duplicate class member that trace keeps live).
+        AstVar* const slotRdVarp
+            = new AstVar{flp, VVarType::WIRE,
+                         varp->name() + (doingAssign() ? "_VassignSlotRd" : "__VforceSlotRd")
+                             + "__" + scopep->nameDotless(),
+                         varp->dtypep()};
+        slotRdVarp->noSubst(true);
+        varp->addNextHere(slotRdVarp);
+        info.m_slotRdVscp = new AstVarScope{flp, scopep, slotRdVarp};
+        scopep->addVarsp(info.m_slotRdVscp);
+        scopep->addBlocksp(
+            newComboActive(flp, "force-slot-rd-update",
+                           new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr,
+                                         createSlotRdUpdateStmt(info, info.m_slotRdVscp)}));
+    }
 
-                AstActive* const activep
-                    = new AstActive{flp, "force-rd-update", new AstSenTree{flp, itemsp}};
-                activep->senTreeStorep(activep->sentreep());
-                activep->addStmtsp(new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr,
-                                                 createForceRdUpdateStmt(info)});
-                scopep->addBlocksp(activep);
+    // The externally forceable read shadow: a static block that zeroes the enable and seeds
+    // the shadow, and an update block sensitive to the enable, value, raw variable and every
+    // RHS shadow.
+    void makeForceRdBlocks(VarForceInfo& info, const std::vector<ForceInfo*>& forceps) {
+        AstVar* const varp = info.m_varp;
+        AstScope* const scopep = info.m_scopep;
+        FileLine* const flp = varp->fileline();
+
+        AstActive* const activeInitp = new AstActive{
+            flp, "force-init", new AstSenTree{flp, new AstSenItem{flp, AstSenItem::Static{}}}};
+        activeInitp->senTreeStorep(activeInitp->sentreep());
+        AstNodeStmt* initStmtp = nullptr;
+        if (AstUnpackArrayDType* const arrDtypep
+            = VN_CAST(varp->dtypeSkipRefp(), UnpackArrayDType)) {
+            const std::vector<AstUnpackArrayDType*> dims = arrDtypep->unpackDimensions();
+            const int innerWidth = dims.back()->subDTypep()->skipRefp()->width();
+            initStmtp = foreachUnpackedLeaf(
+                dims, [&](const std::vector<int>& idx, int /*flat*/) -> AstNodeStmt* {
+                    AstNodeExpr* const lhsp = buildNestedArraySel(
+                        flp, new AstVarRef{flp, info.m_forceEnVscp, VAccess::WRITE}, idx);
+                    return new AstAssign{flp, lhsp, makeZeroConst(varp, innerWidth)};
+                });
+        } else {
+            initStmtp = new AstAssign{flp, new AstVarRef{flp, info.m_forceEnVscp, VAccess::WRITE},
+                                      makeZeroConst(varp, info.m_forceEnVscp->width())};
+        }
+        initStmtp->addNext(makeForceRdRefreshStmt(info));
+        activeInitp->addStmtsp(new AstInitial{flp, initStmtp});
+        scopep->addBlocksp(activeInitp);
+
+        AstSenItem* itemsp = nullptr;
+        auto addSenItem = [&](AstVarScope* vscp) {
+            if (!vscp) return;
+            AstSenItem* const nextp = new AstSenItem{flp, VEdgeType::ET_CHANGED,
+                                                     new AstVarRef{flp, vscp, VAccess::READ}};
+            if (itemsp) {
+                itemsp->addNext(nextp);
+            } else {
+                itemsp = nextp;
+            }
+        };
+        addSenItem(info.m_forceEnVscp);
+        addSenItem(info.m_forceValVscp);
+        AstVarRef* const origSenRefp = new AstVarRef{flp, info.m_varVscp, VAccess::READ};
+        markNonReplaceable(origSenRefp);
+        if (!itemsp) varp->v3fatalSrc("force-rd-update missing force-enable sen item");
+        itemsp->addNext(new AstSenItem{flp, VEdgeType::ET_CHANGED, origSenRefp});
+        for (ForceInfo* const finfop : forceps) addSenItem(finfop->m_rhsVarVscp);
+
+        AstActive* const activep
+            = new AstActive{flp, "force-rd-update", new AstSenTree{flp, itemsp}};
+        activep->senTreeStorep(activep->sentreep());
+        activep->addStmtsp(
+            new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr, createForceRdUpdateStmt(info)});
+        scopep->addBlocksp(activep);
+    }
+
+    // A combinational AstActive wrapping 'bodyp', with its sensitivity tree stored
+    static AstActive* newComboActive(FileLine* flp, const char* name, AstNode* bodyp) {
+        AstActive* const activep = new AstActive{
+            flp, name, new AstSenTree{flp, new AstSenItem{flp, AstSenItem::Combo{}}}};
+        activep->senTreeStorep(activep->sentreep());
+        activep->addStmtsp(bodyp);
+        return activep;
+    }
+
+    // Build 'rd<path> = forceVec.read(var<path>, slot)' for every leaf of a slot-indexed
+    // variable, so that a read of the whole variable sees each leaf's own force.
+    // Guard: force 'id' currently owns something in [lsb, msb]
+    AstNodeExpr* buildOwnsExpr(const VarForceInfo& varInfo, FileLine* flp, int id, int lsb,
+                               int msb) const {
+        AstCMethodHard* const callp
+            = new AstCMethodHard{flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                                 lsb == msb ? VCMethod::FORCE_OWNS_SLOT : VCMethod::FORCE_OWNS_ANY,
+                                 makeConst32(flp, id)};
+        callp->addPinsp(makeConst32(flp, lsb));
+        if (lsb != msb) callp->addPinsp(makeConst32(flp, msb));
+        callp->dtypeSetBit();
+        return callp;
+    }
+
+    // The value force 'finfop' contributes at 'leafp', typed as the leaf.  For a force of
+    // an enclosing aggregate this reads the leaf's own suffix out of the force's typed
+    // shadow; for a bit or part select force the narrow shadow is positioned into the leaf.
+    AstNodeExpr* buildArmRhsExpr(const ForceInfo* finfop, AstNodeExpr* leafp) const {
+        FileLine* const flp = leafp->fileline();
+        UASSERT_OBJ(finfop->m_rhsVarVscp, leafp, "No RHS var for forced variable");
+        const SlotRange leafRange = staticSlotRange(leafp);
+        if (forceEnclosesLeaf(finfop, leafp, leafRange)) {
+            // Enclosing (or exact) force: the leaf's suffix within the force's target
+            const int stripDepth = pathDepth(forceLeafPath(finfop));
+            return rebaseSuffixOnto(leafp, stripDepth,
+                                    new AstVarRef{flp, finfop->m_rhsVarVscp, VAccess::READ});
+        }
+        AstNodeExpr* rhsp = new AstVarRef{flp, finfop->m_rhsVarVscp, VAccess::READ};
+        if (isBitSelForce(finfop)) {
+            AstNodeExpr* const leafDtypeFromp = forceLeafPath(finfop);
+            rhsp = zeroPadToBaseWidth(rhsp, leafDtypeFromp->width(), finfop->m_padLsb,
+                                      finfop->m_padMsb);
+            rhsp->dtypeFrom(leafDtypeFromp);
+        }
+        return rhsp;
+    }
+
+    // Compile the forced value of a single leaf as a chain over the forces that can reach
+    // it.  Slot ownership, which depends on run-time activation order, comes from the
+    // force vector; everything typed is compiled here.  With no overlapping force the raw
+    // read is returned untouched.
+    // The forces that can reach 'leafp': those overlapping its slot range, except
+    // non-enclosing ones naming a different leaf within the element, which can never
+    // alias it whatever their indices
+    std::vector<const ForceInfo*> forcesReachingLeaf(const VarForceInfo& varInfo,
+                                                     AstNodeExpr* leafp) const {
+        const SlotRange leafRange = staticSlotRange(leafp);
+        const string leafSignature = pathSignature(leafp);
+        std::vector<const ForceInfo*> arms;
+        for (const ForceInfo* const finfop : overlappingForces(varInfo, leafRange)) {
+            const bool enclosing = forceEnclosesLeaf(finfop, leafp, leafRange);
+            if (!enclosing && pathSignature(forceLeafPath(finfop)) != leafSignature) continue;
+            arms.push_back(finfop);
+        }
+        return arms;
+    }
+
+    // A leaf's current forced value routes through the variable's whole-value shadow rather
+    // than an inline blend chain when the leaf is itself an aggregate (no single chain can
+    // express it), or when more forces reach it than a chain should carry.  Reads and release
+    // retention pass the same reaching-force count here, so they cannot pick the chain-vs-
+    // shadow boundary differently.
+    static bool routesThroughShadow(AstNodeExpr* leafp, size_t reachingForceCount) {
+        return forceSlots(leafp->dtypep()) > 1
+               || reachingForceCount > static_cast<size_t>(FORCE_CHAIN_MAX);
+    }
+
+    AstNodeExpr* buildForcedLeafExpr(const VarForceInfo& varInfo, AstNodeExpr* leafp,
+                                     AstNodeExpr* rawExprp) const {
+        const std::vector<const ForceInfo*> arms = forcesReachingLeaf(varInfo, leafp);
+        if (arms.empty()) return rawExprp;
+        FileLine* const flp = leafp->fileline();
+        const bool bitwiseLeaf = isBitwiseDType(leafp);
+        AstNodeExpr* chainp = rawExprp;
+        for (const ForceInfo* const finfop : arms) {
+            AstNodeExpr* const slotp = buildForceOrdinalExpr(flp, leafp);
+            AstNodeExpr* const armRhsp = buildArmRhsExpr(finfop, leafp);
+            if (bitwiseLeaf) {
+                AstCMethodHard* const callp = new AstCMethodHard{
+                    flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                    VCMethod::FORCE_BLEND_OWNED, chainp};
+                callp->addPinsp(armRhsp);
+                callp->addPinsp(makeConst32(flp, finfop->m_forceId));
+                callp->addPinsp(slotp);
+                callp->dtypeFrom(leafp);
+                chainp = callp;
+            } else {
+                AstCMethodHard* const ownsp = new AstCMethodHard{
+                    flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                    VCMethod::FORCE_OWNS_SLOT, makeConst32(flp, finfop->m_forceId)};
+                ownsp->addPinsp(slotp);
+                ownsp->dtypeSetBit();
+                AstCond* const condp = new AstCond{flp, ownsp, armRhsp, chainp};
+                condp->dtypeFrom(leafp);
+                chainp = condp;
             }
         }
+        return chainp;
+    }
+
+    // Statements producing the merged value of 'regionPathp' (a constant path within the
+    // variable) into the same path rebased onto 'dstBasep': copy the raw region, then let
+    // each force that can own part of it write its piece, outermost force first, each
+    // guarded on current ownership.  Cost is one copy plus one statement per force.
+    AstNodeStmt* buildMergedRegionStmts(const VarForceInfo& varInfo, AstNodeExpr* regionPathp,
+                                        AstNodeExpr* dstBasep) const {
+        FileLine* const flp = regionPathp->fileline();
+        const SlotRange region = staticSlotRange(regionPathp);
+        const int regionDepth = pathDepth(regionPathp);
+
+        AstNodeExpr* const rawp = regionPathp->cloneTreePure(false);
+        markRawRead(rawp);
+        AstNodeExpr* const dstWholep
+            = rebaseSuffixOnto(regionPathp, regionDepth, dstBasep->cloneTreePure(false));
+        AstNodeStmt* const headp = new AstAssign{flp, dstWholep, rawp};
+        AstNodeStmt* tailp = headp;
+
+        for (const ForceInfo* const finfop : overlappingForces(varInfo, region)) {
+            AstNodeStmt* armp = nullptr;
+            // The force encloses the region only when its target path is also a prefix of the
+            // region's: on a single-slot variable a leaf force and a whole-variable region
+            // share one slot range yet the force path is the deeper of the two, so the leaf
+            // must be written inside the region rather than read whole out of its shadow
+            if (finfop->m_rangeLsb <= region.m_lo && region.m_hi <= finfop->m_rangeMsb
+                && !isBitSelForce(finfop) && pathDepth(forceLeafPath(finfop)) <= regionDepth) {
+                // Force encloses the region: its shadow holds the whole region's suffix
+                const int stripDepth = pathDepth(forceLeafPath(finfop));
+                AstNodeExpr* const srcp
+                    = rebaseSuffixOnto(regionPathp, stripDepth,
+                                       new AstVarRef{flp, finfop->m_rhsVarVscp, VAccess::READ});
+                AstNodeExpr* const dstp
+                    = rebaseSuffixOnto(regionPathp, regionDepth, dstBasep->cloneTreePure(false));
+                armp = new AstAssign{flp, dstp, srcp};
+            } else {
+                // Force inside the region: write its leaf within the destination
+                AstNodeExpr* const fLeafp = forceLeafPath(finfop);
+                AstNodeExpr* const dstp
+                    = rebaseSuffixOnto(fLeafp, regionDepth, dstBasep->cloneTreePure(false));
+                AstNodeExpr* const armRhsp = buildArmRhsExpr(finfop, fLeafp);
+                if (isBitwiseDType(fLeafp) && isBitSelForce(finfop)) {
+                    // Blend into the destination's current value: an enclosing force's arm
+                    // may already have written this leaf, and those bits must survive
+                    AstNodeExpr* const curp
+                        = rebaseSuffixOnto(fLeafp, regionDepth, dstBasep->cloneTreePure(false));
+                    markRawRead(curp);
+                    AstCMethodHard* const blendp = new AstCMethodHard{
+                        flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                        VCMethod::FORCE_BLEND_OWNED, curp};
+                    blendp->addPinsp(armRhsp);
+                    blendp->addPinsp(makeConst32(flp, finfop->m_forceId));
+                    blendp->addPinsp(makeConst32(flp, finfop->m_rangeLsb));
+                    blendp->dtypeFrom(fLeafp);
+                    armp = new AstAssign{flp, dstp, blendp};
+                } else {
+                    armp = new AstAssign{flp, dstp, armRhsp};
+                }
+            }
+            const int guardLo = std::max(finfop->m_rangeLsb, region.m_lo);
+            const int guardHi = std::min(finfop->m_rangeMsb, region.m_hi);
+            AstIf* const ifp = new AstIf{
+                flp, buildOwnsExpr(varInfo, flp, finfop->m_forceId, guardLo, guardHi), armp};
+            tailp->addNextHere(ifp);
+            tailp = ifp;
+        }
+        // Reads and writes of the source variable in here are the raw storage by design
+        for (AstNode* stmtp = headp; stmtp; stmtp = stmtp->nextp()) {
+            stmtp->foreach([&varInfo](AstVarRef* const refp) {
+                if (refp->varScopep() == varInfo.m_varVscp) markNonReplaceable(refp);
+            });
+        }
+        return headp;
+    }
+
+    // Keep the whole-value shadow of a slot-tracked variable up to date
+    AstNodeStmt* createSlotRdUpdateStmt(const VarForceInfo& info, AstVarScope* targetVscp) const {
+        FileLine* const flp = info.m_varVscp->fileline();
+        AstVarRef* const regionp = new AstVarRef{flp, info.m_varVscp, VAccess::READ};
+        AstVarRef* const dstp = new AstVarRef{flp, targetVscp, VAccess::WRITE};
+        AstNodeStmt* const stmtsp = buildMergedRegionStmts(info, regionp, dstp);
+        VL_DO_DANGLING(regionp->deleteTree(), regionp);
+        VL_DO_DANGLING(dstp->deleteTree(), dstp);
+        return stmtsp;
+    }
+
+    // Wrap 'bodyp' as one function per variable, so a procedural refresh of the shadow
+    // is a single call however many forces the variable has and wherever it is read.
+    // The arguments carry the accesses scheduling must know about at each call site:
+    // the shadow written, the raw variable read, and the force vector read.  Everything
+    // else the body reads feeds the always block that maintains the same shadow, whose
+    // visible logic already orders any other process against this call.
+    AstCFunc* createRefreshFunc(const VarForceInfo& info, const string& name, AstVarScope* dstVscp,
+                                bool needsVec, AstNodeStmt* bodyp) const {
+        FileLine* const flp = info.m_varVscp->fileline();
+        AstScope* const scopep = info.m_scopep;
+        AstCFunc* const funcp = new AstCFunc{flp, name, scopep, ""};
+        funcp->isStatic(false);
+        funcp->dontCombine(true);
+        // An entry point the way V3Task's non-inlined functions are: lifetime analysis
+        // treats each call as opaque and analyzes the shared body on its own, rather
+        // than editing it under whichever caller it happens to trace it from
+        funcp->entryPoint(true);
+        funcp->argTypes(EmitCUtil::symClassVar());
+        const auto makeArg
+            = [&](const string& argName, AstVarScope* forVscp, VDirection::en direction) {
+                  AstVar* const argVarp
+                      = new AstVar{flp, VVarType::BLOCKTEMP, argName, forVscp->varp()->dtypep()};
+                  argVarp->funcLocal(true);
+                  argVarp->direction(VDirection{direction});
+                  funcp->addArgsp(argVarp);
+                  AstVarScope* const argVscp = new AstVarScope{flp, scopep, argVarp};
+                  scopep->addVarsp(argVscp);
+                  return argVscp;
+              };
+        AstVarScope* const dstArgVscp = makeArg("dstr", dstVscp, VDirection::REF);
+        AstVarScope* const srcArgVscp = makeArg("srcr", info.m_varVscp, VDirection::CONSTREF);
+        AstVarScope* const vecArgVscp
+            = needsVec ? makeArg("vecr", info.m_forceVecVscp, VDirection::REF) : nullptr;
+        for (AstNode* stmtp = bodyp; stmtp; stmtp = stmtp->nextp()) {
+            stmtp->foreach([&](AstVarRef* const refp) {
+                AstVarScope* argVscp = nullptr;
+                if (refp->varScopep() == dstVscp) {
+                    argVscp = dstArgVscp;
+                } else if (refp->varScopep() == info.m_varVscp) {
+                    argVscp = srcArgVscp;
+                } else if (vecArgVscp && refp->varScopep() == info.m_forceVecVscp) {
+                    argVscp = vecArgVscp;
+                }
+                if (!argVscp) return;
+                refp->varp(argVscp->varp());
+                refp->varScopep(argVscp);
+            });
+        }
+        funcp->addStmtsp(bodyp);
+        scopep->addBlocksp(funcp);
+        return funcp;
+    }
+
+    AstNodeStmt* makeRefreshCallStmt(const VarForceInfo& info, AstCFunc* funcp,
+                                     AstVarScope* dstVscp, bool needsVec) const {
+        UASSERT_OBJ(funcp, info.m_varVscp, "Refresh function not created for variable");
+        FileLine* const flp = info.m_varVscp->fileline();
+        AstVarRef* const dstp = new AstVarRef{flp, dstVscp, VAccess::WRITE};
+        AstVarRef* const srcp = new AstVarRef{flp, info.m_varVscp, VAccess::READ};
+        markNonReplaceable(srcp);
+        dstp->addNext(srcp);
+        if (needsVec) srcp->addNext(new AstVarRef{flp, info.m_forceVecVscp, VAccess::READ});
+        AstCCall* const callp = new AstCCall{flp, funcp, dstp};
+        callp->argTypes("vlSymsp");
+        callp->dtypeSetVoid();
+        return callp->makeStmt();
+    }
+
+    AstNodeStmt* makeSlotRdRefreshStmt(const VarForceInfo& info) const {
+        if (!info.m_slotRdRefreshFuncp) {
+            info.m_slotRdRefreshFuncp = createRefreshFunc(
+                info, info.m_slotRdVscp->varp()->name() + "Upd_" + info.m_scopep->nameDotless(),
+                info.m_slotRdVscp,
+                /*needsVec=*/true, createSlotRdUpdateStmt(info, info.m_slotRdVscp));
+        }
+        return makeRefreshCallStmt(info, info.m_slotRdRefreshFuncp, info.m_slotRdVscp, true);
+    }
+
+    AstNodeStmt* makeForceRdRefreshStmt(const VarForceInfo& info) const {
+        if (!info.m_forceRdRefreshFuncp) {
+            info.m_forceRdRefreshNeedsVec
+                = usesForceSlots(info.m_varp)
+                  && !VN_IS(info.m_varp->dtypeSkipRefp(), UnpackArrayDType);
+            info.m_forceRdRefreshFuncp = createRefreshFunc(
+                info,
+                (doingAssign() ? "_Vassign" : "__Vforce") + std::string{"RdUpd__"}
+                    + info.m_varp->name() + "_" + info.m_scopep->nameDotless(),
+                info.m_forceRdVscp, info.m_forceRdRefreshNeedsVec, createForceRdUpdateStmt(info));
+        }
+        return makeRefreshCallStmt(info, info.m_forceRdRefreshFuncp, info.m_forceRdVscp,
+                                   info.m_forceRdRefreshNeedsVec);
+    }
+
+    // Refresh whichever whole-value shadow the variable keeps, so a same-timestep read of
+    // it is current
+    AstNodeStmt* makeWholeRdRefreshStmt(const VarForceInfo& info) const {
+        return info.m_slotRdVscp ? makeSlotRdRefreshStmt(info) : makeForceRdRefreshStmt(info);
     }
 
     AstNode* createRhsUpdatesForWrite(FileLine* flp, AstVar* writtenVarp) const {
@@ -790,6 +1370,8 @@ public:
         AstVarScope* const vscp = getOneVarRef(forceStmtp->lhsp())->varScopep();
         const VarForceInfo* const varInfo = getVarInfo(vscp);
         UASSERT(varInfo, "Force info not found for variable");
+        const auto aliasIt = varInfo->m_forceAliases.find(forceStmtp);
+        if (aliasIt != varInfo->m_forceAliases.end()) forceStmtp = aliasIt->second;
         auto it2 = varInfo->m_forces.find(forceStmtp);
         UASSERT(it2 != varInfo->m_forces.end(), "Force statement not found");
         return it2->second;
@@ -808,14 +1390,6 @@ public:
         return createForceReadCall(varInfo, flp, VCMethod::FORCE_READ,
                                    originalRefp->cloneTreePure(false), originalRefp->varp(),
                                    nullptr);
-    }
-
-    AstNodeExpr* createForceReadIndexExpression(const VarForceInfo& varInfo,
-                                                AstNodeExpr* originalExprp,
-                                                AstNodeExpr* indexExprp) const {
-        FileLine* const flp = originalExprp->fileline();
-        return createForceReadCall(varInfo, flp, VCMethod::FORCE_READ_INDEX,
-                                   originalExprp->cloneTreePure(false), originalExprp, indexExprp);
     }
 
     static AstNodeExpr* rebuildSelPath(AstNodeExpr* pathp, AstNodeExpr* baseExprp) {
@@ -893,9 +1467,8 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
                     flp, new AstVarRef{flp, enVscp, VAccess::READ}, idx);
                 AstNodeExpr* const valSelp = ForceState::buildNestedArraySel(
                     flp, new AstVarRef{flp, valVscp, VAccess::READ}, idx);
-                AstNodeExpr* const forceExprp = new AstOr{
-                    flp, new AstAnd{flp, enSelp, valSelp},
-                    new AstAnd{flp, new AstNot{flp, enSelp->cloneTreePure(false)}, origSelp}};
+                AstNodeExpr* const forceExprp
+                    = ForceState::makeEnValBlend(flp, enSelp, valSelp, origSelp);
                 AstNodeExpr* const lhsSelp = ForceState::buildNestedArraySel(
                     flp, new AstVarRef{flp, nodep, VAccess::WRITE}, idx);
 
@@ -909,7 +1482,7 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
                 m_state.addForceAssignment(varp, nodep, rhsClonep, forceAssignp,
                                            /*rangeLsb=*/flat, /*rangeMsb=*/flat,
                                            /*padLsb=*/0, /*padMsb=*/innerWidth - 1,
-                                           /*hasArraySel=*/true);
+                                           lhsSelp->cloneTreePure(false));
                 return forceAssignp;
             });
         activep->addStmtsp(new AstAlways{flp, VAlwaysKwd::ALWAYS, nullptr, alwaysBodyHeadp});
@@ -924,8 +1497,15 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
         AstVar* const forcedVarp = lhsVarRefp->varp();
         UASSERT(forcedVarp, "VarRef missing Varp");
 
+        // A force the slot machinery cannot represent (more leaves than the int slot
+        // arithmetic holds, or an aggregate target from a differently-typed right-hand side)
+        // is reported here and left for the convert visitor to drop
+        if (const char* const reason = ForceState::forceUnsupportedReason(nodep)) {
+            nodep->v3warn(E_UNSUPPORTED, "Unsupported: " << reason);
+            return;
+        }
         // Resolve force bookkeeping range/padding for the LHS shape.
-        ForceState::ForceRangeInfo rangeInfo
+        ForceState::ForceRange rangeInfo
             = m_state.getForceRangeInfo(nodep->lhsp(), forcedVarp, true);
 
         // Keep narrow rhs, VlForceVec blends unpacked-array bit-select forces at read time
@@ -933,7 +1513,17 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
 
         m_state.addForceAssignment(forcedVarp, lhsVarRefp->varScopep(), rhsExprp, nodep,
                                    rangeInfo.m_rangeLsb, rangeInfo.m_rangeMsb, rangeInfo.m_padLsb,
-                                   rangeInfo.m_padMsb, rangeInfo.m_hasArraySel);
+                                   rangeInfo.m_padMsb, nodep->lhsp()->cloneTreePure(false));
+    }
+
+    void visit(AstRelease* nodep) override {
+        AstVarRef* const lhsVarRefp = m_state.getOneVarRef(nodep->lhsp());
+        if (!ForceState::usesForceSlots(lhsVarRefp->varp())) return;
+        if (ForceState::forceSlotsOverflow(lhsVarRefp->varp()->dtypep())) {
+            nodep->v3warn(E_UNSUPPORTED,
+                          "Unsupported: Release of a variable with 2^31 or more elements");
+            return;
+        }
     }
 
     void visit(AstAssign* nodep) override {
@@ -998,9 +1588,7 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
             const AstBasicDType* const basicp = varp->dtypep()->skipRefp()->basicp();
             AstNodeExpr* const forceExprp
                 = basicp && basicp->isRanged()
-                      ? static_cast<AstNodeExpr*>(new AstOr{
-                            flp, new AstAnd{flp, enRefp, valRefp},
-                            new AstAnd{flp, new AstNot{flp, enRefp->cloneTreePure(false)}, refp}})
+                      ? ForceState::makeEnValBlend(flp, enRefp, valRefp, refp)
                       : static_cast<AstNodeExpr*>(new AstCond{flp, enRefp, valRefp, refp});
             AstAssignForce* const forceAssignp
                 = new AstAssignForce{flp, new AstVarRef{flp, nodep, VAccess::WRITE}, forceExprp};
@@ -1017,13 +1605,17 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
             // Compute full assignment range (including unpacked arrays) for force bookkeeping.
             const bool bitwiseVar = ForceState::isBitwiseDType(varp);
             const int padMsb = bitwiseVar ? (varp->width() - 1) : 0;
-            int rangeLsb = 0;
-            int rangeMsb = padMsb;
+            const int rangeLsb = 0;
+            // A slot-tracked variable's whole-value force covers every slot, so a later
+            // ownership query for this synthetic force answers over the right range
+            const int rangeMsb = ForceState::usesForceSlots(varp)
+                                     ? ForceState::forceSlots(varp->dtypep()) - 1
+                                     : padMsb;
             if (ForceState::isUnpackedArrayDType(varp->dtypep())) {
                 nodep->v3fatalSrc("Forceable unpacked arrays should have been rejected earlier");
             }
             m_state.addForceAssignment(varp, nodep, rhsClonep, forceAssignp, rangeLsb, rangeMsb, 0,
-                                       padMsb, false);
+                                       padMsb, new AstVarRef{flp, nodep, VAccess::READ});
         }
         iterateChildrenConst(nodep);
     }
@@ -1050,6 +1642,12 @@ class ForceConvertVisitor final : public VNVisitor {
         AstVarRef* const lhsVarRefp = m_state.getOneVarRef(lhsp);
         AstVar* const forcedVarp = lhsVarRefp->varp();
 
+        // Discovery reported forces it could not register and left them alone; drop them here
+        if (ForceState::forceUnsupportedReason(nodep)) {
+            VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
+            return;
+        }
+
         const ForceState::ForceInfo& info = m_state.getForceInfo(nodep);
         const ForceState::VarForceInfo* const varInfo
             = m_state.getVarInfo(lhsVarRefp->varScopep());
@@ -1068,9 +1666,16 @@ class ForceConvertVisitor final : public VNVisitor {
         const bool bitwiseForcedVar = ForceState::isBitwiseDType(forcedVarp);
         // When an externally forceable signal is also forced in (System)Verilog code
         // keep the public __VforceEn/__VforceVal signals in sync with the procedural force too.
-        // Don't do this for array selections; those are represented only in VlForceVec.
-        if (!nodep->user2() && varInfo->m_forceEnVscp && varInfo->m_forceValVscp
-            && !info.m_hasArraySel) {
+        // Those signals hold one whole value, so a force naming a single leaf of a slot-indexed
+        // variable cannot be expressed in them and lives only in VlForceVec.
+        const bool wholeSlotVar = !ForceState::usesForceSlots(forcedVarp) || VN_IS(lhsp, VarRef);
+        // An unpacked array's external enable and value are per element, so the whole-value
+        // mask arithmetic below does not apply to it.  A procedural force of such a variable
+        // lives in its slots and is merged into the read shadow, so the public enable and
+        // value are left to the external interface alone.
+        const bool unpackedArrayVar = ForceState::isUnpackedArrayDType(forcedVarp->dtypep());
+        if (!nodep->user2() && varInfo->m_forceEnVscp && varInfo->m_forceValVscp && wholeSlotVar
+            && !unpackedArrayVar) {
             AstNodeExpr* baseExprp = nodep->rhsp()->cloneTreePure(false);
             baseExprp->foreach(
                 [](AstVarRef* const refp) { ForceState::markNonReplaceable(refp); });
@@ -1109,32 +1714,50 @@ class ForceConvertVisitor final : public VNVisitor {
             }
         }
 
-        // Verilog pseudocode:
-        //   forceVec.addForce(range_lsb, range_msb, &forceRHS[id], rhs_lsb);
-        const AstSel* const selLhsp = VN_CAST(lhsp, Sel);
-        const bool arrayBitSel
-            = info.m_hasArraySel && selLhsp && ForceState::getArraySelInfo(lhsp).m_hasBitSel
-              && ForceState::isBitwiseDType(selLhsp->fromp())
-              && (info.m_padMsb - info.m_padLsb + 1) < selLhsp->fromp()->width();
-        AstNodeExpr* const rhsDatap = ForceState::buildRhsDataExpr(flp, info);
-        AstCExpr* const rhsAddrp = new AstCExpr{flp};
-        rhsAddrp->add("&(");
-        rhsAddrp->add(rhsDatap);
-        rhsAddrp->add(")");
-        AstCMethodHard* const addForceCallp = new AstCMethodHard{
-            flp, new AstVarRef{flp, varInfo->m_forceVecVscp, VAccess::WRITE}, VCMethod::FORCE_ADD,
-            ForceState::makeConst32(flp, info.m_rangeLsb)};
-        addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_rangeMsb));
-        addForceCallp->addPinsp(rhsAddrp);
-        addForceCallp->addPinsp(
-            ForceState::makeConst32(flp, arrayBitSel ? info.m_padLsb : info.m_rangeLsb));
-        if (arrayBitSel) {
-            addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_padLsb));
-            addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_padMsb));
-            addForceCallp->addPinsp(ForceState::makeConst32(flp, selLhsp->fromp()->width()));
+        // Slot-tracked variables register only which force owns which slots; the value
+        // stays in the force's own typed shadow, which compiled reads consult directly.
+        // Bitwise variables keep the value-carrying entry.
+        AstNodeStmt* stmtp = nullptr;
+        if (ForceState::usesForceSlots(forcedVarp)) {
+            UASSERT_OBJ(info.m_forceId >= 0, nodep, "Force registered with a negative id");
+            const AstSel* const selLhsp = VN_CAST(lhsp, Sel);
+            const bool bitSel = selLhsp && ForceState::isBitwiseDType(selLhsp->fromp())
+                                && (info.m_padMsb - info.m_padLsb + 1) < selLhsp->fromp()->width();
+            AstCMethodHard* const addForceCallp = new AstCMethodHard{
+                flp, new AstVarRef{flp, varInfo->m_forceVecVscp, VAccess::WRITE},
+                VCMethod::FORCE_ADD_AT, ForceState::makeConst32(flp, info.m_forceId)};
+            addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_rangeLsb));
+            if (bitSel) {
+                const int elemWidth = selLhsp->fromp()->width();
+                UASSERT_OBJ(0 <= info.m_padLsb && info.m_padLsb <= info.m_padMsb
+                                && info.m_padMsb < elemWidth,
+                            nodep, "Force bit range outside the forced slot");
+                addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_padLsb));
+                addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_padMsb));
+                addForceCallp->addPinsp(ForceState::makeConst32(flp, elemWidth));
+            } else {
+                UASSERT_OBJ(info.m_rangeLsb <= info.m_rangeMsb, nodep,
+                            "Force slot range lsb past msb");
+                addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_rangeMsb));
+            }
+            addForceCallp->dtypeSetVoid();
+            stmtp = addForceCallp->makeStmt();
+        } else {
+            UASSERT_OBJ(info.m_rangeLsb <= info.m_rangeMsb, nodep, "Force range lsb past msb");
+            AstNodeExpr* const rhsDatap = ForceState::buildRhsDataExpr(flp, info);
+            AstCExpr* const rhsAddrp = new AstCExpr{flp};
+            rhsAddrp->add("&(");
+            rhsAddrp->add(rhsDatap);
+            rhsAddrp->add(")");
+            AstCMethodHard* const addForceCallp = new AstCMethodHard{
+                flp, new AstVarRef{flp, varInfo->m_forceVecVscp, VAccess::WRITE},
+                VCMethod::FORCE_ADD, ForceState::makeConst32(flp, info.m_rangeLsb)};
+            addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_rangeMsb));
+            addForceCallp->addPinsp(rhsAddrp);
+            addForceCallp->addPinsp(ForceState::makeConst32(flp, info.m_rangeLsb));
+            addForceCallp->dtypeSetVoid();
+            stmtp = addForceCallp->makeStmt();
         }
-        addForceCallp->dtypeSetVoid();
-        AstNodeStmt* const stmtp = addForceCallp->makeStmt();
 
         AstNode* tailp = rhsAssignp;
         if (valAssignp) {
@@ -1147,7 +1770,7 @@ class ForceConvertVisitor final : public VNVisitor {
         }
         tailp->addNextHere(stmtp);
         if (varInfo->m_forceRdVscp) {
-            stmtp->addNextHere(m_state.createForceRdUpdateStmt(*varInfo));
+            stmtp->addNextHere(m_state.makeForceRdRefreshStmt(*varInfo));
         }
         nodep->replaceWith(rhsAssignp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -1162,20 +1785,20 @@ class ForceConvertVisitor final : public VNVisitor {
 
         const ForceState::VarForceInfo* const varInfo
             = m_state.getVarInfo(lhsVarRefp->varScopep());
-        if (!varInfo) {
+        if (!varInfo || varInfo->m_forces.empty()) {
+            // Releasing something never forced keeps its value, so there is nothing to do
             VL_DO_DANGLING(pushDeletep(nodep->unlinkFrBack()), nodep);
             return;
         }
-        UASSERT_OBJ(!varInfo->m_forces.empty(), nodep, "Var info for variable with no forces");
 
         FileLine* const flp = nodep->fileline();
 
-        const ForceState::ForceRangeInfo rangeInfo
+        const ForceState::ForceRange rangeInfo
             = m_state.getForceRangeInfo(lhsp, releasedVarp, false);
 
         const AstSel* const selLhsp = VN_CAST(lhsp, Sel);
         const bool arrayBitSel
-            = rangeInfo.m_hasArraySel && selLhsp && rangeInfo.m_arrayInfo.m_hasBitSel
+            = ForceState::usesForceSlots(releasedVarp) && selLhsp
               && ForceState::isBitwiseDType(selLhsp->fromp())
               && (rangeInfo.m_padMsb - rangeInfo.m_padLsb + 1) < selLhsp->fromp()->width();
         AstCMethodHard* const releaseCallp = new AstCMethodHard{
@@ -1183,8 +1806,15 @@ class ForceConvertVisitor final : public VNVisitor {
             VCMethod::FORCE_RELEASE, ForceState::makeConst32(flp, rangeInfo.m_rangeLsb)};
         releaseCallp->addPinsp(ForceState::makeConst32(flp, rangeInfo.m_rangeMsb));
         if (arrayBitSel) {
+            UASSERT_OBJ(rangeInfo.m_rangeLsb == rangeInfo.m_rangeMsb
+                            && rangeInfo.m_padLsb <= rangeInfo.m_padMsb,
+                        nodep, "Bit-select release must name one slot and an ordered bit range");
             releaseCallp->addPinsp(ForceState::makeConst32(flp, rangeInfo.m_padLsb));
             releaseCallp->addPinsp(ForceState::makeConst32(flp, rangeInfo.m_padMsb));
+            releaseCallp->addPinsp(ForceState::makeConst32(flp, selLhsp->fromp()->width()));
+        } else {
+            UASSERT_OBJ(rangeInfo.m_rangeLsb <= rangeInfo.m_rangeMsb, nodep,
+                        "Release range lsb past msb");
         }
         releaseCallp->dtypeSetVoid();
         // forceVec.release(range_lsb, range_msb [, bit_lsb, bit_msb]);
@@ -1193,8 +1823,12 @@ class ForceConvertVisitor final : public VNVisitor {
         AstAssign* clearEnp = nullptr;
         // Releases must also clear the external/public force-enable, but only for
         // directly forceable variables and only for non-array-select cases that use that external
-        // force.
-        if (releasedVarp->isForceable() && varInfo->m_forceEnVscp && !rangeInfo.m_hasArraySel) {
+        // force.  An unpacked array's enable is per element and mask arithmetic does not apply
+        // to it; its procedural release lives in the force vector, so the external enable is
+        // left to the external interface alone.
+        if (releasedVarp->isForceable() && varInfo->m_forceEnVscp
+            && !ForceState::isUnpackedArrayDType(releasedVarp->dtypep())
+            && (!ForceState::usesForceSlots(releasedVarp) || VN_IS(lhsp, VarRef))) {
             AstNodeExpr* const enWritep
                 = new AstVarRef{flp, varInfo->m_forceEnVscp, VAccess::WRITE};
             if (ForceState::isBitwiseDType(releasedVarp)) {
@@ -1218,7 +1852,6 @@ class ForceConvertVisitor final : public VNVisitor {
         }
 
         const AstSel* const selp = VN_CAST(lhsp, Sel);
-        AstNodeExpr* const basep = selp ? selp->fromp() : lhsp;
 
         AstNode* stmtListp = releasep;
         if (clearEnp) {
@@ -1228,39 +1861,69 @@ class ForceConvertVisitor final : public VNVisitor {
 
         // IEEE 1800-2023 10.6.2: When released, if the variable is not continuously driven,
         // it maintains its current value until the next procedural assignment.
-        const bool fullBitwiseRelease
-            = ForceState::isBitwiseDType(releasedVarp) && !rangeInfo.m_hasArraySel && !selp
-              && rangeInfo.m_rangeLsb == 0 && rangeInfo.m_rangeMsb == releasedVarp->width() - 1;
+        const bool fullBitwiseRelease = ForceState::isBitwiseDType(releasedVarp)
+                                        && !ForceState::usesForceSlots(releasedVarp) && !selp
+                                        && rangeInfo.m_rangeLsb == 0
+                                        && rangeInfo.m_rangeMsb == releasedVarp->width() - 1;
         if (!releasedVarp->isContinuously()
             && !(m_state.doingAssign() && m_state.hasClockedWrite(releasedVarp)
                  && fullBitwiseRelease)) {
-            // Member/struct paths on non-bitwise types do not lower to a plain VarRef/bit range,
-            // so their current forced value is recovered via the same synthetic path index.
-            // if (!continuously_driven) lhs = force_read_current(lhs_path);
+            // Retention is compiled the same way reads are: leaves take the blend chain,
+            // aggregates take a raw copy plus one guarded write per force.
+            // if (!continuously_driven) lhs = current_forced_value(lhs_path);
             // forceVec.release(range);
-            const bool hasOpaquePath = !ForceState::isBitwiseDType(releasedVarp)
-                                       && !rangeInfo.m_hasArraySel && !VN_IS(lhsp, VarRef);
-            AstNodeExpr* forceReadp = nullptr;
-            if (hasOpaquePath) {
-                forceReadp = m_state.createForceReadIndexExpression(
-                    *varInfo, lhsp, ForceState::makeConst32(flp, rangeInfo.m_rangeLsb));
-            } else if (rangeInfo.m_hasArraySel) {
-                forceReadp = m_state.createForceReadIndexExpression(
-                    *varInfo, basep,
-                    ForceState::buildFlattenIndexExpr(flp, rangeInfo.m_arrayInfo));
-                if (selp) { forceReadp = ForceState::rebuildSelPath(lhsp, forceReadp); }
+            if (ForceState::usesForceSlots(releasedVarp)) {
+                // Strip every trailing bit or part select to reach the leaf, as reads do:
+                // a released target may carry more than one, as in 'a[0][7:4][3:0]'
+                AstNodeExpr* const leafp = ForceState::stripToLeaf(lhsp);
+                AstNodeStmt* retainp = nullptr;
+                const bool aggregate = ForceState::forceSlots(leafp->dtypep()) > 1;
+                const size_t reachingCount
+                    = aggregate ? 0 : m_state.forcesReachingLeaf(*varInfo, leafp).size();
+                AstVarScope* const shadowVscp = varInfo->wholeReadShadowVscp();
+                // A slot-tracked variable reached here has been forced (the release of an
+                // unforced target returned above), so finalizeRhsVars has given it a whole-value
+                // shadow.  An aggregate leaf therefore always routes through that shadow.
+                UASSERT_OBJ(shadowVscp, lhsp,
+                            "Forced slot-tracked variable has no whole-value shadow");
+                // Rebuild the shadow and copy the released region out of it when the leaf routes
+                // through the shadow (the same test reads use).  The shadow merges into its own
+                // storage, so a hole an earlier release punched survives; building an aggregate
+                // straight into the variable would let an enclosing force's arm clobber it
+                // before its own hole repair reads the retained raw value back.
+                if (ForceState::routesThroughShadow(leafp, reachingCount)) {
+                    retainp = m_state.makeWholeRdRefreshStmt(*varInfo);
+                    AstNodeExpr* const srcp = lhsp->cloneTreePure(false);
+                    AstVarRef* const srcBasep = m_state.getOneVarRef(srcp);
+                    srcBasep->varp(shadowVscp->varp());
+                    srcBasep->varScopep(shadowVscp);
+                    ForceState::markRawRead(srcp);
+                    AstNodeExpr* const dstp = lhsp->cloneTreePure(false);
+                    dstp->foreach(
+                        [](AstVarRef* const refp) { ForceState::markNonReplaceable(refp); });
+                    retainp->addNext(new AstAssign{flp, dstp, srcp});
+                } else {
+                    AstNodeExpr* const rawp = leafp->cloneTreePure(false);
+                    ForceState::markRawRead(rawp);
+                    AstNodeExpr* forceReadp = m_state.buildForcedLeafExpr(*varInfo, leafp, rawp);
+                    if (selp) forceReadp = ForceState::rebuildSelPath(lhsp, forceReadp);
+                    retainp = new AstAssign{flp, lhsp->cloneTreePure(false), forceReadp};
+                }
+                retainp->addNext(static_cast<AstNodeStmt*>(stmtListp));
+                stmtListp = retainp;
             } else {
-                forceReadp
+                AstNodeExpr* const forceReadp
                     = selp ? ForceState::rebuildSelPath(
                                  lhsp, m_state.createForceReadExpression(*varInfo, lhsVarRefp))
                            : m_state.createForceReadExpression(*varInfo, lhsVarRefp);
+                AstAssign* const assignp
+                    = new AstAssign{flp, lhsp->cloneTreePure(false), forceReadp};
+                assignp->addNextHere(stmtListp);
+                stmtListp = assignp;
             }
-            AstAssign* const assignp = new AstAssign{flp, lhsp->cloneTreePure(false), forceReadp};
-            assignp->addNextHere(stmtListp);
-            stmtListp = assignp;
         }
 
-        if (varInfo->m_forceRdVscp) stmtListp->addNext(m_state.createForceRdUpdateStmt(*varInfo));
+        if (varInfo->m_forceRdVscp) stmtListp->addNext(m_state.makeForceRdRefreshStmt(*varInfo));
 
         nodep->replaceWith(stmtListp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
@@ -1283,6 +1946,8 @@ class ForceReplaceVisitor final : public VNVisitor {
     VDouble0 m_nonOverlappingForceSels;  // Statistic tracking
     AstNodeStmt* m_stmtp = nullptr;
     bool m_inLogic = false;
+    // Statements already given a shadow refresh, so several reads in one statement share it
+    std::set<std::pair<AstNodeStmt*, const ForceState::VarForceInfo*>> m_slotRdRefreshed;
 
     void iterateLogic(AstNode* nodep) {
         VL_RESTORER(m_inLogic);
@@ -1326,6 +1991,8 @@ class ForceReplaceVisitor final : public VNVisitor {
     }
     void visit(AstSenItem* nodep) override { iterateLogic(nodep); }
     void visit(AstSel* nodep) override {
+        // A select of a leaf inside an aggregate goes through the slot-indexed path instead
+        if (replacePathRead(nodep)) return;
         // Replace Sel on a wide with readSelI/Q/W to avoid materializing the full value
         AstVarRef* const refp = VN_CAST(nodep->fromp(), VarRef);
         if (!refp || ForceState::isNotReplaceable(refp) || !refp->access().isReadOnly()) {
@@ -1367,57 +2034,86 @@ class ForceReplaceVisitor final : public VNVisitor {
         nodep->replaceWith(callp);
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
     }
-    void visit(AstArraySel* nodep) override {
-        if (const AstArraySel* const backSelp = VN_CAST(nodep->backp(), ArraySel)) {
-            // Only the outermost selection of the array path should become a force-aware
-            // read; inner selections along 'fromp' fold into the final flattened index.
-            // A selection used as the index is a read in its own right, as in
-            // 'mem[mem[0]]', so it must not be skipped here.
-            if (backSelp->fromp() == nodep) {
-                iterateChildren(nodep);
-                return;
-            }
-        }
+    // Replace a read of one leaf of a slot-indexed variable, reached through any mix of member
+    // and element selections, with a force-aware read of that leaf's slot.  Returns false when
+    // this node is not such a read, so the caller keeps iterating.
+    bool replacePathRead(AstNodeExpr* nodep) {
+        if (ForceState::isPathFromOfSelector(nodep)) return false;  // An outer node covers it
 
-        AstNode* const basep = AstArraySel::baseFromp(nodep, true);
-        AstVarRef* const baseRefp = VN_CAST(basep, VarRef);
-        if (!baseRefp) {
-            iterateChildren(nodep);
-            return;
-        }
-        AstVar* const varp = baseRefp->varp();
+        // Trailing bit or part selects address bits inside the leaf, so find the leaf first
+        // and put those selects back on top of the force-aware read afterwards.
+        AstNodeExpr* const leafp = ForceState::stripToLeaf(nodep);
+        if (VN_IS(leafp, VarRef)) return false;  // Whole variable, visit(AstVarRef) handles it
+
+        AstVarRef* const baseRefp = VN_CAST(AstArraySel::baseFromp(leafp, true), VarRef);
+        if (!baseRefp || ForceState::isNotReplaceable(baseRefp)) return false;
         const ForceState::VarForceInfo* const varInfo = m_state.getVarInfo(baseRefp->varScopep());
-        // Skip non-forceable reads, reads we intentionally protected earlier, and intermediate
-        // selections that still evaluate to an unpacked array rather than a scalar element.
-        if (ForceState::isNotReplaceable(baseRefp) || !varInfo
-            || !ForceState::isUnpackedArrayDType(varp->dtypep())
-            || VN_IS(nodep->dtypep()->skipRefp(), UnpackArrayDType)) {
-            iterateChildren(nodep);
-            return;
+        if (!varInfo) return false;
+        // An externally forceable aggregate other than an unpacked array keeps its merged value
+        // in __VforceRd, and reads of it go through that instead
+        if (varInfo->m_forceRdVscp
+            && !ForceState::isUnpackedArrayDType(baseRefp->varp()->dtypep())) {
+            return false;
         }
-
-        if (!baseRefp->access().isReadOnly()) {
-            iterateChildren(nodep);
-            return;
-        }
+        // In assignAll() an externally forceable array's committed value lives in
+        // __VforceRd, so element reads use that rather than the ownership entries (#8085)
         if (m_state.doingAssign() && varInfo->m_forceRdVscp) {
             baseRefp->varp(varInfo->m_forceRdVscp->varp());
             baseRefp->varScopep(varInfo->m_forceRdVscp);
-            iterateChildren(nodep);
-            return;
+            return false;
         }
-        const ForceState::ArraySelInfo arrayInfo = ForceState::getArraySelInfo(nodep);
-        // Substitute forced reads inside the index expressions before anything is cloned,
-        // so the fallback value and the flattened index use the same, force-aware index.
-        // An index is an ordinary read, including when it reads the same array as in
-        // 'mem[mem[0]]'.
-        for (AstArraySel* const selp : arrayInfo.m_sels) iterateAndNextNull(selp->bitp());
-        AstNodeExpr* const indexExprp
-            = ForceState::buildFlattenIndexExpr(nodep->fileline(), arrayInfo);
-        AstNodeExpr* const readExprp
-            = m_state.createForceReadIndexExpression(*varInfo, nodep, indexExprp);
-        nodep->replaceWith(readExprp);
+        if (!ForceState::usesForceSlots(baseRefp->varp())) return false;
+        if (!baseRefp->access().isReadOnly()) return false;
+        // A non-aggregate leaf no force can reach stays a plain read
+        const bool aggregate = ForceState::forceSlots(leafp->dtypep()) > 1;
+        const size_t reachingCount
+            = aggregate ? 0 : m_state.forcesReachingLeaf(*varInfo, leafp).size();
+        if (!aggregate && reachingCount == 0) return false;
+
+        // An intermediate selection still naming an aggregate is not one leaf, and a leaf
+        // more forces can reach than a chain should carry is treated the same: rebase it
+        // onto the whole-value shadow, which merges every leaf's force, and keep iterating
+        // so any index expressions inside it are still substituted.
+        if (ForceState::routesThroughShadow(leafp, reachingCount)) {
+            if (varInfo->m_slotRdVscp) {
+                if (m_inLogic && m_stmtp && m_slotRdRefreshed.emplace(m_stmtp, varInfo).second) {
+                    m_stmtp->addHereThisAsNext(m_state.makeSlotRdRefreshStmt(*varInfo));
+                }
+                baseRefp->varp(varInfo->m_slotRdVscp->varp());
+                baseRefp->varScopep(varInfo->m_slotRdVscp);
+                ForceState::markNonReplaceable(baseRefp);
+                return false;
+            }
+            // With no whole-value shadow an aggregate read has no chain to fall back on; a
+            // leaf reached by too many forces still builds one below.
+            if (aggregate) return false;
+        }
+
+        // Substitute forced reads inside the index expressions before anything is cloned, so
+        // the fallback value and the slot ordinal use the same, force-aware index.  An index
+        // is an ordinary read, including when it reads the same array as in 'mem[mem[0]]'.
+        for (AstArraySel* const selp : ForceState::arraySelsOf(leafp)) {
+            iterateAndNextNull(selp->bitp());
+        }
+        AstNodeExpr* const rawp = leafp->cloneTreePure(false);
+        rawp->foreach([](AstVarRef* const refp) { ForceState::markNonReplaceable(refp); });
+        AstNodeExpr* const readExprp = m_state.buildForcedLeafExpr(*varInfo, leafp, rawp);
+        if (leafp == nodep) {
+            nodep->replaceWith(readExprp);
+        } else {
+            nodep->replaceWith(ForceState::rebuildSelPath(nodep, readExprp));
+        }
         VL_DO_DANGLING(pushDeletep(nodep), nodep);
+        return true;
+    }
+
+    void visit(AstArraySel* nodep) override {
+        // A selection used as an index is a read in its own right, as in 'mem[mem[0]]', so
+        // isPathFromOfSelector() inside replacePathRead() only skips selections along 'fromp'.
+        if (!replacePathRead(nodep)) iterateChildren(nodep);
+    }
+    void visit(AstStructSel* nodep) override {
+        if (!replacePathRead(nodep)) iterateChildren(nodep);
     }
 
     void visit(AstVarRef* nodep) override {
@@ -1447,20 +2143,46 @@ class ForceReplaceVisitor final : public VNVisitor {
                 return;
             }
             if (m_inLogic && m_stmtp) {
-                m_stmtp->addNextHere(m_state.createForceRdUpdateStmt(*varInfo));
+                m_stmtp->addNextHere(m_state.makeForceRdRefreshStmt(*varInfo));
             }
             return;
         }
 
-        // For opaque member/struct paths we rewrite the outer path node instead of the base
-        // VarRef, so leave the base reference alone and let visit(AstNode*) handle it.
-        if (nodep->backp() && (VN_IS(nodep->backp(), Sel) || VN_IS(nodep->backp(), StructSel))
-            && !ForceState::isBitwiseDType(nodep->varp())
-            && !ForceState::isUnpackedArrayDType(nodep->varp()->dtypep())) {
+        // On a slot-indexed variable a member or element path is rewritten at its outermost
+        // selector, which needs the base reference left as it is.  A bit-range variable
+        // instead has its whole value read here, and the selects above pick from that.
+        if (ForceState::usesForceSlots(nodep->varp()) && ForceState::isPathFromOfSelector(nodep)) {
             return;
         }
 
-        UASSERT_OBJ(!varInfo->m_forces.empty(), nodep, "Var info for variable with no forces");
+        // A variable may reach here with a release recorded but no force left: a
+        // self-assigning 'force s = s' is removed as redundant before this pass, leaving
+        // its 'release s' behind.  Nothing is forced, so the read stays as it is.
+        if (varInfo->m_forces.empty()) return;
+
+        if (varInfo->m_slotRdVscp) {
+            if (nodep->access().isRW()) {
+                if (m_inLogic) {
+                    nodep->v3warn(E_UNSUPPORTED,
+                                  "Unsupported: Signals used via read-write reference cannot be "
+                                  "forced");
+                }
+                return;
+            }
+            // Reading the whole of a slot-indexed variable means reading its shadow, which
+            // already merges the force on each leaf
+            if (nodep->access().isReadOnly()) {
+                // In procedural code the read may happen in the same time step as the force,
+                // before the block that maintains the shadow has had a chance to run, so
+                // refresh it just ahead of this statement as well.
+                if (m_inLogic && m_stmtp && m_slotRdRefreshed.emplace(m_stmtp, varInfo).second) {
+                    m_stmtp->addHereThisAsNext(m_state.makeSlotRdRefreshStmt(*varInfo));
+                }
+                nodep->varp(varInfo->m_slotRdVscp->varp());
+                nodep->varScopep(varInfo->m_slotRdVscp);
+            }
+            return;
+        }
 
         if (nodep->access().isRW()) {
             nodep->v3warn(E_UNSUPPORTED,
@@ -1472,36 +2194,7 @@ class ForceReplaceVisitor final : public VNVisitor {
             VL_DO_DANGLING(pushDeletep(nodep), nodep);
         }
     }
-    void visit(AstNode* nodep) override {
-        if (ForceState::isOutermostOpaquePathSelector(nodep)) {
-            // Handle the whole opaque path at its outermost node so we can assign one stable
-            // synthetic force-path index to the full selection/member chain.
-            AstNodeExpr* const exprp = VN_AS(nodep, NodeExpr);
-            AstNode* const basep = AstArraySel::baseFromp(exprp, true);
-            AstVarRef* const baseRefp = VN_CAST(basep, VarRef);
-            if (baseRefp) {
-                AstVar* const varp = baseRefp->varp();
-                if (!ForceState::isBitwiseDType(varp)
-                    && !ForceState::isUnpackedArrayDType(varp->dtypep())) {
-                    const ForceState::VarForceInfo* const varInfo
-                        = m_state.getVarInfo(baseRefp->varScopep());
-                    if (!ForceState::isNotReplaceable(baseRefp) && varInfo) {
-                        const int forcePathIndex = varInfo->findForcePathIndex(exprp);
-                        if (forcePathIndex >= 0) {
-                            if (!baseRefp->access().isReadOnly()) return;
-                            AstNodeExpr* const readExprp = m_state.createForceReadIndexExpression(
-                                *varInfo, exprp,
-                                ForceState::makeConst32(nodep->fileline(), forcePathIndex));
-                            nodep->replaceWith(readExprp);
-                            VL_DO_DANGLING(pushDeletep(nodep), nodep);
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-        iterateChildren(nodep);
-    }
+    void visit(AstNode* nodep) override { iterateChildren(nodep); }
 
 public:
     explicit ForceReplaceVisitor(AstNetlist* nodep, const ForceState& state)
@@ -1521,11 +2214,15 @@ public:
 static void forceAllImpl(AstNetlist* nodep, ForceState::ForceHelperVarsByVar& helperVars) {
     UINFO(2, __FUNCTION__ << ":\n");
     if (!v3Global.hasForceableSignals()) return;
-    ForceState state{false, helperVars};
-    { ForceDiscoveryVisitor{nodep, state}; }
-    state.finalizeRhsVars();
-    { ForceConvertVisitor{nodep, state}; }
-    { ForceReplaceVisitor{nodep, state}; }
+    {
+        // Scoped so the state, which owns copies of the target paths, is gone before the
+        // tree check below looks for anything left unlinked
+        ForceState state{false, helperVars};
+        { ForceDiscoveryVisitor{nodep, state}; }
+        state.finalizeRhsVars();
+        { ForceConvertVisitor{nodep, state}; }
+        { ForceReplaceVisitor{nodep, state}; }
+    }
     V3Global::dumpCheckGlobalTree("force", 0, dumpTreeEitherLevel() >= 3);
 }
 
@@ -1558,11 +2255,13 @@ static void assignAllImpl(AstNetlist* nodep, ForceState::ForceHelperVarsByVar& h
             new AstRelease{deassignp->fileline(), deassignp->lhsp()->cloneTreePure(true)});
         deassignp->deleteTree();
     }
-    ForceState state{true, helperVars};
-    { ForceDiscoveryVisitor{nodep, state}; }
-    state.finalizeRhsVars();
-    { ForceConvertVisitor{nodep, state}; }
-    { ForceReplaceVisitor{nodep, state}; }
+    {
+        ForceState state{true, helperVars};
+        { ForceDiscoveryVisitor{nodep, state}; }
+        state.finalizeRhsVars();
+        { ForceConvertVisitor{nodep, state}; }
+        { ForceReplaceVisitor{nodep, state}; }
+    }
     V3Global::dumpCheckGlobalTree("assign-deassign", 0, dumpTreeEitherLevel() >= 3);
 }
 

--- a/src/V3Force.cpp
+++ b/src/V3Force.cpp
@@ -109,6 +109,9 @@ public:
         // side) share its ForceInfo: each execution re-establishes the same ownership
         // and value, so one id, one shadow and one read arm serve them all
         std::unordered_map<AstAssignForce*, AstAssignForce*> m_forceAliases;
+        // Cloned release target paths, owned here; a release can punch a hole in an
+        // enclosing aggregate force just as another force can
+        std::vector<AstNodeExpr*> m_releasePaths;
         // Shared per-variable shadow rebuild functions, created on first use, so each
         // procedural refresh site is one call however many forces the variable has
         mutable AstCFunc* m_slotRdRefreshFuncp = nullptr;
@@ -171,6 +174,9 @@ public:
                 if (AstNodeExpr* const pathp = pair.second.m_lhsPathp) {
                     VL_DO_DANGLING(pathp->deleteTree(), pathp);
                 }
+            }
+            for (AstNodeExpr* pathp : info.m_releasePaths) {
+                VL_DO_DANGLING(pathp->deleteTree(), pathp);
             }
         }
     }
@@ -831,6 +837,10 @@ public:
 
     static bool isBitSelForce(const ForceInfo* finfop) { return VN_IS(finfop->m_lhsPathp, Sel); }
 
+    static bool isAggregateForce(const ForceInfo* finfop) {
+        return forceSlots(forceLeafPath(finfop)->dtypep()) > 1;
+    }
+
     // The leaf's structural identity within its variable: member selections by name,
     // element selections position-blind.  Two paths with different signatures can never
     // address the same slot, whatever their indices.  Callers pass a leaf reached through
@@ -1222,6 +1232,96 @@ public:
                 flp, buildOwnsExpr(varInfo, flp, finfop->m_forceId, guardLo, guardHi), armp};
             tailp->addNextHere(ifp);
             tailp = ifp;
+
+            // An aggregate arm writes its whole path, including anything another force or
+            // a release has punched out of it.  Repair each such candidate: those are
+            // statically enumerable, as only a recorded force or release target can trim
+            // ownership.  A single-slot candidate is recomposed bit-exactly, raw below the
+            // bits this aggregate still owns; a multi-slot candidate is restored to raw
+            // wherever this aggregate owns none of it, widest candidate first, and an inner
+            // force that owns any of it writes afterwards, its arm being ordered later.
+            if (isAggregateForce(finfop)) {
+                AstNode* armTailp = armp;
+                std::vector<AstNodeExpr*> holePathps;
+                for (const ForceInfo* const otherp : overlappingForces(varInfo, region)) {
+                    if (otherp == finfop) continue;
+                    holePathps.push_back(forceLeafPath(otherp));
+                }
+                for (AstNodeExpr* const relPathp : varInfo.m_releasePaths) {
+                    holePathps.push_back(stripToLeaf(relPathp));
+                }
+                std::stable_sort(holePathps.begin(), holePathps.end(),
+                                 [](AstNodeExpr* ap, AstNodeExpr* bp) {
+                                     const SlotRange ar = staticSlotRange(ap);
+                                     const SlotRange br = staticSlotRange(bp);
+                                     return (ar.m_hi - ar.m_lo) > (br.m_hi - br.m_lo);
+                                 });
+                std::set<std::pair<int, int>> seen;
+                for (AstNodeExpr* const holePathp : holePathps) {
+                    const SlotRange hole = staticSlotRange(holePathp);
+                    if (hole.m_lo < finfop->m_rangeLsb || hole.m_hi > finfop->m_rangeMsb) {
+                        continue;
+                    }
+                    if (hole.m_lo == finfop->m_rangeLsb && hole.m_hi == finfop->m_rangeMsb) {
+                        continue;
+                    }
+                    // The arm writes only within the region, so only a hole strictly inside
+                    // it needs repair: one covering the whole region duplicates the arm's
+                    // own guard, and subtree ranges never partially overlap
+                    if (hole.m_lo < region.m_lo || hole.m_hi > region.m_hi) continue;
+                    if (hole.m_lo == region.m_lo && hole.m_hi == region.m_hi) continue;
+                    if (!seen.emplace(hole.m_lo, hole.m_hi).second) continue;
+                    UASSERT_OBJ(pathDepth(holePathp) >= pathDepth(forceLeafPath(finfop))
+                                    && pathDepth(holePathp) > regionDepth,
+                                holePathp, "Candidate inside an aggregate must be deeper");
+                    AstNodeExpr* const holeDstp
+                        = rebaseSuffixOnto(holePathp, regionDepth, dstBasep->cloneTreePure(false));
+                    AstNodeExpr* const holeRawp = holePathp->cloneTreePure(false);
+                    markRawRead(holeRawp);
+                    if (hole.m_lo == hole.m_hi && isBitwiseDType(holePathp)) {
+                        // dst.H = blendOwned(raw.H, aggShadow.<H suffix>, aggId, slot)
+                        const int stripDepth = pathDepth(forceLeafPath(finfop));
+                        AstNodeExpr* const suffixp = rebaseSuffixOnto(
+                            holePathp, stripDepth,
+                            new AstVarRef{flp, finfop->m_rhsVarVscp, VAccess::READ});
+                        AstCMethodHard* const blendp = new AstCMethodHard{
+                            flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                            VCMethod::FORCE_BLEND_OWNED, holeRawp};
+                        blendp->addPinsp(suffixp);
+                        blendp->addPinsp(makeConst32(flp, finfop->m_forceId));
+                        blendp->addPinsp(makeConst32(flp, hole.m_lo));
+                        blendp->dtypeFrom(holePathp);
+                        AstAssign* const recomposep = new AstAssign{flp, holeDstp, blendp};
+                        armTailp->addNextHere(recomposep);
+                        armTailp = recomposep;
+                    } else if (hole.m_lo == hole.m_hi) {
+                        // Non-bitwise leaf has no bit residue: owned or raw
+                        const int stripDepth = pathDepth(forceLeafPath(finfop));
+                        AstNodeExpr* const suffixp = rebaseSuffixOnto(
+                            holePathp, stripDepth,
+                            new AstVarRef{flp, finfop->m_rhsVarVscp, VAccess::READ});
+                        AstNodeExpr* const ownsp
+                            = buildOwnsExpr(varInfo, flp, finfop->m_forceId, hole.m_lo, hole.m_hi);
+                        AstCond* const condp = new AstCond{flp, ownsp, suffixp, holeRawp};
+                        condp->dtypeFrom(holePathp);
+                        AstAssign* const recomposep = new AstAssign{flp, holeDstp, condp};
+                        armTailp->addNextHere(recomposep);
+                        armTailp = recomposep;
+                    } else {
+                        // Multi-slot candidate: raw wherever this aggregate owns none of it
+                        AstCMethodHard* const ownsp = new AstCMethodHard{
+                            flp, new AstVarRef{flp, varInfo.m_forceVecVscp, VAccess::READ},
+                            VCMethod::FORCE_OWNS_ANY, makeConst32(flp, finfop->m_forceId)};
+                        ownsp->addPinsp(makeConst32(flp, hole.m_lo));
+                        ownsp->addPinsp(makeConst32(flp, hole.m_hi));
+                        ownsp->dtypeSetBit();
+                        AstIf* const holeIfp = new AstIf{flp, new AstLogNot{flp, ownsp},
+                                                         new AstAssign{flp, holeDstp, holeRawp}};
+                        armTailp->addNextHere(holeIfp);
+                        armTailp = holeIfp;
+                    }
+                }
+            }
         }
         // Reads and writes of the source variable in here are the raw storage by design
         for (AstNode* stmtp = headp; stmtp; stmtp = stmtp->nextp()) {
@@ -1524,6 +1624,10 @@ class ForceDiscoveryVisitor final : public VNVisitorConst {
                           "Unsupported: Release of a variable with 2^31 or more elements");
             return;
         }
+        ForceState::VarForceInfo& info = m_state.getOrCreateVarInfo(lhsVarRefp->varScopep());
+        AstNodeExpr* const pathp = nodep->lhsp()->cloneTreePure(false);
+        pathp->foreach([](AstVarRef* const refp) { refp->access(VAccess::READ); });
+        info.m_releasePaths.push_back(pathp);
     }
 
     void visit(AstAssign* nodep) override {

--- a/src/V3LiftExpr.cpp
+++ b/src/V3LiftExpr.cpp
@@ -238,8 +238,14 @@ class LiftExprVisitor final : public VNVisitor {
     void visit(AstNodeAssign* nodep) override {
         if (nodep->user1SetOnce()) return;
         VL_RESTORER(m_doNotLiftp);
-        // Do not lift the RHS if this is already a simple assignment to a variable
-        m_doNotLiftp = VN_IS(nodep->lhsp(), NodeVarRef) ? nodep->rhsp() : nullptr;
+        // Do not lift the RHS if this is already a simple assignment to a variable, nor of a
+        // force statement: V3Task lifts a function call out of a force right-hand side into a
+        // combinational block that re-evaluates it, so a call lifted here instead would be
+        // captured once and never track its operands (true whatever the force target's shape,
+        // where a non-variable target such as an unpacked-array element would otherwise lift)
+        m_doNotLiftp = (VN_IS(nodep->lhsp(), NodeVarRef) || VN_IS(nodep, AssignForce))
+                           ? nodep->rhsp()
+                           : nullptr;
         if (AstNode* const newStmtps = lift(nodep->rhsp())) {
             nodep->addHereThisAsNext(newStmtps);
         }

--- a/src/V3Sched.h
+++ b/src/V3Sched.h
@@ -43,7 +43,8 @@ inline bool isVlForceVec(const AstVarScope* vscp) {
 }
 
 inline bool isForceReadMethod(VCMethod method) {
-    return method == VCMethod::FORCE_READ || method == VCMethod::FORCE_READ_INDEX;
+    return method == VCMethod::FORCE_READ || method == VCMethod::FORCE_BLEND_OWNED
+           || method == VCMethod::FORCE_OWNS_ANY || method == VCMethod::FORCE_OWNS_SLOT;
 }
 
 inline void collectForceReadEdgeIgnores(AstNode* nodep, VarScopeSet& out) {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -10144,12 +10144,64 @@ class WidthVisitor final : public VNVisitor {
         }
         return nodep;
     }
+    // Return the node making this force/release left-hand side dynamic, else null.
+    // IEEE 1800-2023 6.21 requires force/release targets to be static variables.
+    static AstNode* forceLhsDynamicRecurse(AstNode* nodep) {
+        if (AstNodeSel* const selp = VN_CAST(nodep, NodeSel)) {
+            if (VN_IS(nodep, AssocSel) || VN_IS(nodep, WildcardSel)) return nodep;
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (AstSel* const selp = VN_CAST(nodep, Sel)) {
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            return forceLhsDynamicRecurse(selp->fromp());
+        }
+        if (VN_IS(nodep, MemberSel)) return nodep;  // Class property
+        if (AstCMethodHard* const callp = VN_CAST(nodep, CMethodHard)) {
+            return callp;  // Queue/dynamic array element select
+        }
+        return nullptr;
+    }
+    static AstNode* forceLhsSliceRecurse(AstNode* nodep) {
+        if (AstSliceSel* const selp = VN_CAST(nodep, SliceSel)) return selp;
+        if (AstNodeSel* const selp = VN_CAST(nodep, NodeSel)) {
+            return forceLhsSliceRecurse(selp->fromp());
+        }
+        if (AstSel* const selp = VN_CAST(nodep, Sel)) return forceLhsSliceRecurse(selp->fromp());
+        if (AstStructSel* const selp = VN_CAST(nodep, StructSel)) {
+            return forceLhsSliceRecurse(selp->fromp());
+        }
+        return nullptr;
+    }
     void checkForceReleaseLhs(AstNode* nodep, AstNode* lhsp) {
+        const string what = VN_IS(nodep, Release) ? "Release"s : "Force"s;
+        // An unpacked array slice is not one of the left-hand sides IEEE 1800-2023 10.6.2
+        // admits, and reaches V3Force with no variable reference at its base
+        if (AstNode* const sliceNodep = forceLhsSliceRecurse(lhsp)) {
+            nodep->v3warn(
+                E_UNSUPPORTED,
+                "Unsupported: " + what + " of an unpacked array slice (IEEE 1800-2023 10.6.2)\n"
+                    << nodep->warnContextPrimary() << '\n'
+                    << sliceNodep->warnOther() << "... Location of the slice\n"
+                    << sliceNodep->warnContextSecondary());
+            return;
+        }
+        if (AstNode* const dynNodep = forceLhsDynamicRecurse(lhsp)) {
+            nodep->v3error(what
+                               + " left-hand-side may not be automatically allocated storage: a "
+                                 "class property, or an associative, dynamic, or queue element "
+                                 "(IEEE 1800-2023 6.21)\n"
+                           << nodep->warnContextPrimary() << '\n'
+                           << dynNodep->warnOther() << "... Location of dynamic selection\n"
+                           << dynNodep->warnContextSecondary());
+            return;
+        }
         // V3Force can't check as vector may have expanded, or propagated constant into index
         if (AstNode* const selNodep = V3Width::selectNonConstantRecurse(lhsp))
-            nodep->v3error((VN_IS(nodep, Release) ? "Release"s : "Force"s)
-                               + " left-hand-side must not have variable bit/part select "
-                                 "(IEEE 1800-2023 10.6.2)\n"
+            nodep->v3error(what
+                               + " left-hand-side must not have a variable bit, part, or element "
+                                 "select (IEEE 1800-2023 10.6.2)\n"
                            << nodep->warnContextPrimary() << '\n'
                            << selNodep->warnOther() << "... Location of non-constant index\n"
                            << selNodep->warnContextSecondary());

--- a/test_regress/t/t_force_agg_overlap.py
+++ b/test_regress/t/t_force_agg_overlap.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_agg_overlap.v
+++ b/test_regress/t/t_force_agg_overlap.v
@@ -1,0 +1,233 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts how 'force' and 'release' behave when the target is a whole aggregate
+// or overlaps an earlier force, per IEEE 1800-2023 10.6.1 and 10.6.2.  Where the
+// standard does not describe overlapping force targets, an aggregate is held to
+// the same rule as a packed vector.
+//
+// Each section below states what it asserts:
+//  1. reading the whole struct while an element of an array member is forced,
+//  2. a bit or part select of an element of an array member,
+//  3. a whole plain unpacked array, which is one uniform stride,
+//  4. more forces on one variable than a compiled read chain carries, so leaf
+//     reads and release retention route through the whole-value shadow, and
+//     re-executed identical force statements, which share one force entry,
+//  5. one-element unpacked arrays, one- and multi-dimensional, whose element
+//     and bit-select forces still take the slot path.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: on
+
+typedef struct {
+  logic [7:0] arr[4];
+  logic [7:0] scalar;
+} st_t;
+
+module t;
+
+  st_t s;
+  st_t src;
+  st_t same;
+  st_t snap;
+  st_t q[2];
+  st_t m[10];
+  logic [7:0] tout;
+  logic [7:0] parr[4];
+  logic [7:0] pfill[4];
+  logic [7:0] psnap[4];
+  logic [15:0] one[5:5];
+  logic [7:0] onemd[2:2][7:7];
+
+  // Copies the struct before selecting from it, so the whole value is materialised
+  function automatic logic [7:0] via_copy(st_t v);
+    st_t copy;
+    copy = v;
+    return copy.arr[2];
+  endfunction
+
+  task automatic grab(input st_t v, output logic [7:0] oval);
+    oval = v.arr[2];
+  endtask
+
+  initial begin
+    //=======================================================================
+    // 1. Reading the whole struct while an element of an array member is
+    //    forced, in the contexts where the struct value has to be materialised
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) begin
+      s.arr[i] = 8'h10 + 8'(i);
+      same.arr[i] = 8'h10 + 8'(i);
+      src.arr[i] = 8'h20 + 8'(i);
+    end
+    s.scalar = 8'h99;
+    same.scalar = 8'h99;
+    src.scalar = 8'h88;
+    #1;
+    force s.arr[2] = 8'haa;
+    force s.scalar = 8'hbb;
+    #1;
+    snap = s;
+    `checkh(snap.arr[2], 8'haa);
+    `checkh(snap.arr[0], 8'h10);
+    `checkh(snap.scalar, 8'hbb);
+    // Same time step as the force, with no delay in between
+    `checkh(via_copy(s), 8'haa);
+    grab(s, tout);
+    `checkh(tout, 8'haa);
+    `checkh((s == same), 1'b0);
+    q[0] = s;
+    `checkh(q[0].arr[2], 8'haa);
+    `checkh(q[0].arr[0], 8'h10);
+    // Two whole-struct reads in one statement
+    `checkh(((s == same) || (s == q[0])), 1'b1);
+    #1;
+    `checkh(via_copy(s), 8'haa);
+    `checkh((s == same), 1'b0);
+    release s.arr[2];
+    release s.scalar;
+    #1;
+
+    //=======================================================================
+    // 2. A bit or part select of an element of an array member
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) s.arr[i] = 8'h10 + 8'(i);
+    s.scalar = 8'h99;
+    #1;
+    force s.arr[2][3:0] = 4'ha;
+    #1;
+    `checkh(s.arr[2], 8'h1a);
+    `checkh(s.arr[1], 8'h11);
+    `checkh(s.scalar, 8'h99);
+    // A second force of a disjoint part of the same element coexists with the first
+    force s.arr[2][7:4] = 4'hc;
+    #1;
+    `checkh(s.arr[2], 8'hca);
+    release s.arr[2][3:0];
+    release s.arr[2][7:4];
+    #1;
+    `checkh(s.arr[2], 8'hca);
+
+    //=======================================================================
+    // 3. A whole plain unpacked array, which is one uniform stride and so needs no
+    //     per-leaf targets, and a read of the whole array while an element is forced
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) begin
+      parr[i] = 8'h10 + 8'(i);
+      pfill[i] = 8'h30 + 8'(i);
+    end
+    #1;
+    force parr = pfill;
+    #1;
+    `checkh(parr[0], 8'h30);
+    `checkh(parr[2], 8'h32);
+    release parr;
+    #1;
+    `checkh(parr[2], 8'h32);
+    force parr[2] = 8'hb9;
+    #1;
+    psnap = parr;
+    `checkh(psnap[2], 8'hb9);
+    `checkh(psnap[0], 8'h30);
+    release parr[2];
+    #1;
+
+    // A bit force inside a whole-array force: the untouched elements keep showing
+    // the whole force, and a release of the bits retains them
+    force parr = pfill;
+    #1;
+    force parr[1][3:0] = 4'he;
+    #1;
+    `checkh(parr[1], 8'h3e);
+    `checkh(parr[0], 8'h30);
+    `checkh(parr[2], 8'h32);
+    release parr[1][3:0];
+    #1;
+    `checkh(parr[1], 8'h3e);
+    `checkh(parr[2], 8'h32);
+    release parr;
+    #1;
+
+    //=======================================================================
+    // 4. Ten forces on one variable, which is past what a compiled read
+    //     chain carries per leaf, so leaf reads and release retention go
+    //     through the whole-value shadow.  The last force wins, a released
+    //     element keeps the value it showed, and re-running the same force
+    //     statement in a loop shares one force entry and still lands.
+    //=======================================================================
+    for (int i = 0; i < 10; ++i) begin
+      for (int j = 0; j < 4; ++j) m[i].arr[j] = 8'(8'h10 * i + j);
+      m[i].scalar = 8'(8'hf0 + i);
+    end
+    for (int i = 0; i < 4; ++i) s.arr[i] = 8'h10 + 8'(i);
+    s.scalar = 8'h99;
+    #1;
+    force s = m[0];
+    force s = m[1];
+    force s = m[2];
+    force s = m[3];
+    force s = m[4];
+    force s = m[5];
+    force s = m[6];
+    force s = m[7];
+    force s = m[8];
+    force s = m[9];
+    #1;
+    `checkh(s.arr[2], 8'h92);
+    `checkh(s.scalar, 8'hf9);
+    snap = s;
+    `checkh(snap.arr[1], 8'h91);
+    release s.arr[2];
+    #1;
+    `checkh(s.arr[2], 8'h92);
+    `checkh(s.scalar, 8'hf9);
+    // An earlier of the ten forces re-executes and takes the variable back whole
+    force s = m[4];
+    #1;
+    `checkh(s.arr[2], 8'h42);
+    `checkh(s.scalar, 8'hf4);
+    release s;
+    #1;
+    `checkh(s.scalar, 8'hf4);
+    // The same force statement re-executed in a loop lands each time
+    for (int i = 0; i < 3; ++i) begin
+      force s.arr[1] = 8'hd1;
+      #1;
+      `checkh(s.arr[1], 8'hd1);
+      release s.arr[1];
+      s.arr[1] = 8'(8'h60 + i);
+      #1;
+      `checkh(s.arr[1], 8'(8'h60 + i));
+    end
+
+    //=======================================================================
+    // 5. A one-element unpacked array is still an unpacked aggregate, so its
+    //     element and bit-select forces take the slot path and must compile
+    //     and run, at one dimension and at a one-by-one multidimensional shape.
+    //=======================================================================
+    one[5] = 16'h1234;
+    #1;
+    force one[5][11:4] = 8'hab;
+    #1;
+    `checkh(one[5], 16'h1ab4);
+    release one[5][11:4];
+    #1;
+    `checkh(one[5], 16'h1ab4);
+    onemd[2][7] = 8'h39;
+    #1;
+    force onemd[2][7] = 8'he4;
+    #1;
+    `checkh(onemd[2][7], 8'he4);
+    release onemd[2][7];
+    #1;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_force_agg_overlap.v
+++ b/test_regress/t/t_force_agg_overlap.v
@@ -9,11 +9,20 @@
 //  1. reading the whole struct while an element of an array member is forced,
 //  2. a bit or part select of an element of an array member,
 //  3. a whole plain unpacked array, which is one uniform stride,
-//  4. more forces on one variable than a compiled read chain carries, so leaf
+//  4. a force replacing an earlier force over the range they share, and a
+//     leaf release that punches a hole in an aggregate force,
+//  5. aggregate forces nested three structs deep, in both activation orders,
+//     with the middle one released while the outer stays active, and release
+//     retention confined to what the released force owned,
+//  6. more forces on one variable than a compiled read chain carries, so leaf
 //     reads and release retention route through the whole-value shadow, and
 //     re-executed identical force statements, which share one force entry,
-//  5. one-element unpacked arrays, one- and multi-dimensional, whose element
-//     and bit-select forces still take the slot path.
+//  7. one-element unpacked arrays, one- and multi-dimensional, whose element
+//     and bit-select forces still take the slot path,
+//  8. releasing an aggregate keeping a hole an earlier sub-region release
+//     punched in it, rather than resurrecting the enclosing force there,
+//  9. recomposing a whole-aggregate force over a non-bitwise single-slot hole
+//     (an inner force on a real member).
 //
 // This file ONLY is placed under the Creative Commons Public Domain.
 // SPDX-FileCopyrightText: 2026 BRDR LIFE
@@ -22,6 +31,7 @@
 // verilog_format: off
 `define stop $stop
 `define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+`define checkr(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got=%g exp=%g\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
 // verilog_format: on
 
 typedef struct {
@@ -30,6 +40,31 @@ typedef struct {
 } st_t;
 
 module t;
+
+  typedef struct {
+    logic [7:0] arr[4];
+    logic [7:0] tail;
+  } tail_t;
+  typedef struct {
+    logic [7:0] x;
+    logic [7:0] y;
+  } lvl0_t;
+  typedef struct {
+    lvl0_t sub;
+    logic [7:0] pad;
+  } lvl1_t;
+  typedef struct {
+    lvl1_t sub;
+    logic [7:0] pad;
+  } lvl2_t;
+  typedef struct {
+    logic [15:0] y;
+    logic [7:0] z;
+  } yz_t;
+  typedef struct {
+    real r;
+    logic [7:0] a;
+  } rb_t;
 
   st_t s;
   st_t src;
@@ -41,8 +76,18 @@ module t;
   logic [7:0] parr[4];
   logic [7:0] pfill[4];
   logic [7:0] psnap[4];
+  logic [7:0] vec;
+  lvl2_t n;
+  lvl2_t nsnap;
+  lvl2_t z2;
+  lvl1_t z1;
+  lvl0_t z0;
+  tail_t rt;
+  tail_t rtsrc;
   logic [15:0] one[5:5];
   logic [7:0] onemd[2:2][7:7];
+  yz_t hs, hrhs;
+  rb_t rbs, rbsrc, rbsnap;
 
   // Copies the struct before selecting from it, so the whole value is materialised
   function automatic logic [7:0] via_copy(st_t v);
@@ -154,7 +199,155 @@ module t;
     #1;
 
     //=======================================================================
-    // 4. Ten forces on one variable, which is past what a compiled read
+    // 4. A force replaces an earlier force over the range they share, and the
+    //     release then keeps that value.  IEEE 1800-2023 10.6.2 does not
+    //     describe overlapping force targets, so an aggregate is held to the
+    //     same rule as the packed vector checked first here.
+    //=======================================================================
+    vec = 8'h11;
+    #1;
+    force vec = 8'h21;
+    #1;
+    `checkh(vec, 8'h21);
+    force vec[3:0] = 4'h5;
+    #1;
+    `checkh(vec, 8'h25);
+    release vec[3:0];
+    #1;
+    `checkh(vec, 8'h25);
+    release vec;
+    #1;
+    `checkh(vec, 8'h25);
+
+    for (int i = 0; i < 4; ++i) src.arr[i] = 8'h20 + 8'(i);
+    src.scalar = 8'h88;
+    #1;
+    force s = src;
+    #1;
+    `checkh(s.arr[2], 8'h22);
+    force s.arr[2] = 8'h30;
+    #1;
+    `checkh(s.arr[2], 8'h30);
+    release s.arr[2];
+    #1;
+    `checkh(s.arr[2], 8'h30);
+    // The rest of the earlier force is still in effect
+    `checkh(s.arr[1], 8'h21);
+    `checkh(s.scalar, 8'h88);
+    // A whole read sees the released element and the still-forced rest alike
+    snap = s;
+    `checkh(snap.arr[2], 8'h30);
+    `checkh(snap.arr[1], 8'h21);
+    // Releasing a leaf the aggregate force still owns punches a hole in it: the leaf
+    // keeps its value, a later assignment lands, and whole reads see both
+    release s.arr[1];
+    #1;
+    `checkh(s.arr[1], 8'h21);
+    s.arr[1] = 8'h77;
+    #1;
+    `checkh(s.arr[1], 8'h77);
+    snap = s;
+    `checkh(snap.arr[1], 8'h77);
+    `checkh(snap.arr[3], 8'h23);
+    `checkh(snap.scalar, 8'h88);
+    release s;
+    #1;
+
+    //=======================================================================
+    // 5. Aggregate forces nested three structs deep.  Outermost first: each
+    //     inner force takes over its subtree, and whole reads and leaf reads
+    //     agree while all three are up.  Releasing the middle one keeps the
+    //     values it showed, leaves the outer force holding the rest, and lets
+    //     a plain assignment land inside the released region.
+    //=======================================================================
+    n.sub.sub.x = 8'h10;
+    n.sub.sub.y = 8'h11;
+    n.sub.pad = 8'h12;
+    n.pad = 8'h13;
+    z2.sub.sub.x = 8'h20;
+    z2.sub.sub.y = 8'h21;
+    z2.sub.pad = 8'h22;
+    z2.pad = 8'h23;
+    z1.sub.x = 8'h30;
+    z1.sub.y = 8'h31;
+    z1.pad = 8'h32;
+    z0.x = 8'h40;
+    z0.y = 8'h41;
+    #1;
+    force n = z2;
+    force n.sub = z1;
+    force n.sub.sub = z0;
+    #1;
+    nsnap = n;
+    `checkh(nsnap.sub.sub.x, 8'h40);
+    `checkh(nsnap.sub.sub.y, 8'h41);
+    `checkh(nsnap.sub.pad, 8'h32);
+    `checkh(nsnap.pad, 8'h23);
+    `checkh(n.sub.sub.x, 8'h40);
+    `checkh(n.sub.pad, 8'h32);
+    `checkh(n.pad, 8'h23);
+    // Releasing the middle releases everything under it, retaining the values
+    // shown, while the outer force keeps the part it still owns
+    release n.sub;
+    #1;
+    nsnap = n;
+    `checkh(nsnap.sub.sub.x, 8'h40);
+    `checkh(nsnap.sub.pad, 8'h32);
+    `checkh(nsnap.pad, 8'h23);
+    n.sub.pad = 8'h77;
+    #1;
+    `checkh(n.sub.pad, 8'h77);
+    nsnap = n;
+    `checkh(nsnap.sub.pad, 8'h77);
+    `checkh(nsnap.pad, 8'h23);
+    release n;
+    #1;
+
+    // The other activation order: the outer force, arriving last, takes back
+    // the innermost subtree
+    force n.sub.sub = z0;
+    #1;
+    `checkh(n.sub.sub.x, 8'h40);
+    force n = z2;
+    #1;
+    nsnap = n;
+    `checkh(nsnap.sub.sub.x, 8'h20);
+    `checkh(nsnap.sub.pad, 8'h22);
+    `checkh(n.sub.sub.x, 8'h20);
+    release n;
+    #1;
+
+    // Release retention writes only what the released force owned: with the
+    // whole struct forced, release the array member, overwrite it plainly,
+    // force one element back, and release the array again.  The second
+    // release must keep the plain values, not resurrect the whole force's own
+    for (int i = 0; i < 4; ++i) begin
+      rt.arr[i] = 8'h10 + 8'(i);
+      rtsrc.arr[i] = 8'ha0 + 8'(i);
+    end
+    rt.tail = 8'h1f;
+    rtsrc.tail = 8'haf;
+    #1;
+    force rt = rtsrc;
+    #1;
+    release rt.arr;
+    #1;
+    for (int i = 0; i < 4; ++i) rt.arr[i] = 8'h50 + 8'(i);
+    #1;
+    force rt.arr[1] = 8'hee;
+    #1;
+    release rt.arr;
+    #1;
+    `checkh(rt.arr[0], 8'h50);
+    `checkh(rt.arr[1], 8'hee);
+    `checkh(rt.arr[2], 8'h52);
+    `checkh(rt.arr[3], 8'h53);
+    `checkh(rt.tail, 8'haf);
+    release rt;
+    #1;
+
+    //=======================================================================
+    // 6. Ten forces on one variable, which is past what a compiled read
     //     chain carries per leaf, so leaf reads and release retention go
     //     through the whole-value shadow.  The last force wins, a released
     //     element keeps the value it showed, and re-running the same force
@@ -185,6 +378,9 @@ module t;
     release s.arr[2];
     #1;
     `checkh(s.arr[2], 8'h92);
+    s.arr[2] = 8'h55;
+    #1;
+    `checkh(s.arr[2], 8'h55);
     `checkh(s.scalar, 8'hf9);
     // An earlier of the ten forces re-executes and takes the variable back whole
     force s = m[4];
@@ -206,7 +402,7 @@ module t;
     end
 
     //=======================================================================
-    // 5. A one-element unpacked array is still an unpacked aggregate, so its
+    // 7. A one-element unpacked array is still an unpacked aggregate, so its
     //     element and bit-select forces take the slot path and must compile
     //     and run, at one dimension and at a one-by-one multidimensional shape.
     //=======================================================================
@@ -224,6 +420,51 @@ module t;
     #1;
     `checkh(onemd[2][7], 8'he4);
     release onemd[2][7];
+    #1;
+
+    //=======================================================================
+    // 8. Releasing an aggregate keeps the value it currently shows, including a
+    //     hole an earlier sub-region release punched in it: releasing the whole
+    //     must not resurrect the enclosing force's value over that hole.
+    //=======================================================================
+    hs.y = 16'h1234;
+    hs.z = 8'h56;
+    hrhs.y = 16'ha000;
+    hrhs.z = 8'hbc;
+    #1;
+    force hs = hrhs;
+    force hs.y[7:4] = 4'he;
+    #1;
+    `checkh(hs.y, 16'ha0e0);
+    release hs.y[7:4];
+    #1;
+    `checkh(hs.y, 16'ha0e0);
+    release hs;
+    #1;
+    `checkh(hs.y, 16'ha0e0);
+    `checkh(hs.z, 8'hbc);
+
+    //=======================================================================
+    // 9. Recomposing a whole-aggregate force over a non-bitwise single-slot
+    //     hole.  An inner force on a real member is one force slot carrying no
+    //     bit residue, so the merged value restores it owned-or-raw rather than
+    //     bit-blended, and a whole-struct read sees the inner force's value.
+    //=======================================================================
+    rbs.r = 1.0;
+    rbs.a = 8'h11;
+    rbsrc.r = 2.5;
+    rbsrc.a = 8'haa;
+    #1;
+    force rbs = rbsrc;
+    force rbs.r = 3.0;
+    #1;
+    rbsnap = rbs;
+    `checkr(rbsnap.r, 3.0);
+    `checkh(rbsnap.a, 8'haa);
+    release rbs.r;
+    #1;
+    `checkh(rbs.a, 8'haa);
+    release rbs;
     #1;
 
     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_force_agg_rhs.py
+++ b/test_regress/t/t_force_agg_rhs.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_agg_rhs.v
+++ b/test_regress/t/t_force_agg_rhs.v
@@ -1,0 +1,80 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts that a 'force' right-hand side on an aggregate leaf is re-evaluated
+// when its operands change, per IEEE 1800-2023 10.6.2, just as a scalar force
+// target is.
+//
+// Each section below states what it asserts:
+//  1. an aggregate-leaf force right-hand side tracking an operand change made
+//     through a function call,
+//  2. a force right-hand side reading a forced sibling element of the same
+//     array, which sees that sibling's force rather than raw storage.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: on
+
+module t;
+
+  logic [7:0] fa[0:1];
+  logic [7:0] fsrc;
+
+  // A force right-hand side is re-evaluated when its operands change, including
+  // through a function call, so this is used to force an element from src
+  function automatic logic [7:0] xf(input logic [7:0] v);
+    return {v[0], v[7:1]} ^ 8'h5a;
+  endfunction
+
+  initial begin
+    //=======================================================================
+    // 1. A force right-hand side on an aggregate leaf tracks a later change of
+    //     its operands through a function call, as a scalar force target does.
+    //=======================================================================
+    fa[0] = 8'h10;
+    fa[1] = 8'h20;
+    fsrc = 8'h24;
+    #1;
+    force fa[1] = xf(fsrc);
+    #1;
+    `checkh(fa[1], 8'h48);
+    fsrc = 8'hc3;
+    #1;
+    `checkh(fa[1], 8'hbb);
+    release fa[1];
+    #1;
+
+    //=======================================================================
+    // 2. A force right-hand side that reads a sibling element of the same
+    //     array sees that sibling's own force, not raw storage.  Only a read
+    //     reaching back into the force's own element stays raw, to avoid a
+    //     combinational cycle.
+    //=======================================================================
+    fa[0] = 8'h10;
+    fa[1] = 8'h20;
+    #1;
+    force fa[1] = fa[0] + 8'd5;
+    #1;
+    `checkh(fa[1], 8'h15);
+    force fa[0] = 8'h40;
+    #1;
+    // fa[1]'s right-hand side sees the forced fa[0], not the raw value
+    `checkh(fa[1], 8'h45);
+    // A procedural write to the forced fa[0] does not leak through
+    fa[0] = 8'h99;
+    #1;
+    `checkh(fa[0], 8'h40);
+    `checkh(fa[1], 8'h45);
+    release fa[0];
+    release fa[1];
+    #1;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_force_agg_trace.py
+++ b/test_regress/t/t_force_agg_trace.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary", "--trace", "--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_agg_trace.v
+++ b/test_regress/t/t_force_agg_trace.v
@@ -1,0 +1,61 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Trace instrumentation over forces on unpacked aggregates.  Two cases that
+// only failed under --trace:
+//  - A self-assigning whole-struct force, which is removed as redundant before
+//    V3Force, left a release behind whose trace read asserted internally.
+//  - Forcing the same unpacked-array member in two elements of an interface
+//    instance array added a same-named read helper to the shared interface
+//    class twice, which trace kept live and the C++ compiler then rejected.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+interface Bus;
+  logic [7:0] data[2];
+endinterface
+
+// verilog_format: off
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0)
+// verilog_format: on
+
+module t;
+  typedef struct {
+    logic [7:0] x;
+    logic [7:0] y;
+  } pair_t;
+  pair_t s;
+
+  Bus buses[2] ();
+
+  initial begin
+    s.x = 8'h12;
+    s.y = 8'h34;
+    // Removed as redundant before V3Force; its release must not fault under trace
+    force s = s;
+    #1;
+    `checkh(s.x, 8'h12);
+    `checkh(s.y, 8'h34);
+    release s;
+
+    for (int i = 0; i < 2; ++i) begin
+      buses[0].data[i] = 8'h10 + 8'(i);
+      buses[1].data[i] = 8'h20 + 8'(i);
+    end
+    #1;
+    force buses[0].data[1] = 8'ha0;
+    force buses[1].data[1] = 8'hb1;
+    #1;
+    `checkh(buses[0].data[1], 8'ha0);
+    `checkh(buses[1].data[1], 8'hb1);
+    `checkh(buses[0].data[0], 8'h10);
+    `checkh(buses[1].data[0], 8'h20);
+    release buses[0].data[1];
+    release buses[1].data[1];
+    #1;
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_force_agg_type_bad.out
+++ b/test_regress/t/t_force_agg_type_bad.out
@@ -1,0 +1,11 @@
+%Error-UNSUPPORTED: t/t_force_agg_type_bad.v:28:5: Unsupported: Force of an unpacked aggregate from an expression of a different type
+   28 |     force s = '0;
+      |     ^~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_force_agg_type_bad.v:29:5: Unsupported: Force of an unpacked aggregate from an expression of a different type
+   29 |     force s.sub = '0;
+      |     ^~~~~
+%Error-UNSUPPORTED: t/t_force_agg_type_bad.v:30:5: Unsupported: Force of an unpacked aggregate from an expression of a different type
+   30 |     force one = '0;
+      |     ^~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_force_agg_type_bad.py
+++ b/test_regress/t/t_force_agg_type_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_agg_type_bad.v
+++ b/test_regress/t/t_force_agg_type_bad.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// The value of a force on an unpacked aggregate is kept in a shadow variable
+// typed as the target, so the right-hand side must be of the target's type.
+// An expression of another type is diagnosed rather than mis-stored.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  typedef struct {
+    logic [7:0] x;
+    logic [7:0] y;
+  } inner_t;
+  typedef struct {
+    inner_t sub;
+    logic [7:0] pad;
+  } outer_t;
+  // A single-member unpacked struct is a typed-shadow target too, though its slot
+  // count is one, so a differently-typed right-hand side is diagnosed the same way
+  typedef struct {
+    logic [7:0] only;
+  } one_t;
+  outer_t s;
+  one_t one;
+  initial begin
+    force s = '0;
+    force s.sub = '0;
+    force one = '0;
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_force_dynamic_bad.out
+++ b/test_regress/t/t_force_dynamic_bad.out
@@ -1,0 +1,37 @@
+%Error: t/t_force_dynamic_bad.v:26:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   26 |     force c.a = 2;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:26:13: ... Location of dynamic selection
+   26 |     force c.a = 2;
+      |             ^
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_force_dynamic_bad.v:27:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   27 |     force aa[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:27:13: ... Location of dynamic selection
+   27 |     force aa[0] = 1;
+      |             ^
+%Error: t/t_force_dynamic_bad.v:28:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   28 |     force dyn[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:28:14: ... Location of dynamic selection
+   28 |     force dyn[0] = 1;
+      |              ^
+%Error: t/t_force_dynamic_bad.v:29:5: Force left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   29 |     force q[0] = 1;
+      |     ^~~~~
+        t/t_force_dynamic_bad.v:29:12: ... Location of dynamic selection
+   29 |     force q[0] = 1;
+      |            ^
+%Error: t/t_force_dynamic_bad.v:30:5: Release left-hand-side may not be automatically allocated storage: a class property, or an associative, dynamic, or queue element (IEEE 1800-2023 6.21)
+                                    : ... note: In instance 't'
+   30 |     release c.a;
+      |     ^~~~~~~
+        t/t_force_dynamic_bad.v:30:15: ... Location of dynamic selection
+   30 |     release c.a;
+      |               ^
+%Error: Exiting due to

--- a/test_regress/t/t_force_dynamic_bad.py
+++ b/test_regress/t/t_force_dynamic_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_dynamic_bad.v
+++ b/test_regress/t/t_force_dynamic_bad.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts that a force or release whose left-hand side is automatically
+// allocated storage reports an error citing IEEE 1800-2023 6.21, for each of a
+// class property, an associative array element, a dynamic array element, and a
+// queue element.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+  class C;
+    int a;
+  endclass
+
+  C c;
+  int aa[int];
+  int dyn[];
+  int q[$];
+
+  initial begin
+    c = new;
+    dyn = new[3];
+    force c.a = 2;
+    force aa[0] = 1;
+    force dyn[0] = 1;
+    force q[0] = 1;
+    release c.a;
+  end
+
+endmodule

--- a/test_regress/t/t_force_forceable_array.py
+++ b/test_regress/t/t_force_forceable_array.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary", "--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_forceable_array.v
+++ b/test_regress/t/t_force_forceable_array.v
@@ -1,0 +1,54 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// A procedural force or release of an externally forceable unpacked array,
+// whole or by element, is visible through the array's read path.  The read
+// path merges the procedural force's slots before overlaying the external
+// per-element enable and value, and the per-element enable is left to the
+// external interface rather than driven with the whole-value mask arithmetic
+// that only a packed signal admits.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); $stop; end while(0)
+// verilog_format: on
+
+module t;
+  logic [7:0] arr[0:3] /* verilator forceable */;
+  logic [7:0] src[0:3];
+
+  initial begin
+    for (int i = 0; i < 4; ++i) begin
+      arr[i] = 8'h10 + 8'(i);
+      src[i] = 8'ha0 + 8'(i);
+    end
+    #1;
+    // Procedural force of one element is visible through the forceable read path
+    force arr[1] = 8'hc1;
+    #1;
+    `checkh(arr[1], 8'hc1);
+    `checkh(arr[0], 8'h10);
+    // A live change of a sibling is unaffected
+    arr[2] = 8'h77;
+    #1;
+    `checkh(arr[2], 8'h77);
+    `checkh(arr[1], 8'hc1);
+    release arr[1];
+    #1;
+    `checkh(arr[1], 8'hc1);
+
+    // Procedural force of the whole forceable array compiles and takes effect
+    force arr = src;
+    #1;
+    `checkh(arr[0], 8'ha0);
+    `checkh(arr[3], 8'ha3);
+    release arr;
+    #1;
+    `checkh(arr[0], 8'ha0);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_force_huge_unsup.out
+++ b/test_regress/t/t_force_huge_unsup.out
@@ -1,0 +1,8 @@
+%Error-UNSUPPORTED: t/t_force_huge_unsup.v:15:5: Unsupported: Force of a variable with 2^31 or more elements
+   15 |     force x[0][0] = 1'b1;
+      |     ^~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_force_huge_unsup.v:16:5: Unsupported: Release of a variable with 2^31 or more elements
+   16 |     release x[0][0];
+      |     ^~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_force_huge_unsup.py
+++ b/test_regress/t/t_force_huge_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_huge_unsup.v
+++ b/test_regress/t/t_force_huge_unsup.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// A variable with more force slots (leaves) than the int slot arithmetic can
+// hold is rejected rather than numbering its slots wrongly and miscompiling.
+// The array is only its type here, so this stays cheap to elaborate.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  // 46341 * 46341 = 2147488281 > 2^31 - 1 leaves
+  bit x[46341][46341];
+  initial begin
+    force x[0][0] = 1'b1;
+    release x[0][0];
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_force_nested_struct.v
+++ b/test_regress/t/t_force_nested_struct.v
@@ -35,11 +35,19 @@ module m;
     snapshot = st2;
     `checkh(snapshot.inner.val, 32'h21);
     `checkh(snapshot.inner.val[0], 1'b1);
+    // Direct member-path reads see the whole-struct force too
+    `checkh(st2.inner.val, 32'h21);
+    `checkh(st2.tail, 32'h23);
+    // A force on a range overlapping an earlier force replaces the earlier one over that
+    // range, and IEEE 1800-2023 10.6.2 then keeps the released value until the next
+    // procedural assignment.  The rest of the earlier force stays in effect.
     force st2.inner.val = 32'h30;
+    snapshot = st2;
+    `checkh(snapshot.inner.val, 32'h30);
     release st2.inner.val;
     snapshot = st2;
-    `checkh(snapshot.inner.val, 32'h21);
-    `checkh(snapshot.inner.val[0], 1'b1);
+    `checkh(snapshot.inner.val, 32'h30);
+    `checkh(snapshot.inner.val[0], 1'b0);
     `checkh(snapshot.inner.other, 32'h22);
     `checkh(snapshot.tail, 32'h23);
     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_force_select_bad.out
+++ b/test_regress/t/t_force_select_bad.out
@@ -1,4 +1,4 @@
-%Error: t/t_force_select_bad.v:24:5: Force left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:24:5: Force left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    24 |     force array1[bad_index] = 1'b1;   
       |     ^~~~~
@@ -6,21 +6,21 @@
    24 |     force array1[bad_index] = 1'b1;   
       |                  ^~~~~~~~~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error: t/t_force_select_bad.v:25:5: Release left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:25:5: Release left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    25 |     release array1[bad_index];   
       |     ^~~~~~~
         t/t_force_select_bad.v:25:20: ... Location of non-constant index
    25 |     release array1[bad_index];   
       |                    ^~~~~~~~~
-%Error: t/t_force_select_bad.v:26:5: Force left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:26:5: Force left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    26 |     force vec[bad_index+:1] = 1'b1;   
       |     ^~~~~
         t/t_force_select_bad.v:26:15: ... Location of non-constant index
    26 |     force vec[bad_index+:1] = 1'b1;   
       |               ^~~~~~~~~
-%Error: t/t_force_select_bad.v:27:5: Release left-hand-side must not have variable bit/part select (IEEE 1800-2023 10.6.2)
+%Error: t/t_force_select_bad.v:27:5: Release left-hand-side must not have a variable bit, part, or element select (IEEE 1800-2023 10.6.2)
                                    : ... note: In instance 't'
    27 |     release vec[bad_index+:1];   
       |     ^~~~~~~

--- a/test_regress/t/t_force_slice_bad.out
+++ b/test_regress/t/t_force_slice_bad.out
@@ -1,0 +1,23 @@
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:19:5: Unsupported: Force of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   19 |     force a[1:2] = fill[1:2];
+      |     ^~~~~
+                    t/t_force_slice_bad.v:19:12: ... Location of the slice
+   19 |     force a[1:2] = fill[1:2];
+      |            ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:20:5: Unsupported: Release of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   20 |     release a[1:2];
+      |     ^~~~~~~
+                    t/t_force_slice_bad.v:20:14: ... Location of the slice
+   20 |     release a[1:2];
+      |              ^
+%Error-UNSUPPORTED: t/t_force_slice_bad.v:21:5: Unsupported: Force of an unpacked array slice (IEEE 1800-2023 10.6.2)
+                                              : ... note: In instance 't'
+   21 |     force s.arr[0:1] = fill[0:1];
+      |     ^~~~~
+                    t/t_force_slice_bad.v:21:16: ... Location of the slice
+   21 |     force s.arr[0:1] = fill[0:1];
+      |                ^
+%Error: Exiting due to

--- a/test_regress/t/t_force_slice_bad.py
+++ b/test_regress/t/t_force_slice_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_slice_bad.v
+++ b/test_regress/t/t_force_slice_bad.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// An unpacked array slice is not one of the left-hand sides IEEE 1800-2023
+// 10.6.2 admits for force or release.  It is diagnosed rather than reaching
+// V3Force with no variable reference at its base, which asserted internally.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  logic [7:0] a[4];
+  logic [7:0] fill[4];
+  typedef struct {
+    logic [7:0] arr[4];
+  } s_t;
+  s_t s;
+  initial begin
+    force a[1:2] = fill[1:2];
+    release a[1:2];
+    force s.arr[0:1] = fill[0:1];
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_force_struct_arr.py
+++ b/test_regress/t/t_force_struct_arr.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_force_struct_arr.v
+++ b/test_regress/t/t_force_struct_arr.v
@@ -1,0 +1,400 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts how 'force' and 'release' behave on targets reached through the member
+// and element path of an aggregate, per IEEE 1800-2023 10.6.1 and 10.6.2.  An
+// element of an unpacked array is a singular reference (6.4), so it is one of
+// the left-hand sides 10.6.2 allows, however the array is reached.
+//
+// Each section below states what it asserts:
+//  1. forces through nested structs, arrays of structs, multi-dimensional
+//     arrays and unpacked unions,
+//  2. element widths and array bounds off the word and power-of-two edges,
+//     reached through a struct member,
+//  3. a scalar member of an array of structs, wherever it sits in the struct,
+//  4. the 'assign' and 'deassign' form, and a force, through an interface,
+//  5. reads reaching a leaf by a run-time index, through a continuous-assign
+//     reader of the whole struct, across differing leaf widths, with an
+//     intermediate aggregate as the target, through a union sibling, and a
+//     member of an array of structs indexed at run time under an enclosing
+//     aggregate force.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: on
+
+typedef struct {
+  logic [7:0] arr[4];
+  logic [7:0] scalar;
+} st_t;
+
+interface Bus;
+  st_t s;
+endinterface
+
+module t;
+
+  typedef struct {
+    logic [7:0] arr[4];
+    logic [7:0] tag;
+  } inner_t;
+  typedef struct {
+    inner_t in;
+    inner_t ia[2];
+    logic [7:0] md[2][3];
+    logic [7:0] tail;
+  } outer_t;
+  typedef union {
+    logic [7:0] ua[4];
+    logic [7:0] ub[4];
+  } uni_t;
+  /* verilator lint_off ASCRANGE */
+  typedef struct {
+    logic [64:0] wide[3];
+    logic [1:7] asc[1:3];
+  } wid_t;
+  /* verilator lint_on ASCRANGE */
+  typedef struct {
+    logic [7:0] head;
+    logic [7:0] arr[4];
+  } head_t;
+  typedef struct {
+    logic [7:0] arr[4];
+    logic [7:0] tail;
+  } tail_t;
+  typedef struct {
+    logic [7:0] narrow;
+    logic [64:0] wide;
+  } mix_t;
+  typedef union {
+    int ua;
+    int ub;
+  } uni2_t;
+  typedef struct {
+    logic [7:0] value;
+    logic flag;
+  } es_t;
+
+  st_t s;
+  st_t src;
+  st_t same;
+  st_t cont_whole;
+  outer_t o;
+  uni_t u;
+  wid_t w;
+  head_t sh[3];
+  tail_t st[3];
+  logic [7:0] drv;
+  uni2_t u2;
+  uni2_t u2copy;
+  uni_t usrc;
+  logic [7:0] ufill[4];
+  bit never = 0;
+  logic sel;
+  es_t es[3];
+  es_t es_src[3];
+  mix_t mix;
+  mix_t mix_src;
+  int idx;
+  logic [7:0] cont_whole_arr2;
+  logic [7:0] cont_whole_scalar;
+
+  Bus bus ();
+
+  // Reads the struct whole, so it takes the shadow rather than a per-leaf read
+  assign cont_whole = s;
+  assign cont_whole_arr2 = cont_whole.arr[2];
+  assign cont_whole_scalar = cont_whole.scalar;
+
+  initial begin
+    //=======================================================================
+    // 1. Nested structs, arrays of structs, multi-dimensional arrays, unions
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) o.in.arr[i] = 8'h10 + 8'(i);
+    o.in.tag = 8'h1f;
+    for (int i = 0; i < 2; ++i)
+      for (int k = 0; k < 4; ++k) o.ia[i].arr[k] = 8'h40 + 8'(i * 16 + k);
+    o.ia[0].tag = 8'h50;
+    o.ia[1].tag = 8'h51;
+    for (int i = 0; i < 2; ++i)
+      for (int k = 0; k < 3; ++k) o.md[i][k] = 8'h60 + 8'(i * 16 + k);
+    o.tail = 8'h7f;
+    for (int i = 0; i < 4; ++i) u.ua[i] = 8'h80 + 8'(i);
+    #1;
+
+    force o.in.arr[2] = 8'ha1;
+    force o.ia[1].arr[3] = 8'ha2;
+    force o.md[1][2] = 8'ha3;
+    force u.ua[1] = 8'ha4;
+    #1;
+    `checkh(o.in.arr[2], 8'ha1);
+    `checkh(o.in.arr[1], 8'h11);
+    `checkh(o.in.tag, 8'h1f);
+    `checkh(o.ia[1].arr[3], 8'ha2);
+    `checkh(o.ia[1].arr[2], 8'h52);
+    `checkh(o.ia[0].arr[3], 8'h43);
+    `checkh(o.md[1][2], 8'ha3);
+    `checkh(o.md[1][1], 8'h71);
+    `checkh(o.md[0][2], 8'h62);
+    `checkh(o.tail, 8'h7f);
+    `checkh(u.ua[1], 8'ha4);
+    `checkh(u.ua[0], 8'h80);
+
+    release o.in.arr[2];
+    release o.ia[1].arr[3];
+    release o.md[1][2];
+    release u.ua[1];
+    #1;
+    `checkh(o.in.arr[2], 8'ha1);
+    `checkh(o.ia[1].arr[3], 8'ha2);
+    `checkh(o.md[1][2], 8'ha3);
+    `checkh(u.ua[1], 8'ha4);
+    o.in.arr[2] = 8'hb1;
+    o.md[1][2] = 8'hb3;
+    #1;
+    `checkh(o.in.arr[2], 8'hb1);
+    `checkh(o.md[1][2], 8'hb3);
+
+    //=======================================================================
+    // 2. Element widths and array bounds off the word and power-of-two edges,
+    //    reached through a struct member
+    //=======================================================================
+    for (int i = 0; i < 3; ++i) w.wide[i] = 65'h1_0000_0000_0000_0000 + 65'(i);
+    for (int i = 1; i <= 3; ++i) w.asc[i] = 7'h20 + 7'(i);
+    #1;
+    force w.wide[1] = 65'h1_dead_beef_feed_face;
+    force w.asc[2] = 7'h2a;
+    #1;
+    `checkh(w.wide[1], 65'h1_dead_beef_feed_face);
+    `checkh(w.wide[0], 65'h1_0000_0000_0000_0000);
+    `checkh(w.asc[2], 7'h2a);
+    `checkh(w.asc[1], 7'h21);
+    `checkh(w.asc[3], 7'h23);
+    release w.wide[1];
+    release w.asc[2];
+    #1;
+    `checkh(w.wide[1], 65'h1_dead_beef_feed_face);
+
+    //=======================================================================
+    // 3. A scalar member of an array of structs, wherever it sits in the struct
+    //=======================================================================
+    for (int i = 0; i < 3; ++i) begin
+      sh[i].head = 8'h70 + 8'(i);
+      st[i].tail = 8'h70 + 8'(i);
+      for (int k = 0; k < 4; ++k) begin
+        sh[i].arr[k] = 8'h10 + 8'(i * 16 + k);
+        st[i].arr[k] = 8'h10 + 8'(i * 16 + k);
+      end
+    end
+    #1;
+    force sh[1].head = 8'hbb;
+    force st[1].tail = 8'hbb;
+    #1;
+    `checkh(sh[1].head, 8'hbb);
+    `checkh(st[1].tail, 8'hbb);
+    `checkh(sh[0].head, 8'h70);
+    `checkh(st[0].tail, 8'h70);
+    `checkh(sh[2].head, 8'h72);
+    `checkh(st[2].tail, 8'h72);
+    `checkh(sh[1].arr[2], 8'h22);
+    `checkh(st[1].arr[2], 8'h22);
+    release sh[1].head;
+    release st[1].tail;
+    #1;
+    `checkh(sh[1].head, 8'hbb);
+    `checkh(st[1].tail, 8'hbb);
+
+    //=======================================================================
+    // 4. The 'assign' and 'deassign' form, and a force, through an interface instance
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) bus.s.arr[i] = 8'h10 + 8'(i);
+    drv = 8'haa;
+    #1;
+    /* verilator lint_off IEEEMAYDEPRECATE */
+    assign bus.s.arr[2] = drv;
+    #1;
+    `checkh(bus.s.arr[2], 8'haa);
+    `checkh(bus.s.arr[1], 8'h11);
+    // A procedural continuous assignment tracks its right-hand side
+    drv = 8'hcc;
+    #1;
+    `checkh(bus.s.arr[2], 8'hcc);
+    deassign bus.s.arr[2];
+    #1;
+    bus.s.arr[2] = 8'h55;
+    #1;
+    // The stale right-hand side must no longer drive the element
+    drv = 8'hdd;
+    #1;
+    `checkh(bus.s.arr[2], 8'h55);
+    /* verilator lint_on IEEEMAYDEPRECATE */
+
+    force bus.s.arr[2] = 8'hee;
+    #1;
+    `checkh(bus.s.arr[2], 8'hee);
+    `checkh(bus.s.arr[1], 8'h11);
+    release bus.s.arr[2];
+    #1;
+    `checkh(bus.s.arr[2], 8'hee);
+
+    //=======================================================================
+    // 5. Reads that reach a leaf by a route the sections above do not take:
+    //     a run-time element index through a member path, a continuous-assign
+    //     reader of the whole struct, a struct whose leaves differ in width,
+    //     an intermediate aggregate as the force target, the other member of a
+    //     union whose storage is shared but whose slots are not, and a member of
+    //     an array of structs read by a run-time index while an enclosing whole-
+    //     element or whole-array aggregate force is up.
+    //=======================================================================
+    for (int i = 0; i < 4; ++i) s.arr[i] = 8'h10 + 8'(i);
+    s.scalar = 8'h99;
+    idx = 2;
+    #1;
+    force s.arr[2] = 8'hf1;
+    #1;
+    // Run-time index, so the slot ordinal is computed rather than folded
+    `checkh(s.arr[idx], 8'hf1);
+    idx = 1;
+    `checkh(s.arr[idx], 8'h11);
+    // A continuous-assign reader of the whole struct
+    `checkh(cont_whole_arr2, 8'hf1);
+    `checkh(cont_whole_scalar, 8'h99);
+    release s.arr[2];
+    #1;
+
+    // Leaves of differing width, forced as a whole struct
+    mix_src.narrow = 8'h5a;
+    mix_src.wide = 65'h1_9999_8888_7777_6666;
+    mix.narrow = 8'h01;
+    mix.wide = 65'h0;
+    #1;
+    force mix = mix_src;
+    #1;
+    `checkh(mix.narrow, 8'h5a);
+    `checkh(mix.wide, 65'h1_9999_8888_7777_6666);
+    release mix;
+    #1;
+    `checkh(mix.wide, 65'h1_9999_8888_7777_6666);
+
+    // An intermediate aggregate as the target
+    force o.in = o.ia[0];
+    #1;
+    `checkh(o.in.arr[2], 8'h42);
+    `checkh(o.in.tag, 8'h50);
+    `checkh(o.ia[1].arr[2], 8'h52);
+    release o.in;
+    #1;
+    `checkh(o.in.arr[2], 8'h42);
+
+    // Union members are tracked apart, so a force through one member is not visible
+    // through the other even though the two share storage.  Pinned here as the
+    // behaviour this change leaves in place, not as a guarantee.
+    for (int i = 0; i < 4; ++i) u.ua[i] = 8'h80 + 8'(i);
+    #1;
+    force u.ua[1] = 8'hc7;
+    #1;
+    `checkh(u.ua[1], 8'hc7);
+    `checkh(u.ub[1], 8'h81);
+    release u.ua[1];
+    #1;
+    `checkh(u.ua[1], 8'hc7);
+
+    // Overlaid union members: a copy of the whole union carries the forced value
+    // through, as the two members are the same storage
+    u2.ua = 1;
+    #1;
+    force u2.ua = 2;
+    // A force that never executes leaves the overlaid member untouched
+    if (never) force u2.ub = 3;
+    #1;
+    u2copy = u2;
+    `checkh(u2copy.ua, 2);
+    `checkh(u2copy.ub, 2);
+    release u2.ua;
+    #1;
+
+    // A whole array member of a union, and the whole union, force and release
+    for (int i = 0; i < 4; ++i) begin
+      u.ua[i] = 8'h10 + 8'(i);
+      usrc.ua[i] = 8'h60 + 8'(i);
+      ufill[i] = 8'h90 + 8'(i);
+    end
+    #1;
+    force u.ua = ufill;
+    #1;
+    `checkh(u.ua[1], 8'h91);
+    `checkh(u.ub[1], 8'h11);
+    release u.ua;
+    #1;
+    `checkh(u.ua[1], 8'h91);
+    force u = usrc;
+    #1;
+    `checkh(u.ua[2], 8'h62);
+    `checkh(u.ub[2], 8'h62);
+    release u;
+    #1;
+
+    // A whole-struct force from an expression, which is evaluated per member and so
+    // must be free of side effects
+    sel = 1'b1;
+    src.scalar = 8'hc1;
+    for (int i = 0; i < 4; ++i) src.arr[i] = 8'hd0 + 8'(i);
+    #1;
+    force s = sel ? src : same;
+    #1;
+    `checkh(s.scalar, 8'hc1);
+    `checkh(s.arr[2], 8'hd2);
+    release s;
+    #1;
+
+    // An array of structs is registered as one entry, so this size costs nothing
+    for (int i = 0; i < 3; ++i) begin
+      es_src[i].value = 8'(8'he0 + i);
+      es_src[i].flag = 1'b1;
+    end
+    #1;
+    force es = es_src;
+    #1;
+    `checkh(es[1].value, 8'he1);
+    `checkh(es[2].flag, 1'b1);
+    release es;
+    #1;
+    `checkh(es[1].value, 8'he1);
+
+    // A member of an array of structs read by a run-time element index, while a whole
+    // element, then the whole array, is force to an aggregate value.  The read reaches
+    // the member by a computed slot ordinal, and the run-time ownership guard picks the
+    // element the force owns, so it agrees with the constant-index read; a run-time index
+    // that lands on an unforced element still reads raw.
+    for (int i = 0; i < 3; ++i) begin es[i].value = 8'h30 + 8'(i); es[i].flag = 1'b0; end
+    #1;
+    force es[2] = '{value: 8'hcc, flag: 1'b1};
+    idx = 2;
+    #1;
+    `checkh(es[idx].value, 8'hcc);
+    `checkh(es[2].value, 8'hcc);
+    `checkh(es[idx].flag, 1'b1);
+    idx = 0;
+    `checkh(es[idx].value, 8'h30);
+    release es[2];
+    #1;
+    force es = es_src;
+    idx = 1;
+    #1;
+    `checkh(es[idx].value, 8'he1);
+    `checkh(es[idx].flag, 1'b1);
+    idx = 2;
+    `checkh(es[idx].value, 8'he2);
+    release es;
+    #1;
+
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_force_struct_readwrite_unsup.out
+++ b/test_regress/t/t_force_struct_readwrite_unsup.out
@@ -1,0 +1,6 @@
+%Error-UNSUPPORTED: t/t_force_struct_readwrite_unsup.v:28:18: Unsupported: Signals used via read-write reference cannot be forced
+                                                            : ... note: In instance 't'
+   28 |     cls.take_ref(s);
+      |                  ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_force_struct_readwrite_unsup.py
+++ b/test_regress/t/t_force_struct_readwrite_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_force_struct_readwrite_unsup.v
+++ b/test_regress/t/t_force_struct_readwrite_unsup.v
@@ -1,0 +1,33 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts that a struct whose leaves are tracked separately for force reports
+// the read-write reference error, the same as a scalar does, when it is passed
+// by reference somewhere its value would have to be read and written as a whole.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+
+  typedef struct {
+    logic [7:0] arr[4];
+    logic [7:0] sc;
+  } st_t;
+
+  class Cls;
+    task take_ref(ref st_t r);
+    endtask
+  endclass
+
+  st_t s;
+  Cls cls = new;
+
+  initial begin
+    force s.arr[2] = 8'haa;
+    cls.take_ref(s);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule

--- a/test_regress/t/t_force_unpacked_struct.v
+++ b/test_regress/t/t_force_unpacked_struct.v
@@ -30,6 +30,9 @@ module t (
 
   struct_t s_array[3];
   struct_t my_struct;
+  int o_arr;
+
+  assign o_arr = my_struct.arr[2];
 
   // Test loop
   always @(posedge clk) begin
@@ -37,48 +40,58 @@ module t (
     if (cyc == 0) begin
       s_array[1].x = 1;
       s_array[1].arr[2] = 1;
+      my_struct.arr[2] = 1;
       my_struct.x <= 1;
       my_struct.pt.b <= 1;
     end
     else if (cyc == 1) begin
       `checkh(s_array[1].x, 1);
       `checkh(s_array[1].arr[2], 1);
+      `checkh(my_struct.arr[2], 1);
       `checkh(my_struct.x, 1);
       `checkh(my_struct.pt.b, 1);
     end
     else if (cyc == 2) begin
-      force s_array[1].x = 0;
+      force s_array[1].x = 7;
       force s_array[1].arr[2] = 2;
+      force my_struct.arr[2] = 5;
       force my_struct.x = 0;
       force my_struct.pt.b = 0;
     end
     else if (cyc == 3) begin
-      `checkh(s_array[1].x, 0);
+      `checkh(s_array[1].x, 7);
       s_array[1].x = 1;
       `checkh(s_array[1].arr[2], 2);
       s_array[1].arr[2] = 3;
+      `checkh(my_struct.arr[2], 5);
+      `checkh(o_arr, 5);
+      my_struct.arr[2] = 3;
       `checkh(my_struct.x, 0);
       my_struct.x <= 1;
       `checkh(my_struct.pt.b, 0);
       my_struct.pt.b <= 1;
     end
     else if (cyc == 4) begin
-      `checkh(s_array[1].x, 0);
+      `checkh(s_array[1].x, 7);
       `checkh(s_array[1].arr[2], 2);
+      `checkh(my_struct.arr[2], 5);
       `checkh(my_struct.x, 0);
       `checkh(my_struct.pt.b, 0);
     end
     else if (cyc == 5) begin
+      release my_struct.arr[2];
       release s_array[1].x;
       release s_array[1].arr[2];
       release my_struct.x;
       release my_struct.pt.b;
     end
     else if (cyc == 6) begin
-      `checkh(s_array[1].x, 0);
+      `checkh(s_array[1].x, 7);
       s_array[1].x = 1;
       `checkh(s_array[1].arr[2], 2);
       s_array[1].arr[2] = 4;
+      `checkh(my_struct.arr[2], 5);
+      my_struct.arr[2] = 6;
       `checkh(my_struct.x, 0);
       my_struct.x <= 1;
       `checkh(my_struct.pt.b, 0);
@@ -87,6 +100,8 @@ module t (
     else if (cyc == 7) begin
       `checkh(s_array[1].x, 1);
       `checkh(s_array[1].arr[2], 4);
+      `checkh(my_struct.arr[2], 6);
+      `checkh(o_arr, 6);
       `checkh(my_struct.x, 1);
       `checkh(my_struct.pt.b, 1);
     end

--- a/test_regress/t/t_forceable_struct_member.py
+++ b/test_regress/t/t_forceable_struct_member.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=["--binary", "--timing"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_forceable_struct_member.v
+++ b/test_regress/t/t_forceable_struct_member.v
@@ -1,0 +1,63 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// Asserts that a struct signal marked externally forceable can also be the
+// target of a procedural 'force' on one of its members: the model elaborates
+// and compiles, the forced member and the forced element of an unpacked-array
+// member read back forced, and sibling fields are unaffected.
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 BRDR LIFE
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkh(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got='h%x exp='h%x\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0)
+// verilog_format: on
+
+module t;
+
+  typedef struct {
+    logic [7:0] arr[4];
+    logic [7:0] a;
+    logic [7:0] b;
+  } st_t;
+
+  st_t s  /*verilator forceable*/;
+
+  initial begin
+    for (int i = 0; i < 4; ++i) s.arr[i] = 8'h10 + 8'(i);
+    s.a = 8'h01;
+    s.b = 8'h02;
+    #1;
+    `checkh(s.a, 8'h01);
+
+    force s.a = 8'haa;
+    #1;
+    `checkh(s.a, 8'haa);
+    `checkh(s.b, 8'h02);
+    `checkh(s.arr[2], 8'h12);
+
+    force s.arr[2] = 8'hbb;
+    #1;
+    `checkh(s.arr[2], 8'hbb);
+    `checkh(s.a, 8'haa);
+    `checkh(s.b, 8'h02);
+    `checkh(s.arr[1], 8'h11);
+
+    release s.a;
+    release s.arr[2];
+    #1;
+    `checkh(s.a, 8'haa);
+    `checkh(s.arr[2], 8'hbb);
+
+    s.a = 8'h55;
+    s.arr[2] = 8'h66;
+    #1;
+    `checkh(s.a, 8'h55);
+    `checkh(s.arr[2], 8'h66);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+
+endmodule


### PR DESCRIPTION
Stack 4 of 4. Stacked on #8168.

Releasing a sub-region of a variable held by an enclosing aggregate force now keeps the value it currently shows. A later procedural assignment can update that region. The enclosing force no longer repaints it.

At compile time, V3Force records each force and release target that can create a hole. It builds the merged whole-value shadow in this order:

* copy the raw value;
* apply force arms from the outermost target to the innermost target;
* after each aggregate arm, repair the holes made by smaller forces and releases.

Hole repair depends on the shape of the hole:

* for a one-slot bitwise leaf, the code combines the raw value and the force value for the exact owned bits;
* for a one-slot non-bitwise leaf, it selects the owned value or the raw value;
* for a multi-slot candidate, it restores the raw value when the aggregate owns no slot in the candidate.

`t_force_nested_struct` forces a struct member, releases it, and reads the member. The old test did not read the member between its force and release. In stack step 3, the whole-value shadow repainted the released member with the whole-struct force value. This commit checks the member value before release, and checks that the same value remains after release. This matches what Verilator already does for a packed vector.

This adds overlap and hole sections to `t_force_agg_overlap`: partial release, nested retention, and non-bitwise `real` member recomposition.
