### PR TITLE
Fix VL_MULS_* UB on signed int overflow (#8247).

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -245,6 +245,7 @@ Patrick Creighton
 Patrick Stewart
 Paul Bowen-Huggett
 Paul Campbell
+Paul Rigge
 Paul Swirhun
 Paul Wright
 Pawel Jewstafjew

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -1194,12 +1194,14 @@ inline WDataOutP VL_MUL_W(int words, WDataOutP owp, WDataInP const lwp,
 inline IData VL_MULS_III(int lbits, IData lhs, IData rhs) VL_PURE {
     const int32_t lhs_signed = VL_EXTENDS_II(32, lbits, lhs);
     const int32_t rhs_signed = VL_EXTENDS_II(32, lbits, rhs);
-    return lhs_signed * rhs_signed;
+    // Signed int overflow is undefined behavior, so cast to unsigned first.
+    return static_cast<uint32_t>(lhs_signed) * static_cast<uint32_t>(rhs_signed);
 }
 inline QData VL_MULS_QQQ(int lbits, QData lhs, QData rhs) VL_PURE {
     const int64_t lhs_signed = VL_EXTENDS_QQ(64, lbits, lhs);
     const int64_t rhs_signed = VL_EXTENDS_QQ(64, lbits, rhs);
-    return lhs_signed * rhs_signed;
+    // Signed int overflow is undefined behavior, so cast to unsigned first.
+    return static_cast<uint64_t>(lhs_signed) * static_cast<uint64_t>(rhs_signed);
 }
 
 inline WDataOutP VL_MULS_WWW(int lbits, WDataOutP owp, WDataInP lwp, WDataInP rwp) VL_MT_SAFE {


### PR DESCRIPTION
These multiplies were performed on signed ints, so if they overflow it is UB. This is mostly a problem when running with sanitizers like ubsan. Casting to unsigned ints before the multiply produces the same result without the UB.

