### PR TITLE
Handle string continuation according to spec

### DIFF
--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -173,6 +173,7 @@ class V3ParseImp final {
     std::deque<string*> m_stringps;  // Created strings for later cleanup
     std::deque<V3Number*> m_numberps;  // Created numbers for later cleanup
     std::deque<FileLine> m_lexLintState;  // Current lint state for save/restore
+    std::string m_lexString;  // Text of the quoted or triple-quoted string currently being lexed
     std::deque<string> m_ppBuffers;  // Preprocessor->lex buffer of characters to process
     size_t m_ppBytes = 0;  // Preprocessor->lex bytes transferred
 
@@ -200,6 +201,7 @@ public:
 
     void lexFileline(FileLine* fl) { m_lexFileline = fl; }
     FileLine* lexFileline() const { return m_lexFileline; }
+    std::string& lexString() { return m_lexString; }
     static void lexErrorPreprocDirective(FileLine* fl, const char* textp) VL_MT_DISABLED;
     static string lexParseTag(const char* textp) VL_MT_DISABLED;
     static double lexParseTimenum(const char* text) VL_MT_DISABLED;

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -1007,8 +1007,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   \"[^\"\\]*\"          { FL; yylval.strp = PARSEP->newString(yytext+1, yyleng-2);
                           return yaSTRING;
                         }
-  \"                    { yy_push_state(STRING); yymore(); }
-  \"\"\"                { yy_push_state(QQQ); yymore(); }
+  \"                    { yy_push_state(STRING); PARSEP->lexString().clear(); }
+  \"\"\"                { yy_push_state(QQQ); PARSEP->lexString().clear(); }
   {vnum}                {
                           /* "# 1'b0" is a delay value so must lex as "#" "1" "'b0" */
                           if (PARSEP->lexPrevToken()=='#') {
@@ -1055,26 +1055,33 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
                           yyleng = 0; yy_pop_state(); FL_BRK; yyterminate(); }
 <STRING>{crnl}          { FL; yylval.fl->v3error("Unterminated string");
                           FL_BRK; }
-<STRING>\\{crnl}        { yymore(); }
-<STRING>\\.             { yymore(); }
+<STRING>\\{crnl}        { PARSEP->lexFileline()->linenoInc(); }  /* IEEE 1800-2023 5.9: backslash-newline continuation is ignored */
+<STRING>\\.             { PARSEP->lexString().append(yytext, yyleng); }
 <STRING>\"              { yy_pop_state();
-                          FL; yylval.strp = PARSEP->newString(yytext+1, yyleng-2);
+                          PARSEP->lexFileline()->forwardToken(PARSEP->lexString().data(),
+                                                              PARSEP->lexString().size(), true);
+                          PARSEP->lexFileline()->forwardToken("\"", 1, true);
+                          FL; yylval.strp = PARSEP->newString(PARSEP->lexString());
                           return yaSTRING; }
-<STRING>{word}          { yymore(); }
-<STRING>.               { yymore(); }
+<STRING>{word}          { PARSEP->lexString().append(yytext, yyleng); }
+<STRING>.               { PARSEP->lexString().append(yytext, yyleng); }
 
   /************************************************************************/
   /* """ */
 <QQQ><<EOF>>            { FL; yylval.fl->v3error("EOF in unterminated \"\"\" string");
                           yyleng = 0; yy_pop_state(); FL_BRK; yyterminate(); }
-<QQQ>\\.                { yymore(); }
-<QQQ>\n                 { yymore(); }
+<QQQ>\\{crnl}           { PARSEP->lexFileline()->linenoInc(); }  /* IEEE 1800-2023 5.9: backslash-newline continuation is ignored */
+<QQQ>\\.                { PARSEP->lexString().append(yytext, yyleng); }
+<QQQ>\n                 { PARSEP->lexString().append(yytext, yyleng); }
 <QQQ>\"\"\"             { yy_pop_state();
-                          FL; yylval.strp = PARSEP->newString(yytext + 3, yyleng - 6);
+                          PARSEP->lexFileline()->forwardToken(PARSEP->lexString().data(),
+                                                              PARSEP->lexString().size(), true);
+                          PARSEP->lexFileline()->forwardToken("\"\"\"", 3, true);
+                          FL; yylval.strp = PARSEP->newString(PARSEP->lexString());
                           return yaSTRING; }
-<QQQ>\"                 { yymore(); }
-<QQQ>{word}             { yymore(); }
-<QQQ>.                  { yymore(); }
+<QQQ>\"                 { PARSEP->lexString().append(yytext, yyleng); }
+<QQQ>{word}             { PARSEP->lexString().append(yytext, yyleng); }
+<QQQ>.                  { PARSEP->lexString().append(yytext, yyleng); }
 
   /************************************************************************/
   /* Attributes */

--- a/test_regress/t/t_display.out
+++ b/test_regress/t/t_display.out
@@ -70,8 +70,7 @@ extra argument:                    0
                    0 : pre argument after
 empty: > <
 [0] Embedded tab '	' and <#013> return
-[0] Embedded
-multiline
+[0] Embeddedmultiline
 '23 23       23'
 '23 23 23      '
 '23 23       23'

--- a/test_regress/t/t_display.v
+++ b/test_regress/t/t_display.v
@@ -4,6 +4,11 @@
 // SPDX-FileCopyrightText: 2003 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
+// verilog_format: off
+`define stop $stop
+`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got=\"%s\" exp=\"%s\"\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
 module t;
   reg [40:0] quad; initial quad = 41'ha_bbbb_cccc;
   reg [80:0] wide; initial wide = 81'habc_1234_5678_1234_5678;
@@ -174,6 +179,24 @@ module t;
     $write("[%0t] Embedded tab '\t' and \r return\n", $time);
     $display("[%0t] Embedded\
 multiline", $time);
+
+    // IEEE 1800-2023 5.9: A backslash immediately before a newline in a
+    // quoted string is ignored, only the backslash and newline are removed.
+    s = "abc \
+def";
+    `checks(s, "abc def");
+    s = "abc\
+def";
+    `checks(s, "abcdef");
+    s = "a\
+b\
+c";
+    `checks(s, "abc");
+    s = "xy\
+z\nq";
+    `checks(s, "xyz\nq");
+    `checks("one \
+two", "one two");
 
     // Str check
 `ifndef NC    // NC-Verilog 5.3 chokes on this test

--- a/test_regress/t/t_display_qqq.out
+++ b/test_regress/t/t_display_qqq.out
@@ -1,5 +1,4 @@
 First "quoted"
-second
-third
+secondthird
 fourth
 *-* All Finished *-*

--- a/test_regress/t/t_display_qqq.v
+++ b/test_regress/t/t_display_qqq.v
@@ -4,14 +4,37 @@
 // SPDX-FileCopyrightText: 2022 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
+// verilog_format: off
+`define stop $stop
+`define checks(gotv,expv) do if ((gotv) != (expv)) begin $write("%%Error: %s:%0d:  got=\"%s\" exp=\"%s\"\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+// verilog_format: off
 module t;
+  string s;
 
   initial begin
     $display("""First "quoted"\nsecond\
 third
 fourth""");
 
+    // IEEE 1800-2023 5.9: a backslash immediately before a newline in a
+    // triple-quoted string is ignored, as in a quoted string
+    s = """one \
+two""";
+    `checks(s, "one two");
+
+    s = """a\
+b\
+c""";
+    `checks(s, "abc");
+
+    s = """one
+two""";
+    `checks(s, "one\ntwo");
+
     $write("*-* All Finished *-*\n");
     $finish;
   end
 endmodule
+// verilog_format: on


### PR DESCRIPTION
SV 2023 spec, in section 5.9, on page 80 says that
> A quoted string shall be contained in a single line unless the newline character is immediately preceded by a
\ (backslash). In this case, the backslash and the newline character are ignored.

Yet running
```
$display("this is \
multiline");
```
with Verilator preserves the newline in the output:
```
this is
multiline
```

This patch fixes it, so that it's handled like it's described in IEEE1800-2023