### PR TITLE
Fix errors on stream connected to instance port

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -1057,7 +1057,7 @@ class WidthVisitor final : public VNVisitor {
             if (!streamImplicitUseAllowed(nodep)) {
                 nodep->v3error(
                     "Streaming concatenation cannot be used in an implicitly cast context "
-                    "(IEEE 1800-2023 11.4.17)\n"
+                    "(IEEE 1800-2023 11.4.14)\n"
                     << nodep->warnMore() << "... Suggest use a cast");
             }
             if (!nodep->dtypep()->widthSized()) {
@@ -7029,6 +7029,12 @@ class WidthVisitor final : public VNVisitor {
             }
             // Very much like like an assignment, but which side is LH/RHS
             // depends on pin being a in/output/inout.
+            const VDirection pinDirection = nodep->modVarp()->direction();
+            if (VN_IS(nodep->exprp(), NodeStream) && pinDirection.isInoutOrRef()) {
+                nodep->exprp()->v3error("Streaming concatenation cannot be connected to '"
+                                        << pinDirection.prettyName()
+                                        << "' port (IEEE 1800-2023 11.4.14)");
+            }
             userIterateAndNext(nodep->exprp(), WidthVP{nodep->modVarp()->dtypep(), PRELIM}.p());
             AstNodeDType* modDTypep = nodep->modVarp()->dtypep();
             AstNodeDType* conDTypep = nodep->exprp()->dtypep();
@@ -7041,7 +7047,8 @@ class WidthVisitor final : public VNVisitor {
             const int conwidth = conDTypep->width();
             if (conDTypep == modDTypep  // If match, we're golden
                 || similarDTypeRecurse(conDTypep, modDTypep)) {
-                userIterateAndNext(nodep->exprp(), WidthVP{subDTypep, FINAL}.p());
+                userIterateAndNext(nodep->exprp(),
+                                   WidthVP{subDTypep, FINAL, STREAM_USE_ASSIGN}.p());
             } else if (m_cellp->rangep()) {
                 const int numInsts = m_cellp->rangep()->elementsConst();
                 if (conwidth == modwidth) {
@@ -7062,7 +7069,8 @@ class WidthVisitor final : public VNVisitor {
                                    << " bits. (IEEE 1800-2023 23.3.3)");
                     subDTypep = conDTypep;  // = same expr dtype
                 }
-                userIterateAndNext(nodep->exprp(), WidthVP{subDTypep, FINAL}.p());
+                userIterateAndNext(nodep->exprp(),
+                                   WidthVP{subDTypep, FINAL, STREAM_USE_ASSIGN}.p());
             } else {
                 if (nodep->modVarp()->direction() == VDirection::REF) {
                     nodep->v3error("Ref connection "

--- a/test_regress/t/t_display_stream_bad.out
+++ b/test_regress/t/t_display_stream_bad.out
@@ -1,45 +1,45 @@
-%Error: t/t_display_stream_bad.v:19:15: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:19:15: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    19 |     result = {<<{value}} + 1;
       |               ^~
         ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
-%Error: t/t_display_stream_bad.v:20:23: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:20:23: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    20 |     result = value + {<<{value}};
       |                       ^~
-%Error: t/t_display_stream_bad.v:21:26: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:21:26: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    21 |     result = value[0] ? {<<{value}} : other;
       |                          ^~
-%Error: t/t_display_stream_bad.v:22:16: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:22:16: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    22 |     result = {{<<{value}}};
       |                ^~
-%Error: t/t_display_stream_bad.v:23:14: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:23:14: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    23 |     flag = ({<<{value}} == other);
       |              ^~
-%Error: t/t_display_stream_bad.v:24:15: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:24:15: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    24 |     $display({<<{value}});
       |               ^~
-%Error: t/t_display_stream_bad.v:25:22: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:25:22: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    25 |     $display("%0d", {<<{value}});
       |                      ^~
-%Error: t/t_display_stream_bad.v:26:29: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:26:29: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    26 |     void'($sformatf("%0d", {<<{value}}));
       |                             ^~
-%Error: t/t_display_stream_bad.v:27:27: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.17)
+%Error: t/t_display_stream_bad.v:27:27: Streaming concatenation cannot be used in an implicitly cast context (IEEE 1800-2023 11.4.14)
                                       : ... note: In instance 't'
                                       : ... Suggest use a cast
    27 |     result = passthrough({<<{value}} + 1);

--- a/test_regress/t/t_stream.v
+++ b/test_regress/t/t_stream.v
@@ -212,6 +212,19 @@ module t (
     dout_rhs_ls_q_37_4 = {<<4{din_q[36:0]}};  // FAST
   end
 
+  // Stream operator in module port connections (input and output pins)
+  logic [31:0] dout_pin_lr;  // Left-stream on input pin, right-stream on output pin
+  logic [31:0] dout_pin_rl;  // Right-stream on input pin, left-stream on output pin
+
+  t_stream_pass pin_lr (
+      .din ({<<{din_i}}),
+      .dout({>>{dout_pin_lr}})
+  );
+  t_stream_pass pin_rl (
+      .din ({>>{din_i}}),
+      .dout({<<{dout_pin_rl}})
+  );
+
   always @(posedge clk) begin
     if (cyc != 0) begin
       cyc <= cyc + 1;
@@ -257,6 +270,9 @@ module t (
 
         if (dout_rhs_ls_q_37_3 != 37'h04_00_00_00_00) $stop;
         if (dout_rhs_ls_q_37_4 != 37'h02_00_00_00_00) $stop;
+
+        if (dout_pin_lr != 32'h80_00_00_00) $stop;
+        if (dout_pin_rl != 32'h80_00_00_00) $stop;
       end
       if (cyc == 3) begin
         // The values below test the strange shift-merge done at the end of
@@ -292,6 +308,9 @@ module t (
 
         if (dout_rhs_ls_q_37_3 != 37'h04_02_30_10_44) $stop;
         if (dout_rhs_ls_q_37_4 != 37'h02_04_06_08_0a) $stop;
+
+        if (dout_pin_lr != 32'h80_40_c0_20) $stop;
+        if (dout_pin_rl != 32'h80_40_c0_20) $stop;
       end
       if (cyc == 4) begin
         if (dout_rhs_ls_i_23_3 != 23'h7f_ff_ff) $stop;
@@ -307,4 +326,11 @@ module t (
     end
   end
 
+endmodule
+
+module t_stream_pass (
+    input  logic [31:0] din,
+    output logic [31:0] dout
+);
+  assign dout = din;
 endmodule

--- a/test_regress/t/t_stream_bad.out
+++ b/test_regress/t/t_stream_bad.out
@@ -15,4 +15,12 @@
                               : ... note: In instance 't'
    15 |     packed_data_32 = {<<x{byte_in}};
       |                       ^~
+%Error: t/t_stream_bad.v:20:31: Streaming concatenation cannot be connected to 'inout' port (IEEE 1800-2023 11.4.14)
+                              : ... note: In instance 't'
+   20 |   sub_inout i_sub_inout (.io({>>{io_bus}}));
+      |                               ^~
+%Error: t/t_stream_bad.v:25:26: Streaming concatenation cannot be connected to 'ref' port (IEEE 1800-2023 11.4.14)
+                              : ... note: In instance 't'
+   25 |   sub_ref i_sub_ref (.r({>>{ref_var}}));
+      |                          ^~
 %Error: Exiting due to

--- a/test_regress/t/t_stream_bad.v
+++ b/test_regress/t/t_stream_bad.v
@@ -15,4 +15,23 @@ module t;
     packed_data_32 = {<<x{byte_in}};
   end
 
+  // An inout port connection is not an assignment, so a stream is not valid
+  wire [31:0] io_bus;
+  sub_inout i_sub_inout (.io({>>{io_bus}}));
+
+  // A ref port connection is a hierarchical reference, not an assignment,
+  // so a stream is not valid
+  logic [31:0] ref_var;
+  sub_ref i_sub_ref (.r({>>{ref_var}}));
+
+endmodule
+
+module sub_inout (
+    inout wire [31:0] io
+);
+endmodule
+
+module sub_ref (
+    ref logic [31:0] r
+);
 endmodule


### PR DESCRIPTION
Connecting a stream to an `input` or `output` port is legal (used to incorrectly error).

Connecting a stream to an `inout` or `ref` is not legal, add explicit error.

Also fix LRM section reference.