### PR TITLE
Fix null pointer dereference in killQueue

### DIFF
--- a/include/verilated_std.sv
+++ b/include/verilated_std.sv
@@ -196,7 +196,8 @@ package std;
     static task killQueue(ref process processQueue[$]);
 `ifdef VERILATOR_TIMING
       repeat (processQueue.size()) begin
-        processQueue.pop_front().kill();
+        process p = processQueue.pop_front();
+        if (p != null) p.kill();
       end
 `endif
     endtask

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -1113,8 +1113,12 @@ package Vt_debug_emitv_std;
                 int signed __Vrepeat0;
                 __Vrepeat0 = processQueue.size();
                 while ((__Vrepeat0 > 32'h0)) begin
-                    begin
-                        kill();
+                    begin : unnamedblk1
+                        Vt_debug_emitv_process pVt_debug_emitv_process;
+                        p = processQueue.pop_front();
+                        if ((p != null)) begin
+                            kill();
+                        end
                     end
                     __Vrepeat0 = (__Vrepeat0 - 32'h1);
                 end

--- a/test_regress/t/t_disable_automatic.py
+++ b/test_regress/t/t_disable_automatic.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--binary"])
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_disable_automatic.v
+++ b/test_regress/t/t_disable_automatic.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+// verilog_format: on
+
+module t;
+  logic clk;
+  int i;
+  always #(1) clk = ~clk;
+  task automatic taska();
+    fork : wait_fork
+      begin
+        repeat (1) @(negedge clk);
+        i = 1;
+      end
+      begin
+        repeat (2) @(negedge clk);
+        i = 2;
+      end
+    join_any
+    disable wait_fork;
+  endtask
+
+  initial begin
+    clk = '0;
+    fork
+      taska();
+      taska();
+    join
+    `checkd(i, 1);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
This pull request fixes the problem of `null pointer dereference` in `include/verilated_std.sv:196: static task killQueue(ref process[$])`.

An example causing this issue:
~~~systemverilog
module t;
  logic clk;
  always #(1) clk = ~clk;
  task taska();
    fork : wait_fork
      begin
        repeat (1) @(negedge clk);
      end
      begin
        repeat (2) @(negedge clk);
      end
    join_any
    disable wait_fork;
  endtask

  initial begin
    clk = '0;
    fork
      taska();
      taska();
    join
    $finish;
  end
endmodule
~~~
Error message:
~~~bash
include/verilated_std.sv:199: Null pointer dereferenced
Aborting...
~~~
When the `taska()` is called for the second time, it's `disable` sees one element in the queue left, but `disable` from the first call is still working. Then, both `disable`s make `pop_front()`, and one of them gets `null` from an empty queue. Calling method on `null` causes `null pointer dereference`.

Second `disable` gets activated, because when one of its processes gets killed by the first `disable`, its death triggers `join_any`, which takes control over the simulation.

The runtime log with PR's changes:
~~~log
-V{t1,177}+            Vt_disable_automatic_std__03a__03aprocess::__VnoInFunc_kill
-V{t1,178}+            Vt_disable_automatic_std__03a__03aprocess::__VnoInFunc_set_status
-V{t1,179}             Process forked at <unknown>:0 finished
-V{t1,180}             Resuming: Process waiting at t_disable_automatic.v:6
---------join_any triggered, second disable activated---------
-V{t1,181}+  Vt_disable_automatic_std__03a__03aprocess__Vclpkg::__VnoInFunc_killQueue
-V{t1,182}+            Vt_disable_automatic_std__03a__03aprocess::__VnoInFunc_kill
-V{t1,183}+            Vt_disable_automatic_std__03a__03aprocess::__VnoInFunc_set_status
-V{t1,184}             Process forked at <unknown>:0 finished
-V{t1,185}             Process forked at t_disable_automatic.v:24 finished
---------first disable continues its killQueue---------
-V{t1,186}             Process forked at t_disable_automatic.v:23 finished
-V{t1,187}             Resuming: Process waiting at t_disable_automatic.v:22
~~~