### PR TITLE
Ci fold notifications

### DIFF
--- a/.github/actions/upload-pr-notification/action.yml
+++ b/.github/actions/upload-pr-notification/action.yml
@@ -1,0 +1,74 @@
+---
+# DESCRIPTION: Github actions composite action
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+name: Upload PR notification
+description: >-
+  Upload the 'pr-notification' artifact, holding a comment for 'pages.yml' to
+  post on a pull request. The given directory must hold the content of the
+  comment in 'body.txt', and its single line summary in 'hist.txt'.
+
+inputs:
+  path:
+    description: "Directory holding the notification contents"
+    required: true
+  key:
+    description: "Unique key for combining comments"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate
+      shell: bash
+      env:
+        NOTIFICATION_DIR: ${{ inputs.path }}
+        EVENT_NAME: ${{ github.event_name }}
+      run: |
+        # The notification is posted on the pull request of the triggering event
+        if [ "${EVENT_NAME}" != "pull_request" ]; then
+          echo "This action can only be used on a 'pull_request' run, but event is '${EVENT_NAME}'" >&2
+          exit 1
+        fi
+        # The content of the comment, and its single line summary
+        for f in body.txt hist.txt; do
+          if [ ! -f "${NOTIFICATION_DIR}/${f}" ]; then
+            echo "No '${f}' in '${NOTIFICATION_DIR}'" >&2
+            exit 1
+          fi
+        done
+        # Nothing else, so the artifact holds only what this action puts in it
+        EXTRA=$(find "${NOTIFICATION_DIR}" -mindepth 1 -not -name body.txt -not -name hist.txt)
+        if [ -n "${EXTRA}" ]; then
+          echo "Unexpected content in '${NOTIFICATION_DIR}':" >&2
+          echo "${EXTRA}" >&2
+          exit 1
+        fi
+        # 'ci-pages-notify.bash' stashes 'hist.txt' in an HTML comment, and later
+        # shows it in the history of the notifications superseding this one, so
+        # it must be a single line, and must neither open nor close an HTML comment
+        if [ $(wc -l < "${NOTIFICATION_DIR}/hist.txt") -ne 1 ]; then
+          echo "'hist.txt' must hold exactly one line" >&2
+          exit 1
+        fi
+        if grep -q -e '<!--' -e '-->' "${NOTIFICATION_DIR}/hist.txt"; then
+          echo "'hist.txt' must not contain '<!--' or '-->'" >&2
+          exit 1
+        fi
+
+    - name: Add metadata
+      shell: bash
+      env:
+        NOTIFICATION_DIR: ${{ inputs.path }}
+        NOTIFICATION_KEY: ${{ inputs.key }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        echo "${NOTIFICATION_KEY}" > "${NOTIFICATION_DIR}/key.txt"
+        echo "${PR_NUMBER}" > "${NOTIFICATION_DIR}/pr-number.txt"
+        ls -lsha "${NOTIFICATION_DIR}"
+
+    - name: Upload notification
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      with:
+        path: ${{ inputs.path }}
+        name: pr-notification

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -143,12 +143,6 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo ${{ github.event.number }} > ../report-artifact/pr-number.txt
           fi
-          # Create the notification artifact, for pull requests only
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            mkdir ../notification-artifact
-            mv obj_coverage/notification.txt ../notification-artifact/body.txt
-            echo ${{ github.event.number }} > ../notification-artifact/pr-number.txt
-          fi
 
       - name: Upload report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -156,12 +150,12 @@ jobs:
           path: report-artifact
           name: coverage-report
 
-      - name: Upload notification
+      - name: Upload PR notification
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        uses: ./repo/.github/actions/upload-pr-notification
         with:
-          path: notification-artifact
-          name: pr-notification
+          path: repo/notification
+          key: coverage
 
   # Create GitHub issue for failed scheduled jobs
   # This should always be the last job (we want an issue if anything breaks)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -132,52 +132,35 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ls -lsha obj_coverage
-          # Combine reports from test jobs
-          nodist/fastcov.py -C obj_coverage/verilator-*.info --lcov -o obj_coverage/verilator.info
-          # For a PR, report patch coverage against the merge-base between the head of the PR and the target branch
+          ci/ci-coverage-report.bash \
+            ${{ github.run_id }} \
+            "${{ github.event_name == 'pull_request' && github.event.number || '' }}" \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}"
+          # Create the report artifact. Note there is no report if the patch is empty.
+          mkdir ../report-artifact
+          [ ! -d obj_coverage/report ] || mv obj_coverage/report ../report-artifact/
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            COVERAGE_BASE=$(git rev-parse --short $(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}))
-            make coverage-report COVERAGE_BASE=${COVERAGE_BASE} |& tee ${{ github.workspace }}/make-coverage-report.log
-          else
-            make coverage-report
+            echo ${{ github.event.number }} > ../report-artifact/pr-number.txt
           fi
-          # Remove data files
-          rm -f obj_coverage/verilator*.info
-          # Some extra work for PRs only
+          # Create the notification artifact, for pull requests only
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Save PR number in report
-            echo ${{ github.event.number }} > obj_coverage/pr-number.txt
-            # Generate notification comment content
-            mkdir -p notification
-            echo ${{ github.event.number }} > notification/pr-number.txt
-            NUM=$(gh run view ${{ github.run_id }} --json number --jq ".number")
-            URL=$(gh run view ${{ github.run_id }} --json url    --jq ".url")
-            echo "Patch coverage from PR workflow [#$NUM]($URL) (code coverage of lines changed relative to ${COVERAGE_BASE}):" > notification/body.txt
-            if [[ ! -f obj_coverage/empty-patch ]]; then
-              echo "<pre>" >> notification/body.txt
-              grep -E "(lines|branches)\.*:" ${{ github.workspace }}/make-coverage-report.log | sed "s/\.*:/:/" >> notification/body.txt || true
-              echo "</pre>" >> notification/body.txt
-              echo "Report: [${{ github.run_id }}](https://${{ github.repository_owner }}.github.io/verilator/coverage-reports/${{ github.run_id }}/index.html)" >> notification/body.txt
-              echo "" >> notification/body.txt
-              echo "Please get to 100% line coverage, and understand all branches; see https://github.com/verilator/verilator/blob/master/docs/internals.rst#code-coverage-results" >> notification/body.txt
-            else
-              echo "Patch contains no code changes" >> notification/body.txt
-            fi
-            cat notification/body.txt
+            mkdir ../notification-artifact
+            mv obj_coverage/notification.txt ../notification-artifact/body.txt
+            echo ${{ github.event.number }} > ../notification-artifact/pr-number.txt
           fi
 
       - name: Upload report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          path: repo/obj_coverage
+          path: report-artifact
           name: coverage-report
 
       - name: Upload notification
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
-          path: repo/notification
+          path: notification-artifact
           name: pr-notification
 
   # Create GitHub issue for failed scheduled jobs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -97,5 +97,7 @@ jobs:
       - name: Comment on PR
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          # Slug of the app the above token belongs to, see 'ci-pages-notify.bash'
+          GH_AUTHOR: ${{ steps.generate-token.outputs.app-slug }}
           PR_RUN_IDS: ${{ needs.build.outputs.pr-run-ids }}
         run: ./ci/ci-pages-notify.bash

--- a/.github/workflows/rtlmeter.yml
+++ b/.github/workflows/rtlmeter.yml
@@ -369,10 +369,6 @@ jobs:
           mkdir ../report-artifact
           mv rtlmeter-report/report ../report-artifact/
           echo ${{ github.event.number }} > ../report-artifact/pr-number.txt
-          # Create the notification artifact
-          mkdir ../notification-artifact
-          mv rtlmeter-report/notification.txt ../notification-artifact/body.txt
-          echo ${{ github.event.number }} > ../notification-artifact/pr-number.txt
 
       - name: Upload report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -380,11 +376,11 @@ jobs:
           path: report-artifact
           name: rtlmeter-report
 
-      - name: Upload notification
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+      - name: Upload PR notification
+        uses: ./verilator/.github/actions/upload-pr-notification
         with:
-          path: notification-artifact
-          name: pr-notification
+          path: verilator/rtlmeter-report/notification
+          key: rtlmeter
 
       - name: Report status
         run: exit ${{ steps.report.outputs.status }}

--- a/Makefile.in
+++ b/Makefile.in
@@ -467,9 +467,11 @@ analyzer-include:
 
 # Bash/sh files
 BASH_FILES = \
+  ci/ci-coverage-report.bash \
   ci/ci-install.bash \
   ci/ci-pages-notify.bash \
   ci/ci-pages.bash \
+  ci/ci-rtlmeter-report.bash \
   ci/ci-script.bash \
   ci/docker/run/hooks/post_push \
   ci/docker/run/verilator-docker \

--- a/ci/ci-coverage-report.bash
+++ b/ci/ci-coverage-report.bash
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# DESCRIPTION: Verilator: CI script for 'coverage.yml' results
+#
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+# This script combines the code coverage data gathered by the test jobs into
+# the HTML report published on GitHub Pages, and for a pull request, builds the
+# content of the response comment posted on it.
+
+# Developer note: You should be able to run this script in your local checkout
+# if you have GitHub CLI (command 'gh') setup, authenticated ('gh auth login'),
+# and have set a default repository ('gh repo set-default').
+
+set -eo pipefail
+
+# Trace when running in the CI
+[ "$GITHUB_ACTIONS" != "true" ] || set -x
+
+# Arguments:
+#  1. run ID
+#  2. number of the pull request, or empty for a non-pull-request run
+#  3. base SHA of the pull request (pull requests only)
+#  4. head SHA of the pull request (pull requests only)
+RUN_ID=$1
+PR_NUMBER=$2
+PR_BASE_SHA=$3
+PR_HEAD_SHA=$4
+
+# Coverage data and report directory, uploaded as the 'coverage-report' artifact
+COVERAGE_DIR=obj_coverage
+ls -lsha ${COVERAGE_DIR}
+
+# Combine the reports from the test jobs
+nodist/fastcov.py -C ${COVERAGE_DIR}/verilator-*.info --lcov -o ${COVERAGE_DIR}/verilator.info
+
+# Create the report. For a pull request, report patch coverage against the
+# merge-base between the head of the pull request and the target branch. The
+# summary quoted in the notification below is only in the log of 'make'.
+MAKE_LOG=make-coverage-report.log
+if [ -n "${PR_NUMBER}" ]; then
+  COVERAGE_BASE=$(git rev-parse --short $(git merge-base ${PR_BASE_SHA} ${PR_HEAD_SHA}))
+  make coverage-report COVERAGE_BASE=${COVERAGE_BASE} |& tee ${MAKE_LOG}
+else
+  make coverage-report
+fi
+
+# Remove the data files, only the HTML report is published
+rm -f ${COVERAGE_DIR}/verilator*.info
+
+# The rest is for pull requests only
+if [ -z "${PR_NUMBER}" ]; then
+  exit 0
+fi
+
+# Get some metadata about the run
+RUN_NUM=$(gh run view ${RUN_ID} --json number --jq ".number")
+RUN_URL=$(gh run view ${RUN_ID} --json url    --jq ".url")
+
+# Repository owner and name of the default repository, used to build the
+# GitHub Pages URL of the report. The owner is lowercased, as required for the
+# '<owner>.github.io' Pages domain.
+PAGES_OWNER=$(gh repo view --json owner --jq '.owner.login' | tr '[:upper:]' '[:lower:]')
+PAGES_NAME=$(gh repo view --json name --jq '.name')
+
+# Create notification comment content
+NOTIFICATION=${COVERAGE_DIR}/notification.txt
+cat > ${NOTIFICATION} <<NOTIFICATION_TEMPLATE
+Patch coverage from PR workflow [#${RUN_NUM}](${RUN_URL}) (code coverage of lines changed relative to ${COVERAGE_BASE}):
+NOTIFICATION_TEMPLATE
+
+if [ -f ${COVERAGE_DIR}/empty-patch ]; then
+  echo "Patch contains no code changes" >> ${NOTIFICATION}
+else
+  cat >> ${NOTIFICATION} <<SUMMARY_TEMPLATE
+<pre>
+$(grep -E "(lines|branches)\.*:" ${MAKE_LOG} | sed "s/\.*:/:/" || true)
+</pre>
+Report: [${RUN_ID}](https://${PAGES_OWNER}.github.io/${PAGES_NAME}/coverage-reports/${RUN_ID}/index.html)
+
+Please get to 100% line coverage, and understand all branches; see https://github.com/verilator/verilator/blob/master/docs/internals.rst#code-coverage-results
+SUMMARY_TEMPLATE
+fi
+
+# Print it
+cat ${NOTIFICATION}

--- a/ci/ci-coverage-report.bash
+++ b/ci/ci-coverage-report.bash
@@ -63,24 +63,38 @@ RUN_URL=$(gh run view ${RUN_ID} --json url    --jq ".url")
 PAGES_OWNER=$(gh repo view --json owner --jq '.owner.login' | tr '[:upper:]' '[:lower:]')
 PAGES_NAME=$(gh repo view --json name --jq '.name')
 
-# Create notification comment content
-NOTIFICATION=${COVERAGE_DIR}/notification.txt
-cat > ${NOTIFICATION} <<NOTIFICATION_TEMPLATE
+REPORT_URL=https://${PAGES_OWNER}.github.io/${PAGES_NAME}/coverage-reports/${RUN_ID}/index.html
+
+###############################################################################
+# Create the PR notification
+###############################################################################
+
+NOTIFICATION_DIR=notification
+mkdir -p ${NOTIFICATION_DIR}
+
+cat > ${NOTIFICATION_DIR}/body.txt <<NOTIFICATION_TEMPLATE
 Patch coverage from PR workflow [#${RUN_NUM}](${RUN_URL}) (code coverage of lines changed relative to ${COVERAGE_BASE}):
 NOTIFICATION_TEMPLATE
 
 if [ -f ${COVERAGE_DIR}/empty-patch ]; then
-  echo "Patch contains no code changes" >> ${NOTIFICATION}
+  # Patch is empty
+  cat >> ${NOTIFICATION_DIR}/body.txt <<SUMMARY_TEMPLATE
+Patch contains no code changes
+SUMMARY_TEMPLATE
+
+  echo "Workflow [#${RUN_NUM}](${RUN_URL}): patch contains no code changes" > ${NOTIFICATION_DIR}/hist.txt
+
 else
-  cat >> ${NOTIFICATION} <<SUMMARY_TEMPLATE
+  # Patch contains code changes
+
+  cat >> ${NOTIFICATION_DIR}/body.txt <<SUMMARY_TEMPLATE
 <pre>
 $(grep -E "(lines|branches)\.*:" ${MAKE_LOG} | sed "s/\.*:/:/" || true)
 </pre>
-Report: [${RUN_ID}](https://${PAGES_OWNER}.github.io/${PAGES_NAME}/coverage-reports/${RUN_ID}/index.html)
+Report: [${RUN_ID}](${REPORT_URL})
 
-Please get to 100% line coverage, and understand all branches; see https://github.com/verilator/verilator/blob/master/docs/internals.rst#code-coverage-results
+Please get to 100% line coverage, and understand all branches; see the [developer docs](https://github.com/verilator/verilator/blob/master/docs/internals.rst#code-coverage-results)
 SUMMARY_TEMPLATE
-fi
 
-# Print it
-cat ${NOTIFICATION}
+  echo "Workflow [#${RUN_NUM}](${RUN_URL}) report: [${RUN_ID}](${REPORT_URL})" > ${NOTIFICATION_DIR}/hist.txt
+fi

--- a/ci/ci-pages-notify.bash
+++ b/ci/ci-pages-notify.bash
@@ -6,8 +6,27 @@
 
 # Notify PRs via comment that their workflow reports are available
 
-# Get the current repo URL - might differ on a fork
-readonly REPO_URL=$(gh repo view --json url --jq .url)
+# Note this deliberately does not 'set -e'. A run that cannot be notified, say
+# because its pull request was locked, must not hold up the notification of all
+# the others, so each failure below moves on to the next run instead. Its
+# artifact is then left in place, so it is retried on the next run of 'pages.yml'.
+
+# The account we post as, which is how we tell our own earlier notifications
+# from anybody else's comments. 'pages.yml' sets this to the slug of the app the
+# token belongs to. Set it to your own login when running this by hand. The 'jq'
+# filter below picks it up from the environment.
+if [ -z "${GH_AUTHOR:-}" ]; then
+  echo "GH_AUTHOR must hold the account we post as" >&2
+  exit 1
+fi
+echo "Posting as '${GH_AUTHOR}'"
+
+# Marker line separating the report from the history of the older reports
+readonly HISTORY_MARKER='<!-- Verilator CI notification history -->'
+# Opening line of the HTML comment stashing the history entry of the report
+# itself. It is not shown in its own history, only inherited by the ones
+# superseding it, hence it is kept out of sight until then.
+readonly NEXTHIST_MARKER='<!-- Verilator CI notification entry'
 
 # Create artifacts root directory
 ARTIFACTS_ROOT=artifacts
@@ -31,8 +50,114 @@ for RUN_ID in ${PR_RUN_IDS//,/ }; do
   fi
   echo "Posting notification found"
 
-  cat ${ARTIFACTS_DIR}/body.txt
-  gh pr comment $(cat ${ARTIFACTS_DIR}/pr-number.txt) --body-file ${ARTIFACTS_DIR}/body.txt
+  PR_NUMBER=$(cat ${ARTIFACTS_DIR}/pr-number.txt)
+
+  # Everything below is created and validated by the 'upload-pr-notification'
+  # action. Move on if this artifact was not made by it, e.g. it is left over
+  # from an earlier version of the CI, so it does not hold up the other runs.
+  for f in body.txt key.txt hist.txt; do
+    if [ ! -f ${ARTIFACTS_DIR}/${f} ]; then
+      echo "Notification has no '${f}'" >&2
+      continue 2  # Note: continues the enclosing 'RUN_ID' loop
+    fi
+  done
+
+  # 'key.txt' holds the key naming the source of the notification. It goes on the
+  # first line of the comment as an HTML comment, so it is invisible when
+  # rendered, and is used below to find the stale notifications with the same
+  # key, which are then superseded by the new one and deleted.
+  COMMENT_MARKER="<!-- Verilator CI notification: $(cat ${ARTIFACTS_DIR}/key.txt) -->"
+
+  # Find the stale notifications from the same source on this PR. That is, our
+  # own comments with the same marker on their first line. Oldest first, as
+  # returned by the API. An app posts as '<slug>[bot]', so drop that suffix to
+  # compare against the slug. Move on if they cannot be listed, as without them
+  # we would post a duplicate instead of superseding them.
+  if ! COMMENT_MARKER="${COMMENT_MARKER}" \
+      gh api --paginate "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" \
+        --jq '.[]
+              | select((.user.login | rtrimstr("[bot]")) == env.GH_AUTHOR)
+              | select((.body | split("\n") | .[0] | rtrimstr("\r")) == env.COMMENT_MARKER)
+              | {id, body}' > ${ARTIFACTS_DIR}/stale.json; then
+    echo "Failed to list the comments of PR #${PR_NUMBER}" >&2
+    continue
+  fi
+
+  # Inherit the history of the newest stale notification. There should only ever
+  # be one, and it holds the whole history anyway, as each notification inherits
+  # the history of the one it superseded. Any older ones are only deleted below.
+  STALE_COUNT=$(wc -l < ${ARTIFACTS_DIR}/stale.json)
+  if [ ${STALE_COUNT} -gt 1 ]; then
+    echo "Found ${STALE_COUNT} stale notifications, only the newest is inherited from"
+  fi
+
+  HISTORY=${ARTIFACTS_DIR}/history.txt
+  touch ${HISTORY}
+  if [ ${STALE_COUNT} -gt 0 ]; then
+    tail -n 1 ${ARTIFACTS_DIR}/stale.json | jq -r '.body' | tr -d '\r' > ${ARTIFACTS_DIR}/stale-body.txt
+    # Its own entry, stashed in an HTML comment
+    awk -v marker="${NEXTHIST_MARKER}" '
+      $0 == marker { inside = 1; next }
+      !inside { next }
+      $0 == "-->" { exit }
+      NF { print }
+    ' ${ARTIFACTS_DIR}/stale-body.txt >> ${HISTORY}
+    # Followed by its history, without the enclosing '<details>' markup
+    awk -v marker="${HISTORY_MARKER}" '
+      $0 == marker { inside = 1; next }
+      !inside { next }
+      $0 == "<details>" || /^<summary>/ { next }
+      $0 == "</details>" { exit }
+      NF { print }
+    ' ${ARTIFACTS_DIR}/stale-body.txt >> ${HISTORY}
+  fi
+
+  # Assemble the comment. Starts with the marker and the report.
+  COMMENT=${ARTIFACTS_DIR}/comment.txt
+  cat > ${COMMENT} <<COMMENT_TEMPLATE
+${COMMENT_MARKER}
+$(cat ${ARTIFACTS_DIR}/body.txt)
+COMMENT_TEMPLATE
+
+  # Then the history inherited from the notifications this one supersedes, so
+  # the older reports remain reachable from the only remaining comment.
+  if [ -s ${HISTORY} ]; then
+    echo "History holds $(wc -l < ${HISTORY}) entries"
+    cat >> ${COMMENT} <<HISTORY_TEMPLATE
+${HISTORY_MARKER}
+<details>
+<summary>PR history</summary>
+
+$(cat ${HISTORY})
+</details>
+HISTORY_TEMPLATE
+  fi
+
+  # Finally this report's own history entry, stashed out of sight until a later
+  # notification inherits it.
+  cat >> ${COMMENT} <<NEXTHIST_TEMPLATE
+${NEXTHIST_MARKER}
+$(cat ${ARTIFACTS_DIR}/hist.txt)
+-->
+NEXTHIST_TEMPLATE
+
+  cat ${COMMENT}
+
+  # Post it. Move on if this failed, without deleting anything below, otherwise
+  # the history held by the stale notifications would be lost.
+  if ! jq -Rs '{body: .}' ${COMMENT} \
+      | gh api --method POST "repos/{owner}/{repo}/issues/${PR_NUMBER}/comments" \
+          --input - > ${ARTIFACTS_DIR}/posted.json; then
+    echo "Failed to post the notification on PR #${PR_NUMBER}" >&2
+    continue
+  fi
+  echo "Posted $(jq -r '.html_url' ${ARTIFACTS_DIR}/posted.json)"
+
+  # Delete the stale notifications, so only the new one remains
+  for COMMENT_ID in $(jq -r '.id' ${ARTIFACTS_DIR}/stale.json); do
+    echo "Deleting stale comment ${COMMENT_ID}"
+    gh api --method DELETE "repos/{owner}/{repo}/issues/comments/${COMMENT_ID}"
+  done
 
   # Get the artifact IDs. Note there can be more than one artifact named
   # 'pr-notification' for a single run, as the artifacts endpoint lists

--- a/ci/ci-rtlmeter-report.bash
+++ b/ci/ci-rtlmeter-report.bash
@@ -88,9 +88,16 @@ venv/bin/python3 $SCRIPT_DIR/ci-rtlmeter-report.py ${SUMMARY_ARGS[@]} > $TMP_DIR
 # Print it
 cat $TMP_DIR/summary.txt
 
-# Create notification comment content
-NOTIFICATION=$TMP_DIR/notification.txt
-cat > $NOTIFICATION <<NOTIFICATION_TEMPLATE
+REPORT_URL=https://${PAGES_OWNER}.github.io/${PAGES_NAME}/rtlmeter-reports/${RUN_ID}/index.html
+
+###############################################################################
+# Create the PR notification
+###############################################################################
+
+NOTIFICATION_DIR=$TMP_DIR/notification
+mkdir -p $NOTIFICATION_DIR
+
+cat > ${NOTIFICATION_DIR}/body.txt <<NOTIFICATION_TEMPLATE
 Performance metrics for PR workflow [#$RUN_NUM]($RUN_URL), comparing:
 - target branch commit [${REF_SHA:0:9}](https://github.com/${PAGES_OWNER}/${PAGES_NAME}/commit/${REF_SHA}) (A)
 - with PR merge commit [${RUN_SHA:0:9}](https://github.com/${PAGES_OWNER}/${PAGES_NAME}/commit/${RUN_SHA}) (B)
@@ -106,10 +113,15 @@ The reported numbers are the geometric means of the ratios of the metrics over a
 less than 1 is a regression, greater than 1 is an improvement.
 The jobs run on variable and noisy runners, so some variance is expected between runs.
 
-Detailed report: [${RUN_ID}](https://${PAGES_OWNER}.github.io/${PAGES_NAME}/rtlmeter-reports/${RUN_ID}/index.html)
+Detailed report: [${RUN_ID}](${REPORT_URL})
 NOTIFICATION_TEMPLATE
 
+echo "Workflow [#$RUN_NUM]($RUN_URL) report: [${RUN_ID}](${REPORT_URL})" > ${NOTIFICATION_DIR}/hist.txt
+
+###############################################################################
 # Create detailed report
+###############################################################################
+
 REPORT=$TMP_DIR/body.html
 cat > $REPORT <<SUMMARY_TEMPLATE
 <h3>Summary of all runs</h3>


### PR DESCRIPTION
Notifications posted on pull requests now carry a marker naming their
source, as an HTML comment on their first line, which is invisible when
rendered. When posting, 'ci-pages-notify.bash' finds its own earlier
notifications with the same marker on that pull request, and deletes them.
A pull request therefore holds a single comment per source, rather than
accumulating one per run.

The superseded comments are not lost entirely. Each notification carries a
one line summary linking its report, stashed in an HTML comment, and the
notification superseding it inherits that summary, together with the
history the superseded one held itself, into a collapsed 'PR history'
section. That section therefore lists all the earlier reports, stays flat
however many runs a pull request sees, and holds no entry for the report
shown right above it.

The 'pr-notification' artifact is now uploaded via the new reusable
'upload-pr-notification' action, which validates the content the reporting
scripts produced, and records the source key and the pull request number
alongside it.

Fixes https://github.com/verilator/verilator/issues/8037