### PR TITLE
Fix internal error on an enum literal inside a `with` lambda body (#8190)

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -11,6 +11,7 @@ Please see the Verilator manual for 200+ additional contributors. Thanks to all.
 404allen404
 Adam Bagley
 Adam Kostrzewski
+Aditya Shevade
 Adrian Sampson
 Adrien Le Masle
 أحمد المحمودي (Ahmed El-Mahmoudy)

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -2853,9 +2853,7 @@ class ConstraintExprVisitor final : public VNVisitor {
                 }
                 VL_DO_DANGLING(elemSelp->deleteTree(), elemSelp);
 
-                // This body is a fresh clone, instantiated after V3Const's usual
-                // enum-literal folding pass already ran -- re-fold just the literal,
-                // leaving the still-symbolic `item` comparison alone.
+                // enum-literal folding pass already ran -- re-fold the literals.
                 perElemExprp = V3Const::constifyEdit(perElemExprp);
 
                 perElemExprp->foreach([&](AstNode* nodep) {

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -36,6 +36,7 @@
 #include "V3Randomize.h"
 
 #include "V3Ast.h"
+#include "V3Const.h"
 #include "V3Error.h"
 #include "V3FileLine.h"
 #include "V3Global.h"
@@ -2854,6 +2855,11 @@ class ConstraintExprVisitor final : public VNVisitor {
                     });
                 }
                 VL_DO_DANGLING(elemSelp->deleteTree(), elemSelp);
+
+                // This body is a fresh clone, instantiated after V3Const's usual
+                // enum-literal folding pass already ran -- re-fold just the literal,
+                // leaving the still-symbolic `item` comparison alone.
+                perElemExprp = V3Const::constifyEdit(perElemExprp);
 
                 perElemExprp->foreach([&](AstNode* nodep) {
                     // Don't mark loop variable references as randomizable

--- a/test_regress/t/t_constraint_enum_lambda_arg.py
+++ b/test_regress/t/t_constraint_enum_lambda_arg.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+if not test.have_solver:
+    test.skip("No constraint solver installed")
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_constraint_enum_lambda_arg.v
+++ b/test_regress/t/t_constraint_enum_lambda_arg.v
@@ -4,11 +4,6 @@
 // SPDX-FileCopyrightText: 2026 Aditya Shevade
 // SPDX-License-Identifier: CC0-1.0
 
-// An enum literal in a with (...) lambda body (e.g. `item == WRITE`) used
-// to hit a hard internal error: the per-element body is cloned after
-// V3Const's usual enum-literal folding pass already ran. sum()'s result
-// is unchecked below since sum()-with-comparison folds to a constant
-// regardless of contents, a separate bug.
 typedef enum bit [1:0] {
   READ,
   WRITE,
@@ -41,7 +36,7 @@ class StructFieldEnumLambdaArg;
   }
 endclass
 
-// Same crash, but via a locator method (find()) instead of a reduction
+// Same shape, but via a locator method (find()) instead of a reduction
 // (sum()) -- both take a with (...) lambda body the same way.
 class EnumLambdaArgFind;
   rand cmd_e items[];
@@ -52,9 +47,9 @@ class EnumLambdaArgFind;
     // find() with (...) inside a constraint is separately unsupported
     // (CONSTRAINTIGN, fatal by default) -- suppressed here since this
     // test is only about the enum literal not crashing the compiler.
-    /* verilator lint_off CONSTRAINTIGN */
+    // verilator lint_off CONSTRAINTIGN
     items.find(item) with (item == WRITE).size() >= 0;
-    /* verilator lint_on CONSTRAINTIGN */
+    // verilator lint_on CONSTRAINTIGN
   }
 endclass
 
@@ -63,7 +58,6 @@ module t;
     automatic EnumLambdaArg obj = new();
     automatic StructFieldEnumLambdaArg sobj = new();
     automatic EnumLambdaArgFind fobj = new();
-    // Guards that randomize() completes at all -- see the note above.
     repeat (5) void'(obj.randomize());
     repeat (5) void'(sobj.randomize());
     repeat (5) void'(fobj.randomize());

--- a/test_regress/t/t_constraint_enum_lambda_arg.v
+++ b/test_regress/t/t_constraint_enum_lambda_arg.v
@@ -1,0 +1,74 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Aditya Shevade
+// SPDX-License-Identifier: CC0-1.0
+
+// An enum literal in a with (...) lambda body (e.g. `item == WRITE`) used
+// to hit a hard internal error: the per-element body is cloned after
+// V3Const's usual enum-literal folding pass already ran. sum()'s result
+// is unchecked below since sum()-with-comparison folds to a constant
+// regardless of contents, a separate bug.
+typedef enum bit [1:0] {
+  READ,
+  WRITE,
+  FLUSH,
+  INVALID
+} cmd_e;
+
+class EnumLambdaArg;
+  rand cmd_e items[];
+  constraint c_size {
+    items.size() == 8;
+  }
+  constraint c_count {
+    items.sum() with (item == WRITE ? 1 : 0) == 3;
+  }
+endclass
+
+// Same shape, but the enum lives in a struct field reached via the lambda
+// argument (item.kind), not the array element itself.
+typedef struct {
+  cmd_e kind;
+} entry_t;
+class StructFieldEnumLambdaArg;
+  rand entry_t items[];
+  constraint c_size {
+    items.size() == 8;
+  }
+  constraint c_count {
+    items.sum() with (item.kind == WRITE ? 1 : 0) == 3;
+  }
+endclass
+
+// Same crash, but via a locator method (find()) instead of a reduction
+// (sum()) -- both take a with (...) lambda body the same way.
+class EnumLambdaArgFind;
+  rand cmd_e items[];
+  constraint c_size {
+    items.size() == 8;
+  }
+  constraint c_find {
+    // find() with (...) inside a constraint is separately unsupported
+    // (CONSTRAINTIGN, fatal by default) -- suppressed here since this
+    // test is only about the enum literal not crashing the compiler.
+    /* verilator lint_off CONSTRAINTIGN */
+    items.find(item) with (item == WRITE).size() >= 0;
+    /* verilator lint_on CONSTRAINTIGN */
+  }
+endclass
+
+module t;
+  initial begin
+    automatic EnumLambdaArg obj = new();
+    automatic StructFieldEnumLambdaArg sobj = new();
+    automatic EnumLambdaArgFind fobj = new();
+    // Guards that randomize() completes at all -- see the note above.
+    repeat (5) void'(obj.randomize());
+    repeat (5) void'(sobj.randomize());
+    repeat (5) void'(fobj.randomize());
+
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_constraint_enum_lambda_arg.v
+++ b/test_regress/t/t_constraint_enum_lambda_arg.v
@@ -4,6 +4,11 @@
 // SPDX-FileCopyrightText: 2026 Aditya Shevade
 // SPDX-License-Identifier: CC0-1.0
 
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
 typedef enum bit [1:0] {
   READ,
   WRITE,
@@ -12,10 +17,7 @@ typedef enum bit [1:0] {
 } cmd_e;
 
 class EnumLambdaArg;
-  rand cmd_e items[];
-  constraint c_size {
-    items.size() == 8;
-  }
+  rand cmd_e items[8];
   constraint c_count {
     items.sum() with (item == WRITE ? 1 : 0) == 3;
   }
@@ -27,22 +29,18 @@ typedef struct {
   cmd_e kind;
 } entry_t;
 class StructFieldEnumLambdaArg;
-  rand entry_t items[];
-  constraint c_size {
-    items.size() == 8;
-  }
-  constraint c_count {
-    items.sum() with (item.kind == WRITE ? 1 : 0) == 3;
+  rand entry_t items[8];
+  constraint c_find {
+    // verilator lint_off CONSTRAINTIGN
+    items.find(item) with (item.kind == WRITE).size() >= 0;
+    // verilator lint_on CONSTRAINTIGN
   }
 endclass
 
 // Same shape, but via a locator method (find()) instead of a reduction
 // (sum()) -- both take a with (...) lambda body the same way.
 class EnumLambdaArgFind;
-  rand cmd_e items[];
-  constraint c_size {
-    items.size() == 8;
-  }
+  rand cmd_e items[8];
   constraint c_find {
     // find() with (...) inside a constraint is separately unsupported
     // (CONSTRAINTIGN, fatal by default) -- suppressed here since this
@@ -58,9 +56,15 @@ module t;
     automatic EnumLambdaArg obj = new();
     automatic StructFieldEnumLambdaArg sobj = new();
     automatic EnumLambdaArgFind fobj = new();
-    repeat (5) void'(obj.randomize());
-    repeat (5) void'(sobj.randomize());
-    repeat (5) void'(fobj.randomize());
+    int ok;
+    repeat (5) begin
+      ok = obj.randomize();
+      `checkd(ok, 1);
+      ok = sobj.randomize();
+      `checkd(ok, 1);
+      ok = fobj.randomize();
+      `checkd(ok, 1);
+    end
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
Fix #8190.

`items.sum() with (item == WRITE ? 1 : 0) == 3` (same with `find()`) crashed with "Visit function missing? Constraint function missing for math node: ENUMITEMREF". The `with (...)` body gets cloned and instantiated inside `V3Randomize.cpp` itself, after `V3Const`'s normal enum-literal folding already ran, so any enum literal in there never gets resolved and the constraint visitor has no idea what to do with it.

Fix is to re-fold just that cloned per-element body with `V3Const::constifyEdit()` right after it's built. First pass at this added a general visitor override instead, which fixed the crash but broke 5 other tests — turns out an enum-typed rand var's own auto-generated legal-value constraint goes through the same visitor and needs different handling. Scoping the fold to just the per-element body avoids that.

New test covers a plain enum-typed array element, an enum reached through a struct field, and both `sum()` and `find()`. It only checks that `randomize()` doesn't crash, not that the sum is actually correct — there's a separate, unrelated bug where `sum() with (...)` always folds to a constant regardless of contents (reproduces with plain ints too, nothing to do with enums). Filing that one separately.

192/192 on `t_constraint*`/`t_randomize*`/`t_dist_warn_coverage`/`t_dist_docs_options`.
