### PR TITLE
A non-blocking assignment made after a #0 does not take effect in that time slot

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -21,6 +21,7 @@ Aleksander Kiryk
 Alex Chadwick
 Alex Solomatnikov
 Alex Zhou
+Alexandre Dauquier <85447468+dalex78@users.noreply.github.com> dalex78 <85447468+dalex78@users.noreply.github.com>
 Aliaksei Chapyzhenka
 Ameya Vikram Singh
 Andrea Calabrese

--- a/include/verilated_timing.cpp
+++ b/include/verilated_timing.cpp
@@ -68,6 +68,11 @@ void VlDelayScheduler::resume() {
         return;
     }
     bool resumed = false;
+    // A zero-delay resume in this time slot makes this region run once more,
+    // so that whatever those processes scheduled takes effect now. There may
+    // be nothing of our own to resume, and that is not an error.
+    const bool afterZeroDelay = m_resumedZeroDelay;
+    m_resumedZeroDelay = false;
 
     while (!m_queue.empty() && (m_queue.cbegin()->first == m_context.time())) {
         VlCoroutineHandle handle = std::move(m_queue.begin()->second);
@@ -77,6 +82,7 @@ void VlDelayScheduler::resume() {
     }
 
     if (!resumed) {
+        if (afterZeroDelay) return;  // Ran only to let the later regions run
         if (m_context.time() == 0) {
             // Nothing was scheduled at time 0, but resume() got called due to --x-initial-edge
             return;
@@ -95,6 +101,7 @@ void VlDelayScheduler::resumeZeroDelay() {
         return;
     }
     m_zeroDelayesSwap.swap(m_zeroDelayed);
+    if (!m_zeroDelayesSwap.empty()) m_resumedZeroDelay = true;
     for (VlCoroutineHandle& handle : m_zeroDelayesSwap) handle.resume();
     m_zeroDelayesSwap.clear();
 }

--- a/include/verilated_timing.h
+++ b/include/verilated_timing.h
@@ -173,6 +173,11 @@ class VlDelayScheduler final {
     std::vector<VlCoroutineHandle> m_zeroDelayed;  // Coroutines waiting for #0
     // Coroutines that waited for #0 and are being resumed now. As member to avoid reallocations
     std::vector<VlCoroutineHandle> m_zeroDelayesSwap;
+    // Set when resumeZeroDelay() resumed a process. A process resumed in the
+    // Inactive region may have scheduled a non-blocking assignment, and IEEE
+    // 1800-2023 4.5 puts the NBA region after the Inactive region of the same
+    // time slot, so the regions that follow must still run in this time slot.
+    bool m_resumedZeroDelay = false;
 
 public:
     // CONSTRUCTORS
@@ -191,7 +196,8 @@ public:
     // Are there coroutines to resume at the current simulation time?
     bool awaitingCurrentTime() const {
         return !m_context.gotFinish()
-               && (!m_queue.empty() && (m_queue.cbegin()->first <= m_context.time()));
+               && (m_resumedZeroDelay
+                   || (!m_queue.empty() && (m_queue.cbegin()->first <= m_context.time())));
     }
     // Are there coroutines to resume in the inactive region after a #0 delay?
     bool awaitingZeroDelay() const { return !m_context.gotFinish() && !m_zeroDelayed.empty(); }

--- a/test_regress/t/t_timing_zerodly_nba.py
+++ b/test_regress/t/t_timing_zerodly_nba.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=["--exe --main --timing"])
+
+test.execute(check_finished=True)
+
+test.passes()

--- a/test_regress/t/t_timing_zerodly_nba.v
+++ b/test_regress/t/t_timing_zerodly_nba.v
@@ -1,0 +1,46 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// A non-blocking assignment made by a process that was resumed after a #0
+// must take effect in that same time slot: IEEE 1800-2023 4.5 puts the NBA
+// region after the Inactive region of one time slot, not of the next one.
+
+module t;
+
+   logic [3:0] x = 4'h0;
+   logic [3:0] y;
+   int         z;
+
+   assign y = x;
+   assign z = (x == 4'h4) ? 40 : (x == 4'h7) ? 70 : -1;
+
+   initial begin
+      // The #0 is what puts the assignment below in the Inactive region
+      #0;
+      x <= 4'h4;
+      #1;
+      if (x !== 4'h4) $stop;
+      if (y !== 4'h4) $stop;
+      if (z !== 40) $stop;
+
+      // And again, to show it is not a one-off at time zero
+      #0;
+      x <= 4'h7;
+      #1;
+      if (y !== 4'h7) $stop;
+      if (z !== 70) $stop;
+
+      // Without a #0 the same assignment has always worked
+      x <= 4'h4;
+      #1;
+      if (y !== 4'h4) $stop;
+      if (z !== 40) $stop;
+
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+
+endmodule


### PR DESCRIPTION
AI generated fix. 
Please see the associated ticket: https://github.com/verilator/verilator/issues/8214
I'll close that MR because I cannot take the responsibility for its correctness. 
I hope that PR can be a starting point for the maintainers which will tackle that bug.