### PR TITLE
Fix SIMILARNAME warning on parameters and localparams (#8186)

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2153,6 +2153,9 @@ List Of Warnings
 
    .. include:: ../../docs/gen/ex_SIMILARNAME_msg.rst
 
+   Parameters and localparams are not checked, as they are elaborated away
+   and so cannot reach a downstream tool as a name.
+
    Disabled by default as this is a code-style warning; it will simulate
    correctly.
 

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -361,7 +361,7 @@ public:
         AstNode* const fnodep = foundp ? foundp->nodep() : nullptr;
         if (!fnodep) {
             // Not found, will add in a moment.
-            if (!lookupSymp->ignoreForSimilarTest(nodep->type())) {  // ignore typedefs etc
+            if (!lookupSymp->ignoreForSimilarTest(nodep)) {  // ignore typedefs, params, etc
                 const VSymEnt* const alt = lookupSymp->findSimilarIdFlat(name);
                 if (alt) {
                     nodep->v3warn(SIMILARNAME, "Declaration overlaps another with different case: "

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -137,7 +137,7 @@ public:
             m_idNameMap.emplace(name, entp);
         }
         if (name.find("__DOT__") == std::string::npos
-            && !ignoreForSimilarTest(entp->nodep()->type())) {  // ignore hierarchical equivalents
+            && !ignoreForSimilarTest(entp->nodep())) {  // ignore hierarchical equivalents
             string lc = name;
             for (auto& c : lc) c = (char)tolower(c);
             if (m_idNameSimilarMap.find(lc) == m_idNameSimilarMap.end())
@@ -168,8 +168,12 @@ public:
         if (it != m_idNameMap.end()) return it->second;
         return nullptr;
     }
-    bool ignoreForSimilarTest(VNType t) {  // node types that don't affect final net types
-        switch (t) {
+    static bool ignoreForSimilarTest(const AstNode* nodep) {
+        // Nodes that don't affect final net types
+        // Parameters and localparams are elaborated away, so they can't
+        // collide with a net downstream
+        if (const AstVar* const varp = VN_CAST(nodep, Var)) return varp->isParam();
+        switch (nodep->type()) {
         case VNType::TypedefFwd:
         case VNType::Typedef:
         case VNType::ParamTypeDType:

--- a/test_regress/t/t_lint_similarname.v
+++ b/test_regress/t/t_lint_similarname.v
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2025 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
-module t;
+module t #(parameter int SIZE = 4);
 
   // verilator lint_off UNDRIVEN
   // verilator lint_off UNUSEDSIGNAL
@@ -12,9 +12,27 @@ module t;
   reg i;
   wire I;
 
+  import pkg::*;
+
+  // Parameters and localparams are elaborated away, so they must not
+  // collide with a net that differs only in lexical case
+  localparam int WIDTH = 8;
+  logic [WIDTH-1:0] width;
+  logic [WIDTH-1:0] reg_ctrl;
+  logic [SIZE-1:0] size;
 
   initial begin
+    width = WIDTH[WIDTH-1:0];
+    reg_ctrl = REG_CTRL;
+    size = {SIZE{1'b0}};
+    if (width !== 8'd8) $stop;
+    if (reg_ctrl !== 8'h00) $stop;
+    if (size !== {SIZE{1'b0}}) $stop;
     $finish;
   end
 
 endmodule
+
+package pkg;
+  localparam logic [7:0] REG_CTRL = 8'h00;
+endpackage


### PR DESCRIPTION
Fixes #8186.

## Problem

`SIMILARNAME` (added in #7992) also fires on parameters and localparams. The
warning exists because some downstream VLSI tools do not distinguish net and
gate names that differ only in lexical case. Parameters and localparams are
elaborated away, so they never reach such a tool as a name.

From the issue, a package localparam and a module net collide:

```systemverilog
// package
localparam logic [7:0] REG_CTRL = 8'h00;
// module
logic [31:0] reg_ctrl;
```

## Fix

`VSymEnt::ignoreForSimilarTest()` filtered on `VNType` alone, which cannot
separate a parameter from a net -- both are `AstVar`. It now takes the node and
returns true for an `AstVar` whose `varType()` is a parameter.

The filter is applied on both sides:

- `VSymEnt::insert()` -- a param no longer enters `m_idNameSimilarMap`, so it is
  never the "original declaration" a later net is reported against.
- `V3LinkDot` `checkDuplicate()` -- a param is never itself reported.

Both are needed. In the issue's case the package localparam is inserted first,
so filtering only the report side would still warn.

## Test

`t_lint_similarname.v` gains all three parameter kinds, alongside the existing
`reg i` / `wire I` pair that must still warn:

- module `parameter` (`SIZE` vs `size`)
- module `localparam` (`WIDTH` vs `width`)
- package `localparam` reached by wildcard import (`REG_CTRL` vs `reg_ctrl`) --
  the issue's own reproducer

Before the fix, `-Wall` on that file reports four warnings:

```
t_lint_similarname.v:13:8:  ... 'I'
t_lint_similarname.v:20:21: ... 'width'
t_lint_similarname.v:21:21: ... 'reg_ctrl'
t_lint_similarname.v:22:20: ... 'size'
```

After the fix, only `'I'` remains. The `t_lint_similarname_bad.out` golden is
unchanged: `reg i` / `wire I` stay on lines 12-13, so the message and the
`docs/gen/ex_SIMILARNAME_*` extracts do not move.

`docs/guide/warnings.rst` records the exclusion.
