### PR TITLE
Fix excessive SIMILARNAME warnings

### DIFF
--- a/docs/guide/warnings.rst
+++ b/docs/guide/warnings.rst
@@ -2147,7 +2147,7 @@ List Of Warnings
 
 .. option:: SIMILARNAME
 
-   Warns that a variable name only differs from another in lexical case.
+   Warns that an entity name only differs from another in lexical case.
 
    Faulty example:
 
@@ -2157,8 +2157,12 @@ List Of Warnings
 
    .. include:: ../../docs/gen/ex_SIMILARNAME_msg.rst
 
-   Parameters and localparams are not checked, as they are elaborated away
-   and so cannot reach a downstream tool as a name.
+   Only declarations that can reach a downstream VLSI tool as a name are
+   checked, that is nets, variables, instances, named blocks (``begin``,
+   ``fork``, and generate blocks), functions and tasks. All of these can form
+   part of a flattened signal or scope name.  Other declarations, such as
+   parameters, localparams, genvars and typedefs, are elaborated away, and so
+   are not checked.
 
    Disabled by default as this is a code-style warning; it will simulate
    correctly.

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -361,7 +361,7 @@ public:
         AstNode* const fnodep = foundp ? foundp->nodep() : nullptr;
         if (!fnodep) {
             // Not found, will add in a moment.
-            if (!lookupSymp->ignoreForSimilarTest(nodep)) {  // ignore typedefs, params, etc
+            if (forPrimary() && VSymEnt::checkSimilarname(nodep)) {
                 const VSymEnt* const alt = lookupSymp->findSimilarIdFlat(name);
                 if (alt) {
                     nodep->v3warn(SIMILARNAME, "Declaration overlaps another with different case: "

--- a/src/V3SymTable.h
+++ b/src/V3SymTable.h
@@ -136,8 +136,8 @@ public:
         } else {
             m_idNameMap.emplace(name, entp);
         }
-        if (name.find("__DOT__") == std::string::npos
-            && !ignoreForSimilarTest(entp->nodep())) {  // ignore hierarchical equivalents
+        if (!name.empty() && name.find("__DOT__") == std::string::npos  // ignore hierarchical
+            && checkSimilarname(entp->nodep())) {
             string lc = name;
             for (auto& c : lc) c = (char)tolower(c);
             if (m_idNameSimilarMap.find(lc) == m_idNameSimilarMap.end())
@@ -168,23 +168,17 @@ public:
         if (it != m_idNameMap.end()) return it->second;
         return nullptr;
     }
-    static bool ignoreForSimilarTest(const AstNode* nodep) {
-        // Nodes that don't affect final net types
-        // Parameters and localparams are elaborated away, so they can't
-        // collide with a net downstream
-        if (const AstVar* const varp = VN_CAST(nodep, Var)) return varp->isParam();
-        switch (nodep->type()) {
-        case VNType::TypedefFwd:
-        case VNType::Typedef:
-        case VNType::ParamTypeDType:
-        case VNType::EnumItem:
-        case VNType::EnumItemRef:
-        case VNType::Let:
-        case VNType::Class:
-        case VNType::Task:
-        case VNType::Func: return true;
-        default: return false;
+    static bool checkSimilarname(const AstNode* nodep) {
+        // Only declarations that can contribute a name to the netlist handed
+        // to a backend tool.
+        if (const AstVar* const varp = VN_CAST(nodep, Var)) {
+            return !varp->isParam() && !varp->isGenVar();
         }
+        return VN_IS(nodep, Cell)  //
+               || VN_IS(nodep, NodeBlock)  //
+               || VN_IS(nodep, GenBlock)  //
+               || VN_IS(nodep, Func)  // Note: not AstNodeFTask (Property/Sequence)
+               || VN_IS(nodep, Task);
     }
     VSymEnt* findSimilarIdFlat(const string& name) const {
         // Find identifier without looking upward through symbol hierarchy
@@ -196,6 +190,9 @@ public:
         for (auto& c : s) c = (char)tolower(c);
         if (m_idNameSimilarMap.find(s) == m_idNameSimilarMap.end()) return nullptr;
         for (auto it = m_idNameMap.begin(); it != m_idNameMap.end(); ++it) {
+            // Only report a declaration that is itself checked, otherwise we
+            // might point at e.g. a localparam that merely sorts first
+            if (!checkSimilarname(it->second->nodep())) continue;
             string t = it->first;
             for (auto& c : t) c = (char)tolower(c);
             if (t == s && name != it->first) { return it->second; }

--- a/test_regress/t/t_lint_similarname.py
+++ b/test_regress/t/t_lint_similarname.py
@@ -9,10 +9,8 @@
 
 import vltest_bootstrap
 
-test.scenarios('simulator_st')
+test.scenarios('linter')
 
-test.compile(verilator_flags2=['-Wall -Wno-DECLFILENAME -Wno-SIMILARNAME'])
-
-test.execute()
+test.lint(verilator_flags2=['-Wall', '-Wno-DECLFILENAME', '-Wno-SIMILARNAME'])
 
 test.passes()

--- a/test_regress/t/t_lint_similarname.v
+++ b/test_regress/t/t_lint_similarname.v
@@ -14,24 +14,386 @@ module t #(parameter int SIZE = 4);
 
   import pkg::*;
 
-  // Parameters and localparams are elaborated away, so they must not
-  // collide with a net that differs only in lexical case
+  // Parameters and localparams: should not warn
   localparam int WIDTH = 8;
   logic [WIDTH-1:0] width;
-  logic [WIDTH-1:0] reg_ctrl;
+  logic [WIDTH-1:0] reg_ctrl = REG_CTRL;
   logic [SIZE-1:0] size;
 
+  // Genvar: should not warn
+  logic genvar_name;
+  genvar GENVAR_NAME;
+  generate
+    for (GENVAR_NAME = 0; GENVAR_NAME < 1; GENVAR_NAME++) begin : gen_loop
+      logic unused_loop;
+    end
+  endgenerate
+
+  // Typedef: should not warn
+  logic typedef_name;
+  typedef logic TYPEDEF_NAME;
+
+  // Enum item: should not warn
+  logic enum_item;
+  typedef enum logic {ENUM_ITEM} enum_t;
+
+  // Struct member: should not warn
+  typedef struct packed {logic member_name; logic MEMBER_NAME;} memb_t;
+  memb_t memb;
+
+  // Property and sequence: should not warn
+  logic prop_name, seq_name;
+  property PROP_NAME; @(posedge i) prop_name; endproperty
+  sequence SEQ_NAME; @(posedge i) seq_name; endsequence
+
+  // Clocking block: should not warn
+  logic clock_name;
+  clocking CLOCK_NAME @(posedge i); input clock_name; endclocking
+
+  // Modport: should not warn
+  Ifc ifc ();
+
+  // Randsequence production: should not warn
+  logic rs_name;
   initial begin
-    width = WIDTH[WIDTH-1:0];
-    reg_ctrl = REG_CTRL;
-    size = {SIZE{1'b0}};
-    if (width !== 8'd8) $stop;
-    if (reg_ctrl !== 8'h00) $stop;
-    if (size !== {SIZE{1'b0}}) $stop;
-    $finish;
+    randsequence (rs_main)
+      rs_main : rs_prod RS_PROD;
+      rs_prod : {
+        rs_name = 1'b0;
+      };
+      RS_PROD : {
+        rs_name = 1'b0;
+      };
+    endsequence
   end
 
+  // All ordered crosses of {var, net, genblock, begin, fork, task, function,
+  // instance}: should warn
+
+  // var/var
+  logic var_var;
+  logic VAR_VAR;
+
+  // var/net
+  logic var_net;
+  wire VAR_NET;
+
+  // var/genblock
+  logic var_genblock;
+  if (1) begin : VAR_GENBLOCK
+  end
+
+  // var/begin
+  logic var_begin;
+  initial begin : VAR_BEGIN
+  end
+
+  // var/fork
+  logic var_fork;
+  initial fork : VAR_FORK
+  join
+
+  // var/task
+  logic var_task;
+  task automatic VAR_TASK(); endtask
+
+  // var/function
+  logic var_function;
+  function automatic bit VAR_FUNCTION(); return 1'b0; endfunction
+
+  // var/instance
+  logic var_instance;
+  sub VAR_INSTANCE ();
+
+  // net/var
+  wire net_var;
+  logic NET_VAR;
+
+  // net/net
+  wire net_net;
+  wire NET_NET;
+
+  // net/genblock
+  wire net_genblock;
+  if (1) begin : NET_GENBLOCK
+  end
+
+  // net/begin
+  wire net_begin;
+  initial begin : NET_BEGIN
+  end
+
+  // net/fork
+  wire net_fork;
+  initial fork : NET_FORK
+  join
+
+  // net/task
+  wire net_task;
+  task automatic NET_TASK(); endtask
+
+  // net/function
+  wire net_function;
+  function automatic bit NET_FUNCTION(); return 1'b0; endfunction
+
+  // net/instance
+  wire net_instance;
+  sub NET_INSTANCE ();
+
+  // genblock/var
+  if (1) begin : genblock_var
+  end
+  logic GENBLOCK_VAR;
+
+  // genblock/net
+  if (1) begin : genblock_net
+  end
+  wire GENBLOCK_NET;
+
+  // genblock/genblock
+  if (1) begin : genblock_genblock
+  end
+  if (1) begin : GENBLOCK_GENBLOCK
+  end
+
+  // genblock/begin
+  if (1) begin : genblock_begin
+  end
+  initial begin : GENBLOCK_BEGIN
+  end
+
+  // genblock/fork
+  if (1) begin : genblock_fork
+  end
+  initial fork : GENBLOCK_FORK
+  join
+
+  // genblock/task
+  if (1) begin : genblock_task
+  end
+  task automatic GENBLOCK_TASK(); endtask
+
+  // genblock/function
+  if (1) begin : genblock_function
+  end
+  function automatic bit GENBLOCK_FUNCTION(); return 1'b0; endfunction
+
+  // genblock/instance
+  if (1) begin : genblock_instance
+  end
+  sub GENBLOCK_INSTANCE ();
+
+  // begin/var
+  initial begin : begin_var
+  end
+  logic BEGIN_VAR;
+
+  // begin/net
+  initial begin : begin_net
+  end
+  wire BEGIN_NET;
+
+  // begin/genblock
+  initial begin : begin_genblock
+  end
+  if (1) begin : BEGIN_GENBLOCK
+  end
+
+  // begin/begin
+  initial begin : begin_begin
+  end
+  initial begin : BEGIN_BEGIN
+  end
+
+  // begin/fork
+  initial begin : begin_fork
+  end
+  initial fork : BEGIN_FORK
+  join
+
+  // begin/task
+  initial begin : begin_task
+  end
+  task automatic BEGIN_TASK(); endtask
+
+  // begin/function
+  initial begin : begin_function
+  end
+  function automatic bit BEGIN_FUNCTION(); return 1'b0; endfunction
+
+  // begin/instance
+  initial begin : begin_instance
+  end
+  sub BEGIN_INSTANCE ();
+
+  // fork/var
+  initial fork : fork_var
+  join
+  logic FORK_VAR;
+
+  // fork/net
+  initial fork : fork_net
+  join
+  wire FORK_NET;
+
+  // fork/genblock
+  initial fork : fork_genblock
+  join
+  if (1) begin : FORK_GENBLOCK
+  end
+
+  // fork/begin
+  initial fork : fork_begin
+  join
+  initial begin : FORK_BEGIN
+  end
+
+  // fork/fork
+  initial fork : fork_fork
+  join
+  initial fork : FORK_FORK
+  join
+
+  // fork/task
+  initial fork : fork_task
+  join
+  task automatic FORK_TASK(); endtask
+
+  // fork/function
+  initial fork : fork_function
+  join
+  function automatic bit FORK_FUNCTION(); return 1'b0; endfunction
+
+  // fork/instance
+  initial fork : fork_instance
+  join
+  sub FORK_INSTANCE ();
+
+  // task/var
+  task automatic task_var(); endtask
+  logic TASK_VAR;
+
+  // task/net
+  task automatic task_net(); endtask
+  wire TASK_NET;
+
+  // task/genblock
+  task automatic task_genblock(); endtask
+  if (1) begin : TASK_GENBLOCK
+  end
+
+  // task/begin
+  task automatic task_begin(); endtask
+  initial begin : TASK_BEGIN
+  end
+
+  // task/fork
+  task automatic task_fork(); endtask
+  initial fork : TASK_FORK
+  join
+
+  // task/task
+  task automatic task_task(); endtask
+  task automatic TASK_TASK(); endtask
+
+  // task/function
+  task automatic task_function(); endtask
+  function automatic bit TASK_FUNCTION(); return 1'b0; endfunction
+
+  // task/instance
+  task automatic task_instance(); endtask
+  sub TASK_INSTANCE ();
+
+  // function/var
+  function automatic bit function_var(); return 1'b0; endfunction
+  logic FUNCTION_VAR;
+
+  // function/net
+  function automatic bit function_net(); return 1'b0; endfunction
+  wire FUNCTION_NET;
+
+  // function/genblock
+  function automatic bit function_genblock(); return 1'b0; endfunction
+  if (1) begin : FUNCTION_GENBLOCK
+  end
+
+  // function/begin
+  function automatic bit function_begin(); return 1'b0; endfunction
+  initial begin : FUNCTION_BEGIN
+  end
+
+  // function/fork
+  function automatic bit function_fork(); return 1'b0; endfunction
+  initial fork : FUNCTION_FORK
+  join
+
+  // function/task
+  function automatic bit function_task(); return 1'b0; endfunction
+  task automatic FUNCTION_TASK(); endtask
+
+  // function/function
+  function automatic bit function_function(); return 1'b0; endfunction
+  function automatic bit FUNCTION_FUNCTION(); return 1'b0; endfunction
+
+  // function/instance
+  function automatic bit function_instance(); return 1'b0; endfunction
+  sub FUNCTION_INSTANCE ();
+
+  // instance/var
+  sub instance_var ();
+  logic INSTANCE_VAR;
+
+  // instance/net
+  sub instance_net ();
+  wire INSTANCE_NET;
+
+  // instance/genblock
+  sub instance_genblock ();
+  if (1) begin : INSTANCE_GENBLOCK
+  end
+
+  // instance/begin
+  sub instance_begin ();
+  initial begin : INSTANCE_BEGIN
+  end
+
+  // instance/fork
+  sub instance_fork ();
+  initial fork : INSTANCE_FORK
+  join
+
+  // instance/task
+  sub instance_task ();
+  task automatic INSTANCE_TASK(); endtask
+
+  // instance/function
+  sub instance_function ();
+  function automatic bit INSTANCE_FUNCTION(); return 1'b0; endfunction
+
+  // instance/instance
+  sub instance_instance ();
+  sub INSTANCE_INSTANCE ();
+
+  // Unchecked declaration sorting first must not be reported as the original
+  localparam int SORTS_FIRST = 1;
+  logic [SORTS_FIRST-1:0] Sorts_First;
+  logic [SORTS_FIRST-1:0] sorts_first;
+
 endmodule
+
+module sub;
+endmodule
+
+interface Ifc;
+  logic modport_name;
+  modport MODPORT_NAME (input modport_name);
+endinterface
+
+// Constraint: should not warn
+class Cls;
+  rand int constraint_name;
+  constraint CONSTRAINT_NAME {constraint_name > 0;}
+endclass
 
 package pkg;
   localparam logic [7:0] REG_CTRL = 8'h00;

--- a/test_regress/t/t_lint_similarname_bad.out
+++ b/test_regress/t/t_lint_similarname_bad.out
@@ -6,4 +6,394 @@
       |       ^
                       ... For warning description see https://verilator.org/warn/SIMILARNAME?v=latest
                       ... Use "/* verilator lint_off SIMILARNAME */" and lint_on around source to disable this message.
+%Warning-SIMILARNAME: t/t_lint_similarname.v:75:9: Declaration overlaps another with different case: 'VAR_VAR'
+   75 |   logic VAR_VAR;
+      |         ^~~~~~~
+                      t/t_lint_similarname.v:74:9: ... Location of original declaration
+   74 |   logic var_var;
+      |         ^~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:79:8: Declaration overlaps another with different case: 'VAR_NET'
+   79 |   wire VAR_NET;
+      |        ^~~~~~~
+                      t/t_lint_similarname.v:78:9: ... Location of original declaration
+   78 |   logic var_net;
+      |         ^~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:83:18: Declaration overlaps another with different case: 'VAR_GENBLOCK'
+   83 |   if (1) begin : VAR_GENBLOCK
+      |                  ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:82:9: ... Location of original declaration
+   82 |   logic var_genblock;
+      |         ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:88:11: Declaration overlaps another with different case: 'VAR_BEGIN'
+   88 |   initial begin : VAR_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:87:9: ... Location of original declaration
+   87 |   logic var_begin;
+      |         ^~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:93:11: Declaration overlaps another with different case: 'VAR_FORK'
+   93 |   initial fork : VAR_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:92:9: ... Location of original declaration
+   92 |   logic var_fork;
+      |         ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:98:18: Declaration overlaps another with different case: 'VAR_TASK'
+   98 |   task automatic VAR_TASK(); endtask
+      |                  ^~~~~~~~
+                      t/t_lint_similarname.v:97:9: ... Location of original declaration
+   97 |   logic var_task;
+      |         ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:102:26: Declaration overlaps another with different case: 'VAR_FUNCTION'
+  102 |   function automatic bit VAR_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:101:9: ... Location of original declaration
+  101 |   logic var_function;
+      |         ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:106:7: Declaration overlaps another with different case: 'VAR_INSTANCE'
+  106 |   sub VAR_INSTANCE ();
+      |       ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:105:9: ... Location of original declaration
+  105 |   logic var_instance;
+      |         ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:110:9: Declaration overlaps another with different case: 'NET_VAR'
+  110 |   logic NET_VAR;
+      |         ^~~~~~~
+                      t/t_lint_similarname.v:109:8: ... Location of original declaration
+  109 |   wire net_var;
+      |        ^~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:114:8: Declaration overlaps another with different case: 'NET_NET'
+  114 |   wire NET_NET;
+      |        ^~~~~~~
+                      t/t_lint_similarname.v:113:8: ... Location of original declaration
+  113 |   wire net_net;
+      |        ^~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:118:18: Declaration overlaps another with different case: 'NET_GENBLOCK'
+  118 |   if (1) begin : NET_GENBLOCK
+      |                  ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:117:8: ... Location of original declaration
+  117 |   wire net_genblock;
+      |        ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:123:11: Declaration overlaps another with different case: 'NET_BEGIN'
+  123 |   initial begin : NET_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:122:8: ... Location of original declaration
+  122 |   wire net_begin;
+      |        ^~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:128:11: Declaration overlaps another with different case: 'NET_FORK'
+  128 |   initial fork : NET_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:127:8: ... Location of original declaration
+  127 |   wire net_fork;
+      |        ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:133:18: Declaration overlaps another with different case: 'NET_TASK'
+  133 |   task automatic NET_TASK(); endtask
+      |                  ^~~~~~~~
+                      t/t_lint_similarname.v:132:8: ... Location of original declaration
+  132 |   wire net_task;
+      |        ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:137:26: Declaration overlaps another with different case: 'NET_FUNCTION'
+  137 |   function automatic bit NET_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:136:8: ... Location of original declaration
+  136 |   wire net_function;
+      |        ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:141:7: Declaration overlaps another with different case: 'NET_INSTANCE'
+  141 |   sub NET_INSTANCE ();
+      |       ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:140:8: ... Location of original declaration
+  140 |   wire net_instance;
+      |        ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:146:9: Declaration overlaps another with different case: 'GENBLOCK_VAR'
+  146 |   logic GENBLOCK_VAR;
+      |         ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:144:18: ... Location of original declaration
+  144 |   if (1) begin : genblock_var
+      |                  ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:151:8: Declaration overlaps another with different case: 'GENBLOCK_NET'
+  151 |   wire GENBLOCK_NET;
+      |        ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:149:18: ... Location of original declaration
+  149 |   if (1) begin : genblock_net
+      |                  ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:156:18: Declaration overlaps another with different case: 'GENBLOCK_GENBLOCK'
+  156 |   if (1) begin : GENBLOCK_GENBLOCK
+      |                  ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:154:18: ... Location of original declaration
+  154 |   if (1) begin : genblock_genblock
+      |                  ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:162:11: Declaration overlaps another with different case: 'GENBLOCK_BEGIN'
+  162 |   initial begin : GENBLOCK_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:160:18: ... Location of original declaration
+  160 |   if (1) begin : genblock_begin
+      |                  ^~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:168:11: Declaration overlaps another with different case: 'GENBLOCK_FORK'
+  168 |   initial fork : GENBLOCK_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:166:18: ... Location of original declaration
+  166 |   if (1) begin : genblock_fork
+      |                  ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:174:18: Declaration overlaps another with different case: 'GENBLOCK_TASK'
+  174 |   task automatic GENBLOCK_TASK(); endtask
+      |                  ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:172:18: ... Location of original declaration
+  172 |   if (1) begin : genblock_task
+      |                  ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:179:26: Declaration overlaps another with different case: 'GENBLOCK_FUNCTION'
+  179 |   function automatic bit GENBLOCK_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:177:18: ... Location of original declaration
+  177 |   if (1) begin : genblock_function
+      |                  ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:184:7: Declaration overlaps another with different case: 'GENBLOCK_INSTANCE'
+  184 |   sub GENBLOCK_INSTANCE ();
+      |       ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:182:18: ... Location of original declaration
+  182 |   if (1) begin : genblock_instance
+      |                  ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:189:9: Declaration overlaps another with different case: 'BEGIN_VAR'
+  189 |   logic BEGIN_VAR;
+      |         ^~~~~~~~~
+                      t/t_lint_similarname.v:187:11: ... Location of original declaration
+  187 |   initial begin : begin_var
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:194:8: Declaration overlaps another with different case: 'BEGIN_NET'
+  194 |   wire BEGIN_NET;
+      |        ^~~~~~~~~
+                      t/t_lint_similarname.v:192:11: ... Location of original declaration
+  192 |   initial begin : begin_net
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:199:18: Declaration overlaps another with different case: 'BEGIN_GENBLOCK'
+  199 |   if (1) begin : BEGIN_GENBLOCK
+      |                  ^~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:197:11: ... Location of original declaration
+  197 |   initial begin : begin_genblock
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:205:11: Declaration overlaps another with different case: 'BEGIN_BEGIN'
+  205 |   initial begin : BEGIN_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:203:11: ... Location of original declaration
+  203 |   initial begin : begin_begin
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:211:11: Declaration overlaps another with different case: 'BEGIN_FORK'
+  211 |   initial fork : BEGIN_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:209:11: ... Location of original declaration
+  209 |   initial begin : begin_fork
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:217:18: Declaration overlaps another with different case: 'BEGIN_TASK'
+  217 |   task automatic BEGIN_TASK(); endtask
+      |                  ^~~~~~~~~~
+                      t/t_lint_similarname.v:215:11: ... Location of original declaration
+  215 |   initial begin : begin_task
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:222:26: Declaration overlaps another with different case: 'BEGIN_FUNCTION'
+  222 |   function automatic bit BEGIN_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:220:11: ... Location of original declaration
+  220 |   initial begin : begin_function
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:227:7: Declaration overlaps another with different case: 'BEGIN_INSTANCE'
+  227 |   sub BEGIN_INSTANCE ();
+      |       ^~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:225:11: ... Location of original declaration
+  225 |   initial begin : begin_instance
+      |           ^~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:232:9: Declaration overlaps another with different case: 'FORK_VAR'
+  232 |   logic FORK_VAR;
+      |         ^~~~~~~~
+                      t/t_lint_similarname.v:230:11: ... Location of original declaration
+  230 |   initial fork : fork_var
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:237:8: Declaration overlaps another with different case: 'FORK_NET'
+  237 |   wire FORK_NET;
+      |        ^~~~~~~~
+                      t/t_lint_similarname.v:235:11: ... Location of original declaration
+  235 |   initial fork : fork_net
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:242:18: Declaration overlaps another with different case: 'FORK_GENBLOCK'
+  242 |   if (1) begin : FORK_GENBLOCK
+      |                  ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:240:11: ... Location of original declaration
+  240 |   initial fork : fork_genblock
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:248:11: Declaration overlaps another with different case: 'FORK_BEGIN'
+  248 |   initial begin : FORK_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:246:11: ... Location of original declaration
+  246 |   initial fork : fork_begin
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:254:11: Declaration overlaps another with different case: 'FORK_FORK'
+  254 |   initial fork : FORK_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:252:11: ... Location of original declaration
+  252 |   initial fork : fork_fork
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:260:18: Declaration overlaps another with different case: 'FORK_TASK'
+  260 |   task automatic FORK_TASK(); endtask
+      |                  ^~~~~~~~~
+                      t/t_lint_similarname.v:258:11: ... Location of original declaration
+  258 |   initial fork : fork_task
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:265:26: Declaration overlaps another with different case: 'FORK_FUNCTION'
+  265 |   function automatic bit FORK_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:263:11: ... Location of original declaration
+  263 |   initial fork : fork_function
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:270:7: Declaration overlaps another with different case: 'FORK_INSTANCE'
+  270 |   sub FORK_INSTANCE ();
+      |       ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:268:11: ... Location of original declaration
+  268 |   initial fork : fork_instance
+      |           ^~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:274:9: Declaration overlaps another with different case: 'TASK_VAR'
+  274 |   logic TASK_VAR;
+      |         ^~~~~~~~
+                      t/t_lint_similarname.v:273:18: ... Location of original declaration
+  273 |   task automatic task_var(); endtask
+      |                  ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:278:8: Declaration overlaps another with different case: 'TASK_NET'
+  278 |   wire TASK_NET;
+      |        ^~~~~~~~
+                      t/t_lint_similarname.v:277:18: ... Location of original declaration
+  277 |   task automatic task_net(); endtask
+      |                  ^~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:282:18: Declaration overlaps another with different case: 'TASK_GENBLOCK'
+  282 |   if (1) begin : TASK_GENBLOCK
+      |                  ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:281:18: ... Location of original declaration
+  281 |   task automatic task_genblock(); endtask
+      |                  ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:287:11: Declaration overlaps another with different case: 'TASK_BEGIN'
+  287 |   initial begin : TASK_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:286:18: ... Location of original declaration
+  286 |   task automatic task_begin(); endtask
+      |                  ^~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:292:11: Declaration overlaps another with different case: 'TASK_FORK'
+  292 |   initial fork : TASK_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:291:18: ... Location of original declaration
+  291 |   task automatic task_fork(); endtask
+      |                  ^~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:297:18: Declaration overlaps another with different case: 'TASK_TASK'
+  297 |   task automatic TASK_TASK(); endtask
+      |                  ^~~~~~~~~
+                      t/t_lint_similarname.v:296:18: ... Location of original declaration
+  296 |   task automatic task_task(); endtask
+      |                  ^~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:301:26: Declaration overlaps another with different case: 'TASK_FUNCTION'
+  301 |   function automatic bit TASK_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:300:18: ... Location of original declaration
+  300 |   task automatic task_function(); endtask
+      |                  ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:305:7: Declaration overlaps another with different case: 'TASK_INSTANCE'
+  305 |   sub TASK_INSTANCE ();
+      |       ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:304:18: ... Location of original declaration
+  304 |   task automatic task_instance(); endtask
+      |                  ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:309:9: Declaration overlaps another with different case: 'FUNCTION_VAR'
+  309 |   logic FUNCTION_VAR;
+      |         ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:308:26: ... Location of original declaration
+  308 |   function automatic bit function_var(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:313:8: Declaration overlaps another with different case: 'FUNCTION_NET'
+  313 |   wire FUNCTION_NET;
+      |        ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:312:26: ... Location of original declaration
+  312 |   function automatic bit function_net(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:317:18: Declaration overlaps another with different case: 'FUNCTION_GENBLOCK'
+  317 |   if (1) begin : FUNCTION_GENBLOCK
+      |                  ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:316:26: ... Location of original declaration
+  316 |   function automatic bit function_genblock(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:322:11: Declaration overlaps another with different case: 'FUNCTION_BEGIN'
+  322 |   initial begin : FUNCTION_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:321:26: ... Location of original declaration
+  321 |   function automatic bit function_begin(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:327:11: Declaration overlaps another with different case: 'FUNCTION_FORK'
+  327 |   initial fork : FUNCTION_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:326:26: ... Location of original declaration
+  326 |   function automatic bit function_fork(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:332:18: Declaration overlaps another with different case: 'FUNCTION_TASK'
+  332 |   task automatic FUNCTION_TASK(); endtask
+      |                  ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:331:26: ... Location of original declaration
+  331 |   function automatic bit function_task(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:336:26: Declaration overlaps another with different case: 'FUNCTION_FUNCTION'
+  336 |   function automatic bit FUNCTION_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:335:26: ... Location of original declaration
+  335 |   function automatic bit function_function(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:340:7: Declaration overlaps another with different case: 'FUNCTION_INSTANCE'
+  340 |   sub FUNCTION_INSTANCE ();
+      |       ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:339:26: ... Location of original declaration
+  339 |   function automatic bit function_instance(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:344:9: Declaration overlaps another with different case: 'INSTANCE_VAR'
+  344 |   logic INSTANCE_VAR;
+      |         ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:343:7: ... Location of original declaration
+  343 |   sub instance_var ();
+      |       ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:348:8: Declaration overlaps another with different case: 'INSTANCE_NET'
+  348 |   wire INSTANCE_NET;
+      |        ^~~~~~~~~~~~
+                      t/t_lint_similarname.v:347:7: ... Location of original declaration
+  347 |   sub instance_net ();
+      |       ^~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:352:18: Declaration overlaps another with different case: 'INSTANCE_GENBLOCK'
+  352 |   if (1) begin : INSTANCE_GENBLOCK
+      |                  ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:351:7: ... Location of original declaration
+  351 |   sub instance_genblock ();
+      |       ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:357:11: Declaration overlaps another with different case: 'INSTANCE_BEGIN'
+  357 |   initial begin : INSTANCE_BEGIN
+      |           ^~~~~
+                      t/t_lint_similarname.v:356:7: ... Location of original declaration
+  356 |   sub instance_begin ();
+      |       ^~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:362:11: Declaration overlaps another with different case: 'INSTANCE_FORK'
+  362 |   initial fork : INSTANCE_FORK
+      |           ^~~~
+                      t/t_lint_similarname.v:361:7: ... Location of original declaration
+  361 |   sub instance_fork ();
+      |       ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:367:18: Declaration overlaps another with different case: 'INSTANCE_TASK'
+  367 |   task automatic INSTANCE_TASK(); endtask
+      |                  ^~~~~~~~~~~~~
+                      t/t_lint_similarname.v:366:7: ... Location of original declaration
+  366 |   sub instance_task ();
+      |       ^~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:371:26: Declaration overlaps another with different case: 'INSTANCE_FUNCTION'
+  371 |   function automatic bit INSTANCE_FUNCTION(); return 1'b0; endfunction
+      |                          ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:370:7: ... Location of original declaration
+  370 |   sub instance_function ();
+      |       ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:375:7: Declaration overlaps another with different case: 'INSTANCE_INSTANCE'
+  375 |   sub INSTANCE_INSTANCE ();
+      |       ^~~~~~~~~~~~~~~~~
+                      t/t_lint_similarname.v:374:7: ... Location of original declaration
+  374 |   sub instance_instance ();
+      |       ^~~~~~~~~~~~~~~~~
+%Warning-SIMILARNAME: t/t_lint_similarname.v:380:27: Declaration overlaps another with different case: 'sorts_first'
+  380 |   logic [SORTS_FIRST-1:0] sorts_first;
+      |                           ^~~~~~~~~~~
+                      t/t_lint_similarname.v:379:27: ... Location of original declaration
+  379 |   logic [SORTS_FIRST-1:0] Sorts_First;
+      |                           ^~~~~~~~~~~
 %Error: Exiting due to


### PR DESCRIPTION
Still used to warn on a bunch of exotic conflicts, like genvar conflicting with block name.

Turn the blacklist of things not to warn for into a whitelist of things to warn for (only nets and variables), add more tests.

---

@MoonbaseOtago could you please review the added test cases that are marked "should not warn". I think the only one we might still want is instance (cell) names. I'm happy to add back any that upsets the downstream tools, but there is a lot of legacy code out there so I think it would be best to pin down the minimal set we actually need.