### PR TITLE
Support s_until/s_until_with in property expression

### DIFF
--- a/src/V3AssertNfa.cpp
+++ b/src/V3AssertNfa.cpp
@@ -316,6 +316,7 @@ class SvaNfaBuilder final {
     std::vector<AstNodeExpr*> m_outerAbortStack;
     bool m_inUnboundedScope = false;  // Sticky: nodes created after inherit liveness
     bool m_markStrongPending = false;  // Mark new vertices as strong s_always in-window
+    bool m_isCover = false;  // Cover directives do not fail at end-of-simulation
     // IEEE 1800-2023 16.14.3 cover sequence: each end-of-match fires the action,
     // not just the first. Builder builds parallel-branch (no first-match-wins)
     // topology when true. Default false preserves cover_property semantics.
@@ -1327,7 +1328,7 @@ class SvaNfaBuilder final {
         return result;
     }
 
-    // until / until_with (weak forms only) per IEEE 1800-2023 16.12.12.
+    // until / until_with per IEEE 1800-2023 16.12.12.
     // Topology: combinational wait vertex with self-feeding state register.
     //   entry  --link[T]--> waitC
     //   waitR  --link[T]--> waitC                          (back-loop)
@@ -1340,21 +1341,17 @@ class SvaNfaBuilder final {
     // every cycle q is false). Per-cycle reject comes from the explicit
     // rejectOnFail link to the sink vertex.
     //
-    // Weak non-overlapping (p until q):
+    // Non-overlapping (p until q):
     //   REQUIRE = sampled(p) || sampled(q)   accept = sampled(q)
-    // Weak overlapping (p until_with q):
+    // Overlapping (p until_with q):
     //   REQUIRE = sampled(p)                 accept = sampled(p) && sampled(q)
+    // Strong forms use the same checks and mark the registered wait state as
+    // an end-of-simulation liveness obligation.
     BuildResult buildUntil(AstUntil* nodep, SvaStateVertex* entryVtxp, bool isTopLevelStep) {
         FileLine* const flp = nodep->fileline();
         if (!isTopLevelStep) {
             nodep->v3warn(E_UNSUPPORTED, "Unsupported: '" << nodep->verilogKwd()
                                                           << "' in complex property expression");
-            return BuildResult::failWithError();
-        }
-        if (nodep->isStrong()) {
-            nodep->v3warn(E_UNSUPPORTED, "Unsupported: s_until"
-                                             << (nodep->isOverlapping() ? "_with" : "")
-                                             << " (in property expression)");
             return BuildResult::failWithError();
         }
         AstNodeExpr* const lhsp = nodep->lhsp();
@@ -1379,6 +1376,7 @@ class SvaNfaBuilder final {
         SvaStateVertex* const waitCp = scopedCreateVertex();
         SvaStateVertex* const waitRp = scopedCreateVertex();
         waitCp->m_isUnbounded = true;
+        waitRp->m_strongPending = nodep->isStrong() && !m_isCover;
 
         // Entry and back-loop Links carry no condition; throughout-folding still applies.
         guardedLink(entryVtxp, waitCp, flp);
@@ -1552,10 +1550,11 @@ class SvaNfaBuilder final {
 
 public:
     SvaNfaBuilder(SvaGraph& graph, AstNodeModule* modp, V3UniqueNames& propTempNames,
-                  bool isCoverSeq = false, bool isSeqEvent = false)
+                  bool isCoverSeq = false, bool isSeqEvent = false, bool isCover = false)
         : m_graph{graph}
         , m_modp{modp}
         , m_propTempNames{propTempNames}
+        , m_isCover{isCover}
         , m_isCoverSeq{isCoverSeq}
         , m_isSeqEvent{isSeqEvent} {}
 
@@ -3220,7 +3219,8 @@ class AssertNfaVisitor final : public VNVisitor {
         FileLine* const flp = assertp->fileline();
 
         SvaGraph graph;
-        SvaNfaBuilder builder{graph, m_modp, m_propTempNames, isCoverSeq, isSeqEvent};
+        SvaNfaBuilder builder{graph,      m_modp,     m_propTempNames,
+                              isCoverSeq, isSeqEvent, coverp != nullptr};
 
         const BuildResult result = buildAssertionGraph(builder, graph, seqBodyp, parts, flp);
         if (result.valid()) wireMatchAndMidSources(graph, result, flp);

--- a/src/V3AssertPre.cpp
+++ b/src/V3AssertPre.cpp
@@ -1325,6 +1325,13 @@ private:
             !m_pexprp, nodep,
             "'" << nodep->verilogKwd()
                 << "' in complex property expression should have been rejected by V3AssertNfa");
+        if (nodep->isStrong()
+            && (v3Global.opt.timing().isSetFalse() || !v3Global.opt.timing().isSetTrue())) {
+            nodep->v3warn(E_NOTIMING, nodep->verilogKwd() << " requires --timing");
+            nodep->replaceWith(new AstConst{flp, AstConst::BitFalse{}});
+            VL_DO_DANGLING(pushDeletep(nodep), nodep);
+            return;
+        }
         if (nodep->isStrong()) {
             // p s_until q / p s_until_with q: q must eventually be true. Until then, p must
             // be true on every sampled tick. For s_until, check q first: when q is true on

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1816,13 +1816,6 @@ class WidthVisitor final : public VNVisitor {
     }
 
     void visit(AstUntil* nodep) override {
-        if (nodep->isStrong()
-            && (v3Global.opt.timing().isSetFalse() || !v3Global.opt.timing().isSetTrue())) {
-            nodep->v3warn(E_NOTIMING, nodep->verilogKwd() << " requires --timing");
-            nodep->replaceWith(new AstConst{nodep->fileline(), AstConst::BitFalse{}});
-            VL_DO_DANGLING(nodep->deleteTree(), nodep);
-            return;
-        }
         assertAtExpr(nodep);
         if (m_vup->prelim()) {
             iterateCheckBool(nodep, "LHS", nodep->lhsp(), BOTH);
@@ -6218,6 +6211,17 @@ class WidthVisitor final : public VNVisitor {
         VL_RESTORER(m_hasSExpr);
         assertAtExpr(nodep);
         if (m_vup->prelim()) {  // First stage evaluation
+            // Only bare strong until uses V3AssertPre's timing-based lowering. Embedded forms
+            // are lowered without timing by V3AssertNfa.
+            AstNode* propp = nodep->propp();
+            while (AstLogNot* const notp = VN_CAST(propp, LogNot)) propp = notp->lhsp();
+            AstUntil* const untilp = VN_CAST(propp, Until);
+            if (untilp && VN_IS(nodep->backp(), NodeCoverOrAssert) && untilp->isStrong()
+                && (v3Global.opt.timing().isSetFalse() || !v3Global.opt.timing().isSetTrue())) {
+                untilp->v3warn(E_NOTIMING, untilp->verilogKwd() << " requires --timing");
+                untilp->replaceWith(new AstConst{untilp->fileline(), AstConst::BitFalse{}});
+                VL_DO_DANGLING(pushDeletep(untilp), untilp);
+            }
             iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);
             userIterateAndNext(nodep->sensesp(), nullptr);
             if (nodep->disablep()) {

--- a/test_regress/t/t_property_s_until_nfa.out
+++ b/test_regress/t/t_property_s_until_nfa.out
@@ -1,0 +1,2 @@
+*-* All Finished *-*
+[65] %Error: t_property_s_until_nfa.v:45: Assertion failed in top.t

--- a/test_regress/t/t_property_s_until_nfa.py
+++ b/test_regress/t/t_property_s_until_nfa.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.compile(verilator_flags2=['--assert', '+define+TEST_PRE_NOTIMING'],
+             fails=True,
+             expect_filename='t/t_property_s_until_nfa_pre.out')
+test.lint(verilator_flags2=['--assert', '--no-timing', '+define+TEST_PRE_NOTIMING'],
+          fails=True,
+          expect_filename='t/t_property_s_until_nfa_pre.out')
+test.compile(verilator_flags2=['--assert', '+define+TEST_WIDTH_NOTIMING'],
+             fails=True,
+             expect_filename='t/t_property_s_until_nfa_width.out')
+test.lint(verilator_flags2=['--assert', '--no-timing', '+define+TEST_WIDTH_NOTIMING'],
+          fails=True,
+          expect_filename='t/t_property_s_until_nfa_width.out')
+test.compile(verilator_flags2=['--assert', '--no-stop-fail'])
+test.execute(expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_property_s_until_nfa.v
+++ b/test_regress/t/t_property_s_until_nfa.v
@@ -1,0 +1,64 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+module t (
+    input clk
+);
+
+  int cyc = 0;
+  int pass_count[6];
+
+  property named_s_until;
+    @(posedge clk) (cyc == 1) |=> 1'b1 s_until (cyc == 3);
+  endproperty
+
+`ifdef TEST_PRE_NOTIMING
+  property named_bare_s_until;
+    @(posedge clk) 1'b1 s_until 1'b1;
+  endproperty
+
+  assert property (named_bare_s_until);
+`endif
+
+`ifdef TEST_WIDTH_NOTIMING
+  assert property (@(posedge clk) 1'b1 s_until 1'b1);
+`endif
+
+  // These obligations resolve normally and must not fail at end of simulation.
+  assert property (named_s_until) pass_count[0]++;
+  assert property (@(posedge clk) (cyc == 1) |=> 1'b1 s_until (cyc == 3)) pass_count[1]++;
+  assert property (@(posedge clk) (cyc == 1) |=> 1'b1 s_until_with (cyc == 3)) pass_count[2]++;
+  assert property (@(posedge clk) (cyc == 0) |-> ##1 (1'b1 s_until (cyc == 2))) pass_count[3]++;
+  assert property (@(posedge clk) ##1 (1'b0 s_until 1'b1)) pass_count[4]++;
+  assert property (@(posedge clk) ##1 (1'b1 s_until_with 1'b1)) pass_count[5]++;
+  cover property (@(posedge clk) (cyc == 1) |=> 1'b1 s_until 1'b0);
+
+  // This obligation remains live and must fail at end of simulation.
+  assert property (@(posedge clk) (cyc == 1) |=> 1'b1 s_until 1'b0);
+
+  final begin
+    `checkd(pass_count[0], 6);
+    `checkd(pass_count[1], 6);
+    `checkd(pass_count[2], 6);
+    `checkd(pass_count[3], 6);
+    `checkd(pass_count[4], 5);
+    `checkd(pass_count[5], 5);
+  end
+
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (cyc == 5) begin
+      $display("*-* All Finished *-*");
+      $finish;
+    end
+  end
+
+endmodule

--- a/test_regress/t/t_property_s_until_nfa_pre.out
+++ b/test_regress/t/t_property_s_until_nfa_pre.out
@@ -1,0 +1,6 @@
+%Error-NOTIMING: t/t_property_s_until_nfa.v:25:25: s_until requires --timing
+                                                 : ... note: In instance 't'
+   25 |     @(posedge clk) 1'b1 s_until 1'b1;
+      |                         ^~~~~~~
+                 ... For error description see https://verilator.org/warn/NOTIMING?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_property_s_until_nfa_width.out
+++ b/test_regress/t/t_property_s_until_nfa_width.out
@@ -1,0 +1,6 @@
+%Error-NOTIMING: t/t_property_s_until_nfa.v:32:40: s_until requires --timing
+                                                 : ... note: In instance 't'
+   32 |   assert property (@(posedge clk) 1'b1 s_until 1'b1);
+      |                                        ^~~~~~~
+                 ... For error description see https://verilator.org/warn/NOTIMING?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_property_sexpr_parse_unsup.out
+++ b/test_regress/t/t_property_sexpr_parse_unsup.out
@@ -1,16 +1,16 @@
-%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:80:14: Logical operator IMPLICATION expects 1 bit on the RHS, but RHS's CMETHODHARD 'at' generates 8 bits.
+%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:76:14: Logical operator IMPLICATION expects 1 bit on the RHS, but RHS's CMETHODHARD 'at' generates 8 bits.
                                                      : ... note: In instance 't.ieee'
-   80 |     $rose(a) |-> q[0];
+   76 |     $rose(a) |-> q[0];
       |              ^~~
                      ... For warning description see https://verilator.org/warn/WIDTHTRUNC?v=latest
                      ... Use "/* verilator lint_off WIDTHTRUNC */" and lint_on around source to disable this message.
-%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:85:29: Logical operator SEXPR expects 1 bit on the exprp, but exprp's CMETHODHARD 'at' generates 8 bits.
+%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:81:29: Logical operator SEXPR expects 1 bit on the exprp, but exprp's CMETHODHARD 'at' generates 8 bits.
                                                      : ... note: In instance 't.ieee'
-   85 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
+   81 |     ($rose(a), l_b = b) |-> ##[3:10] q[l_b];
       |                             ^~
-%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:106:31: Logical operator SEXPR expects 1 bit on the exprp, but exprp's VARREF 'b' generates 32 bits.
+%Warning-WIDTHTRUNC: t/t_property_sexpr_unsup.v:102:31: Logical operator SEXPR expects 1 bit on the exprp, but exprp's VARREF 'b' generates 32 bits.
                                                       : ... note: In instance 't.ieee'
-  106 |   assert property (@clk not a ##1 b);
+  102 |   assert property (@clk not a ##1 b);
       |                               ^~
 %Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:47:39: Unsupported: 'until' in complex property expression
                                                     : ... note: In instance 't'
@@ -21,32 +21,24 @@
                                                     : ... note: In instance 't'
    49 |   assert property (@(posedge clk) val until (val ##1 val)) $display("[%0t] sequence in until, fileline:%d", $time, 49);
       |                                       ^~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:51:44: Unsupported: s_until (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:51:39: Unsupported: 's_until' in complex property expression
                                                     : ... note: In instance 't'
-   51 |   assert property (@(posedge clk) ##1 (val s_until val)) $display("[%0t] s_until in sequence, fileline:%d", $time, 51);
-      |                                            ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:53:39: Unsupported: s_until (in property expression)
-                                                    : ... note: In instance 't'
-   53 |   assert property (@(posedge clk) val s_until val s_until val) $display("[%0t] nested s_until, fileline:%d", $time, 53);
+   51 |   assert property (@(posedge clk) val s_until val s_until val) $display("[%0t] nested s_until, fileline:%d", $time, 51);
       |                                       ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:39: Unsupported: s_until (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:53:39: Unsupported: 's_until' in complex property expression
                                                     : ... note: In instance 't'
-   55 |   assert property (@(posedge clk) val s_until (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 55);
+   53 |   assert property (@(posedge clk) val s_until (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 53);
       |                                       ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:57:44: Unsupported: s_until_with (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:39: Unsupported: 's_until_with' in complex property expression
                                                     : ... note: In instance 't'
-   57 |   assert property (@(posedge clk) ##1 (val s_until_with val)) $display("[%0t] s_until_with in sequence, fileline:%d", $time, 57);
-      |                                            ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:59:39: Unsupported: s_until_with (in property expression)
-                                                    : ... note: In instance 't'
-   59 |   assert property (@(posedge clk) val s_until_with val s_until_with val) $display("[%0t] nested s_until_with, fileline:%d", $time, 59);
+   55 |   assert property (@(posedge clk) val s_until_with val s_until_with val) $display("[%0t] nested s_until_with, fileline:%d", $time, 55);
       |                                       ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:61:39: Unsupported: s_until_with (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:57:39: Unsupported: 's_until_with' in complex property expression
                                                     : ... note: In instance 't'
-   61 |   assert property (@(posedge clk) val s_until_with (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 61);
+   57 |   assert property (@(posedge clk) val s_until_with (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 57);
       |                                       ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:63:40: Unsupported: 'until' in complex property expression
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:59:40: Unsupported: 'until' in complex property expression
                                                     : ... note: In instance 't'
-   63 |   assert property (@(posedge clk) (val until val) or val) $display("[%0t] until inside or, fileline:%d", $time, 63);
+   59 |   assert property (@(posedge clk) (val until val) or val) $display("[%0t] until inside or, fileline:%d", $time, 59);
       |                                        ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_property_sexpr_unsup.out
+++ b/test_regress/t/t_property_sexpr_unsup.out
@@ -7,32 +7,24 @@
                                                     : ... note: In instance 't'
    49 |   assert property (@(posedge clk) val until (val ##1 val)) $display("[%0t] sequence in until, fileline:%d", $time, 49);
       |                                       ^~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:51:44: Unsupported: s_until (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:51:39: Unsupported: 's_until' in complex property expression
                                                     : ... note: In instance 't'
-   51 |   assert property (@(posedge clk) ##1 (val s_until val)) $display("[%0t] s_until in sequence, fileline:%d", $time, 51);
-      |                                            ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:53:39: Unsupported: s_until (in property expression)
-                                                    : ... note: In instance 't'
-   53 |   assert property (@(posedge clk) val s_until val s_until val) $display("[%0t] nested s_until, fileline:%d", $time, 53);
+   51 |   assert property (@(posedge clk) val s_until val s_until val) $display("[%0t] nested s_until, fileline:%d", $time, 51);
       |                                       ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:39: Unsupported: s_until (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:53:39: Unsupported: 's_until' in complex property expression
                                                     : ... note: In instance 't'
-   55 |   assert property (@(posedge clk) val s_until (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 55);
+   53 |   assert property (@(posedge clk) val s_until (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 53);
       |                                       ^~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:57:44: Unsupported: s_until_with (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:55:39: Unsupported: 's_until_with' in complex property expression
                                                     : ... note: In instance 't'
-   57 |   assert property (@(posedge clk) ##1 (val s_until_with val)) $display("[%0t] s_until_with in sequence, fileline:%d", $time, 57);
-      |                                            ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:59:39: Unsupported: s_until_with (in property expression)
-                                                    : ... note: In instance 't'
-   59 |   assert property (@(posedge clk) val s_until_with val s_until_with val) $display("[%0t] nested s_until_with, fileline:%d", $time, 59);
+   55 |   assert property (@(posedge clk) val s_until_with val s_until_with val) $display("[%0t] nested s_until_with, fileline:%d", $time, 55);
       |                                       ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:61:39: Unsupported: s_until_with (in property expression)
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:57:39: Unsupported: 's_until_with' in complex property expression
                                                     : ... note: In instance 't'
-   61 |   assert property (@(posedge clk) val s_until_with (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 61);
+   57 |   assert property (@(posedge clk) val s_until_with (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, 57);
       |                                       ^~~~~~~~~~~~
-%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:63:40: Unsupported: 'until' in complex property expression
+%Error-UNSUPPORTED: t/t_property_sexpr_unsup.v:59:40: Unsupported: 'until' in complex property expression
                                                     : ... note: In instance 't'
-   63 |   assert property (@(posedge clk) (val until val) or val) $display("[%0t] until inside or, fileline:%d", $time, 63);
+   59 |   assert property (@(posedge clk) (val until val) or val) $display("[%0t] until inside or, fileline:%d", $time, 59);
       |                                        ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_property_sexpr_unsup.v
+++ b/test_regress/t/t_property_sexpr_unsup.v
@@ -48,13 +48,9 @@ module t (  /*AUTOARG*/
 
   assert property (@(posedge clk) val until (val ##1 val)) $display("[%0t] sequence in until, fileline:%d", $time, `__LINE__);
 
-  assert property (@(posedge clk) ##1 (val s_until val)) $display("[%0t] s_until in sequence, fileline:%d", $time, `__LINE__);
-
   assert property (@(posedge clk) val s_until val s_until val) $display("[%0t] nested s_until, fileline:%d", $time, `__LINE__);
 
   assert property (@(posedge clk) val s_until (val ##1 val)) $display("[%0t] sequence in until_with, fileline:%d", $time, `__LINE__);
-
-  assert property (@(posedge clk) ##1 (val s_until_with val)) $display("[%0t] s_until_with in sequence, fileline:%d", $time, `__LINE__);
 
   assert property (@(posedge clk) val s_until_with val s_until_with val) $display("[%0t] nested s_until_with, fileline:%d", $time, `__LINE__);
 

--- a/test_regress/t/t_property_until_implication.v
+++ b/test_regress/t/t_property_until_implication.v
@@ -23,6 +23,8 @@ module t (
 
   int fail_nonoverlap = 0;
   int fail_overlap = 0;
+  int fail_strong_nonoverlap = 0;
+  int fail_strong_overlap = 0;
 
   // Weak non-overlapping until as implication consequent.
   // IEEE 1800-2023 16.12.12: c true at every tick until at least one tick
@@ -40,6 +42,15 @@ module t (
   // 1-bit reduction. The assertion itself is trivially true (q == 1).
   assert property (@(posedge clk) trig |=> 0 until 1);
 
+  // Strong forms use the same per-cycle checks, but require the RHS to
+  // eventually match. On the first consequent tick, s_until does not require
+  // the LHS when the RHS is true; s_until_with does.
+  assert property (@(posedge clk) (cyc == 2) |=> 0 s_until (cyc == 3))
+  else fail_strong_nonoverlap = fail_strong_nonoverlap + 1;
+
+  assert property (@(posedge clk) (cyc == 2) |=> 0 s_until_with (cyc == 3))
+  else fail_strong_overlap = fail_strong_overlap + 1;
+
   always @(posedge clk) begin
 `ifdef TEST_VERBOSE
     $write("[%0t] cyc==%0d crc=%x trig=%b c=%b d=%b\n", $time, cyc, crc, trig, c, d);
@@ -56,6 +67,8 @@ module t (
       // "no internal error on `until` as |=> consequent" (issue #7548).
       `checkd(fail_nonoverlap, 7);  // Other sims: 8, one other: 7
       `checkd(fail_overlap, 22);  // Other sims: 24, one other: 22
+      `checkd(fail_strong_nonoverlap, 0);
+      `checkd(fail_strong_overlap, 1);
       $write("*-* All Finished *-*\n");
       $finish;
     end


### PR DESCRIPTION
Support s_until/s_until_with by using the existing NFA machinery and adding a strong obligation. Requires timing to properly handle a strong obligation.