### PR TITLE
Treat method calls in an always block as a reorder barrier

### DIFF
--- a/src/V3Reorder.cpp
+++ b/src/V3Reorder.cpp
@@ -430,6 +430,15 @@ class ReorderVisitor final : public VNVisitor {
         iterateChildren(nodep);
     }
 
+    void visit(AstNodeCCall* nodep) override {
+        if (!m_graphp || m_noReorderWhy) return;
+        // The callee is not inlined, so the variables it reads and writes carry no VarRef at
+        // the call site, and the scoreboard would let assignments to them move across the
+        // call. Treat any such call as a barrier.
+        m_noReorderWhy = "CCall";
+        iterateChildren(nodep);
+    }
+
     void visit(AstExprStmt* nodep) override {
         if (!m_graphp || m_noReorderWhy) return;
         VL_RESTORER(m_inDly);

--- a/test_regress/t/t_always_reorder_class.out
+++ b/test_regress/t/t_always_reorder_class.out
@@ -1,0 +1,2 @@
+r0=0 r1=1 r2=2 r3=3
+*-* All Finished *-*

--- a/test_regress/t/t_always_reorder_class.py
+++ b/test_regress/t/t_always_reorder_class.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute(expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_always_reorder_class.v
+++ b/test_regress/t/t_always_reorder_class.v
@@ -1,0 +1,52 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Matthew Ballance
+// SPDX-License-Identifier: CC0-1.0
+
+// V3Reorder builds its scoreboard from the AstVarRefs it can see at each
+// statement.  A class method is not inlined, so a module-scope variable it
+// reads carries no AstVarRef at the call site: the assignments to that variable
+// and the calls that read it land in unrelated weakly-connected components and
+// are free to be interleaved arbitrarily.  Each call below must observe the
+// value assigned immediately before it, so the reads come back 0, 1, 2, 3.
+//
+// A covergroup's sample() is one of these methods, reading its coverpoint
+// variables, but there is nothing covergroup-specific about the hazard.
+// Note: The sampling block below is kept free of display tasks, as
+// those are impure and would constrain the ordering on their own.
+
+module t (
+    input clk
+);
+
+  int cyc = 0;
+  logic [1:0] v;
+  int r0, r1, r2, r3;
+
+  class Reader;
+    function int getv();
+      return int'(v);
+    endfunction
+  endclass
+
+  Reader rd = new;
+
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    if (cyc == 1) begin
+      v  = 2'd0;
+      r0 = rd.getv();
+      v  = 2'd1;
+      r1 = rd.getv();
+      v  = 2'd2;
+      r2 = rd.getv();
+      v  = 2'd3;
+      r3 = rd.getv();
+    end else if (cyc == 2) begin
+      $write("r0=%0d r1=%0d r2=%0d r3=%0d\n", r0, r1, r2, r3);
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+endmodule


### PR DESCRIPTION
I ran into this issue with covergroup tests, but it also shows up with class-method calls (as shown in the testcase). Currently, the reordering pass is free to reorder variable assignments around non-inlined task calls in an always block even if those tasks (eg sample()) access the assigned variables. This PR treats all non-inlined method calls as a reorder barrier. 
I wouldn't expect this PR to introduce a performance regression, since method calls in always blocks aren't common outside of tests.
