### PR TITLE
Fix invalid conversion of VlQueue

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5660,10 +5660,8 @@ class WidthVisitor final : public VNVisitor {
                 patternAssoc(nodep, vdtypep, defaultp);
             } else if (auto* const vdtypep = VN_CAST(dtypep, WildcardArrayDType)) {
                 patternWildcard(nodep, vdtypep, defaultp);
-            } else if (auto* const vdtypep = VN_CAST(dtypep, DynArrayDType)) {
-                patternDynArray(nodep, vdtypep, defaultp);
-            } else if (auto* const vdtypep = VN_CAST(dtypep, QueueDType)) {
-                patternQueue(nodep, vdtypep, defaultp);
+            } else if (VN_IS(dtypep, DynArrayDType) || VN_IS(dtypep, QueueDType)) {
+                patternDynArrayOrQueue(nodep, dtypep);
             } else if (VN_IS(dtypep, BasicDType) && VN_AS(dtypep, BasicDType)->isRanged()) {
                 patternBasic(nodep, dtypep, defaultp);
             } else {
@@ -6039,38 +6037,28 @@ class WidthVisitor final : public VNVisitor {
         nodep->replaceWith(newp);
         // UINFOTREE(9, newp, "", "apat-out");
     }
-    void patternDynArray(AstPattern* nodep, AstDynArrayDType* arrayp, AstPatMember* defaultp) {
-        AstNodeExpr* newp = new AstConsDynArray{nodep->fileline()};
-        newp->dtypeFrom(arrayp);
-        for (AstPatMember* patp = VN_AS(nodep->itemsp(), PatMember); patp;
-             patp = VN_AS(patp->nextp(), PatMember)) {
-            patp->dtypep(arrayp->subDTypep());
-            AstNodeExpr* const rhsp = patternMemberValueIterate(patp);
-            const bool rhsIsValue
-                = AstNode::computeCastable(rhsp->dtypep(), arrayp->subDTypep(), nullptr)
-                      .isAssignable();
-            AstConsDynArray* const newap
-                = new AstConsDynArray{nodep->fileline(), rhsIsValue, rhsp, false, newp};
-            newap->dtypeFrom(arrayp);
-            newp = newap;
+    void patternDynArrayOrQueue(AstPattern* nodep, AstNodeDType* arrayp) {
+        AstNodeExpr* newp = nullptr;
+        const bool isDynArray = VN_IS(arrayp, DynArrayDType);
+        if (isDynArray) {
+            newp = new AstConsDynArray{nodep->fileline()};
+        } else {
+            newp = new AstConsQueue{nodep->fileline()};
         }
-        nodep->replaceWith(newp);
-        // UINFOTREE(9, newp, "", "apat-out");
-    }
-    void patternQueue(AstPattern* nodep, AstQueueDType* arrayp, AstPatMember* defaultp) {
-        AstNodeExpr* newp = new AstConsQueue{nodep->fileline()};
         newp->dtypeFrom(arrayp);
         for (AstPatMember* patp = VN_AS(nodep->itemsp(), PatMember); patp;
              patp = VN_AS(patp->nextp(), PatMember)) {
             patp->dtypep(arrayp->subDTypep());
             AstNodeExpr* const rhsp = patternMemberValueIterate(patp);
-            const bool rhsIsDirect
-                = AstNode::computeCastable(rhsp->dtypep(), arrayp, nullptr).isAssignable();
             const bool rhsIsValue
-                = AstNode::computeCastable(rhsp->dtypep(), arrayp->subDTypep(), nullptr)
+                = AstNode::computeCastable(arrayp->subDTypep(), rhsp->dtypep(), nullptr)
                       .isAssignable();
-            AstConsQueue* const newap = new AstConsQueue{
-                nodep->fileline(), !rhsIsDirect && rhsIsValue, rhsp, false, newp};
+            AstNodeExpr* newap = nullptr;
+            if (isDynArray) {
+                newap = new AstConsDynArray{nodep->fileline(), rhsIsValue, rhsp, false, newp};
+            } else {
+                newap = new AstConsQueue{nodep->fileline(), rhsIsValue, rhsp, false, newp};
+            }
             newap->dtypeFrom(arrayp);
             newp = newap;
         }

--- a/test_regress/t/t_pattern_array_queue.py
+++ b/test_regress/t/t_pattern_array_queue.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_pattern_array_queue.v
+++ b/test_regress/t/t_pattern_array_queue.v
@@ -1,0 +1,48 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d (%s !== %s)\n", `__FILE__,`__LINE__, (gotv), (expv), `"gotv`", `"expv`"); `stop; end while(0);
+// verilog_format: on
+
+module t();
+  byte array1[];
+  byte array2[];
+  byte queue1[$];
+  byte queue2[$];
+  byte byte_e;
+  initial begin
+    queue2 = {8'ha, 8'hb};
+    array2 = {8'hc, 8'hd};
+    byte_e = 8'he;
+
+    array1 = {byte_e};
+    `checkd(array1[0], 8'he);
+
+    array1 = {queue2};
+    `checkd(array1[0], 8'ha);
+    `checkd(array1[1], 8'hb);
+
+    array1 = {array2};
+    `checkd(array1[0], 8'hc);
+    `checkd(array1[1], 8'hd);
+
+    queue1 = {byte_e};
+    `checkd(queue1[0], 8'he);
+
+    queue1 = {queue2};
+    `checkd(queue1[0], 8'ha);
+    `checkd(queue1[1], 8'hb);
+
+    queue1 = {array2};
+    `checkd(queue1[0], 8'hc);
+    `checkd(queue1[1], 8'hd);
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_stream_bitqueue.v
+++ b/test_regress/t/t_stream_bitqueue.v
@@ -62,6 +62,12 @@ module t (  /*AUTOARG*/
       `checkh(bit_qq[2], 1'b1);
       `checkh(bit_qq[3], 1'b0);
 
+      bit_q = {bit_q_t'(4'ha)};
+      `checkh(bit_q[0], 1'b1);
+      `checkh(bit_q[1], 1'b0);
+      `checkh(bit_q[2], 1'b1);
+      `checkh(bit_q[3], 1'b0);
+
       bit_q = bit_q_t'({>>{4'hd}});
       `checkh(bit_q[0], 1'b1);
       `checkh(bit_q[1], 1'b1);
@@ -72,6 +78,18 @@ module t (  /*AUTOARG*/
       `checkh(bit_q[0], 1'b0);
       `checkh(bit_q[1], 1'b0);
       `checkh(bit_q[2], 1'b1);
+      `checkh(bit_q[3], 1'b1);
+
+      bit_q = {bit_q_t'({>>{4'hf}})};
+      `checkh(bit_q[0], 1'b1);
+      `checkh(bit_q[1], 1'b1);
+      `checkh(bit_q[2], 1'b1);
+      `checkh(bit_q[3], 1'b1);
+
+      bit_q = {bit_q_t'({<<{4'hb}})};
+      `checkh(bit_q[0], 1'b1);
+      `checkh(bit_q[1], 1'b1);
+      `checkh(bit_q[2], 1'b0);
       `checkh(bit_q[3], 1'b1);
 
       bit_q = {>>{bit_q_t'(4'he)}};


### PR DESCRIPTION
This pull request fixes the problem of invalid conversion function for `VlQueue` in pattern `array = {queue}`.

An example causing the issue:
~~~systemverilog
module t();
  byte array[];
  byte queue[$];
  initial begin
    queue = {8'ha, 8'hb};
    array = {queue};
    $display(array[1]);
    $finish;
  end
endmodule
~~~
Error message:
~~~bash
error: cannot convert ‘VlQueue<unsigned char>’ to ‘const unsigned char&’
      |     t__DOT__array1 = VlQueue<CData/*7:0*/>::consVC(t__DOT__queue1,
      |                                                    ^~~~~~~~~~~~~~
      |                                                    |
      |                                                    VlQueue<unsigned char>
~~~
`consVC` was generated instead of `consCC`.

In `src/V3Width.cpp:5953: WidthVisitor::patternDynArray`
~~~cpp
const bool rhsIsValue
            = AstNode::computeCastable(rhsp->dtypep(), arrayp->subDTypep(), nullptr)
                  .isAssignable();
~~~
`computeCastable` had parameters in wrong order, `arrayp->subDTypep()` should be `toDtp`, and `rhsp->dtypep()` - `fromDtp`

Similar function `src/V3Width.cpp:5971 WidthVisitor::patternQueue` has the exact same problem for `rhsIsValue`and `rhsIsDirect`.

`rhsIsDirect` was removed, because scenarios, which are going through the `patternQueue` can trigger only this part of `src/V3Ast.cpp:computeCastableImp`:
~~~cpp
} else if (VN_IS(toDtp, QueueDType) && (VN_IS(fromDtp, BasicDType) || VN_IS(fromDtp, StreamDType))) {
        return VCastable::COMPATIBLE;
}
~~~
The case with `BasicDType` is only for casting:
~~~systemverilog
typedef bit bit_q_t[$];
bit_q_t queue;
queue = bit_q_t'(4'he);
~~~
and it works fine with pattern (test added).

The case with `StreamDType` is impossible in `patternQueue`, for
~~~systemverilog
queue = {{>>{8'ha}}};
~~~
verilator gives output
~~~text
Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
~~~
Without `rhsIsDirect` `patternDynArray` and `patternQueue` are identical, so they were merged into `patternDynArrayOrQueue`