### PR TITLE
Fix param dependent param types

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -1485,58 +1485,7 @@ class ParamProcessor final {
                         cloneVarp->childDTypep(origDTypep->cloneTree(false));
                         cloneVarp->dtypep(nullptr);
                         // Inline param refs so widthing doesn't touch the template (#7411).
-                        constexpr int maxSubstIters = 1000;
-                        for (int it = 0; it < maxSubstIters; ++it) {
-                            bool any = false;
-                            cloneVarp->foreach([&](AstVarRef* varrefp) {
-                                AstVar* const targetp = varrefp->varp();
-                                AstNode* replacep = nullptr;
-                                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                                    if (pp->modVarp() == targetp) {
-                                        if (AstConst* const constp = VN_CAST(pp->exprp(), Const)) {
-                                            replacep = constp->cloneTree(false);
-                                        }
-                                        break;
-                                    }
-                                }
-                                if (!replacep && targetp->valuep()) {
-                                    replacep = targetp->valuep()->cloneTree(false);
-                                }
-                                if (replacep) {
-                                    varrefp->replaceWith(replacep);
-                                    VL_DO_DANGLING(varrefp->deleteTree(), varrefp);
-                                    any = true;
-                                }
-                            });
-                            // Replace RefDType to a ParamTypeDType with pin override
-                            // or the paramtype's default so constify below does not
-                            // reach into the template.  Collect then replace in
-                            // reverse so descendants aren't freed early.
-                            std::vector<std::pair<AstRefDType*, AstNodeDType*>> toReplace;
-                            cloneVarp->foreach([&](AstRefDType* refp) {
-                                AstParamTypeDType* const ptdp
-                                    = VN_CAST(refp->refDTypep(), ParamTypeDType);
-                                if (!ptdp) return;
-                                AstPin* overridePinp = nullptr;
-                                for (AstPin* pp = paramsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                                    if (pp->modPTypep() == ptdp) {
-                                        overridePinp = pp;
-                                        break;
-                                    }
-                                }
-                                AstNodeDType* const substp
-                                    = overridePinp ? VN_CAST(overridePinp->exprp(), NodeDType)
-                                                   : ptdp->subDTypep();
-                                if (substp) toReplace.emplace_back(refp, substp);
-                            });
-                            for (auto it = toReplace.rbegin(); it != toReplace.rend(); ++it) {
-                                AstRefDType* const refp = it->first;
-                                refp->replaceWith(it->second->cloneTree(false));
-                                VL_DO_DANGLING(refp->deleteTree(), refp);
-                                any = true;
-                            }
-                            if (!any) break;
-                        }
+                        V3Param::substituteParams(cloneVarp, paramsp);
                         // Bail if anything still points at the template.
                         cloneVarp->foreach([&](AstVarRef* varrefp) {
                             varrefp->v3fatalSrc(
@@ -3560,6 +3509,100 @@ public:
 };
 
 //######################################################################
+// Substitute an instance's parameter overrides into a detached clone (IEEE 1800-2023 23.10.3)
+
+class ParamSubstVisitor final {
+    std::map<const AstVar*, const AstPin*> m_pinMap;  // Parameter var -> overriding pin
+    std::map<const AstParamTypeDType*, const AstPin*> m_ptypeMap;  // Type param -> overriding pin
+    std::map<const AstVar*, AstNode*> m_valueCache;  // Parameter var -> resolved value (or null)
+    std::set<const AstVar*> m_inProgress;  // Parameters currently being resolved (cycle guard)
+
+    // Resolve one parameter to its per-instance value, or null if it can't be folded here
+    AstNode* paramValuep(AstVar* varp) {
+        const auto it = m_valueCache.find(varp);
+        if (it != m_valueCache.end()) return it->second;
+        // Bail on self reference
+        if (!m_inProgress.emplace(varp).second) return nullptr;
+        const auto pinIt = m_pinMap.find(varp);
+        AstNode* const sourcep = pinIt != m_pinMap.end() ? pinIt->second->exprp() : varp->valuep();
+        AstNode* valuep = nullptr;
+        if (sourcep) {
+            AstVar* const holderp
+                = new AstVar{varp->fileline(), VVarType::MODULETEMP, "__Vpinparam",
+                             VFlagChildDType{}, varp->subDTypep()->cloneTree(false)};
+            holderp->valuep(sourcep->cloneTree(false));
+            substitute(holderp);
+            if (!holderp->exists([](const AstVarRef*) { return true; })) {
+                V3Const::constifyParamsNoWarnEdit(holderp);
+                AstNode* const foldedp = holderp->valuep();
+                // Unpacked array params fold to an InitArray, not a Const; keep either
+                if (VN_IS(foldedp, Const) || VN_IS(foldedp, InitArray)) {
+                    valuep = foldedp->unlinkFrBack();
+                }
+            }
+            VL_DO_DANGLING(holderp->deleteTree(), holderp);
+        }
+        m_inProgress.erase(varp);
+        m_valueCache.emplace(varp, valuep);
+        return valuep;
+    }
+
+    bool substituteTypes(AstNode* nodep) {
+        // Collect then replace in reverse so descendants aren't freed early
+        std::vector<std::pair<AstRefDType*, AstNodeDType*>> replacements;
+        nodep->foreach([this, &replacements](AstRefDType* refp) {
+            const AstParamTypeDType* const ptypep = VN_CAST(refp->refDTypep(), ParamTypeDType);
+            if (!ptypep) return;
+            const auto it = m_ptypeMap.find(ptypep);
+            AstNodeDType* const substp = it != m_ptypeMap.end()
+                                             ? VN_CAST(it->second->exprp(), NodeDType)
+                                             : ptypep->subDTypep();
+            if (substp) replacements.emplace_back(refp, substp);
+        });
+        for (auto it = replacements.rbegin(); it != replacements.rend(); ++it) {
+            AstRefDType* const refp = it->first;
+            refp->replaceWith(it->second->cloneTree(false));
+            VL_DO_DANGLING(refp->deleteTree(), refp);
+        }
+        return !replacements.empty();
+    }
+
+public:
+    void substitute(AstNode* nodep) {
+        // A type param's default can expand to refs to value params, so re-run to a fixpoint
+        constexpr int maxSubstIters = 1000;
+        for (int it = 0; it < maxSubstIters; ++it) {
+            bool any = false;
+            nodep->foreach([this, &any](AstVarRef* refp) {
+                AstVar* const targetp = refp->varp();
+                if (!targetp || !targetp->isGParam()) return;
+                AstNode* const valuep = paramValuep(targetp);
+                if (!valuep) return;
+                refp->replaceWith(valuep->cloneTree(false));
+                VL_DO_DANGLING(refp->deleteTree(), refp);
+                any = true;
+            });
+            if (substituteTypes(nodep)) any = true;
+            if (!any) break;
+        }
+    }
+
+    explicit ParamSubstVisitor(const AstPin* pinsp) {
+        for (const AstPin* pp = pinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
+            if (!pp->exprp()) continue;
+            if (pp->modVarp()) m_pinMap.emplace(pp->modVarp(), pp);
+            if (pp->modPTypep()) m_ptypeMap.emplace(pp->modPTypep(), pp);
+        }
+    }
+    ~ParamSubstVisitor() {
+        for (const auto& pair : m_valueCache) {
+            if (pair.second) pair.second->deleteTree();
+        }
+    }
+    VL_UNCOPYABLE(ParamSubstVisitor);
+};
+
+//######################################################################
 // Param class functions
 
 void V3Param::param(AstNetlist* rootp) {
@@ -3580,4 +3623,8 @@ void V3Param::finalizeDeferredParams(AstNetlist* rootp) {
         if (varp->valuep() && !VN_IS(varp->valuep(), Const)) V3Const::constifyParamsEdit(varp);
     }
     rootp->clearDeferredParamVarps();
+}
+
+void V3Param::substituteParams(AstNode* nodep, const AstPin* pinsp) {
+    ParamSubstVisitor{pinsp}.substitute(nodep);
 }

--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -3558,7 +3558,7 @@ class ParamSubstVisitor final {
                                              ? VN_CAST(it->second->exprp(), NodeDType)
                                              : ptypep->subDTypep();
             if (substp) replacements.emplace_back(refp, substp);
-        });
+        });  // LCOV_EXCL_LINE
         for (auto it = replacements.rbegin(); it != replacements.rend(); ++it) {
             AstRefDType* const refp = it->first;
             refp->replaceWith(it->second->cloneTree(false));

--- a/src/V3Param.h
+++ b/src/V3Param.h
@@ -21,6 +21,8 @@
 #include "verilatedos.h"
 
 class AstNetlist;
+class AstNode;
+class AstPin;
 
 //============================================================================
 
@@ -28,6 +30,7 @@ class V3Param final {
 public:
     static void param(AstNetlist* rootp) VL_MT_DISABLED;
     static void finalizeDeferredParams(AstNetlist* rootp) VL_MT_DISABLED;
+    static void substituteParams(AstNode* nodep, const AstPin* pinsp) VL_MT_DISABLED;
 };
 
 #endif  // Guard

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7022,6 +7022,42 @@ class WidthVisitor final : public VNVisitor {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
     }
+    static const AstCell* pinCellParamp(const AstPin* pinp) {
+        const AstNode* headp = pinp;
+        while (headp->backp() && headp->backp()->nextp() == headp) headp = headp->backp();
+        const AstCell* const cellp = VN_CAST(headp->backp(), Cell);
+        return cellp && cellp->paramsp() == headp ? cellp : nullptr;
+    }
+    static AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp, const AstCell* cellp) {
+        if (!templateDtp->exists(
+                [](const AstVarRef* refp) { return refp->varp() && refp->varp()->isGParam(); })) {
+            return nullptr;  // Not parameter dependent
+        }
+        AstNodeDType* const clonep = templateDtp->cloneTree(false);
+        // Hold under a temporary Var so edited nodes have a back pointer
+        AstVar* const holderp = new AstVar{templateDtp->fileline(), VVarType::MODULETEMP,
+                                           "__Vpindtype", VFlagChildDType{}, clonep};
+        holderp->foreach([cellp](AstVarRef* refp) {
+            AstVar* const targetp = refp->varp();
+            if (!targetp || !targetp->isGParam()) return;
+            AstNode* replacep = nullptr;
+            for (AstPin* pp = cellp->paramsp(); pp; pp = VN_AS(pp->nextp(), Pin)) {
+                if (pp->modVarp() == targetp) {
+                    if (pp->exprp()) replacep = pp->exprp()->cloneTree(false);
+                    break;
+                }
+            }
+            // Not overridden by this instance, so the default applies
+            if (!replacep && targetp->valuep()) replacep = targetp->valuep()->cloneTree(false);
+            if (!replacep) return;
+            refp->replaceWith(replacep);
+            VL_DO_DANGLING(refp->deleteTree(), refp);
+        });
+        AstNodeDType* const resultp = holderp->childDTypep();
+        resultp->unlinkFrBack();
+        VL_DO_DANGLING(holderp->deleteTree(), holderp);
+        return resultp;
+    }
     void visit(AstPin* nodep) override {
         // UINFOTREE(1, nodep, "", "PinPre");
         // TOP LEVEL NODE
@@ -7030,12 +7066,26 @@ class WidthVisitor final : public VNVisitor {
             bool didWidth = false;
             if (AstPattern* const patternp = VN_CAST(nodep->exprp(), Pattern)) {
                 const AstVar* const modVarp = nodep->modVarp();
-                // Convert BracketArrayDType
-                userIterate(modVarp->childDTypep(),
-                            WidthVP{SELF, BOTH}.p());  // May relink pointed to node
-                AstNodeDType* const setDtp = modVarp->childDTypep();
-                if (!patternp->childDTypep()) patternp->childDTypep(setDtp->cloneTree(false));
-                userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
+                AstNodeDType* instDtp = nullptr;
+                if (!patternp->childDTypep()) {
+                    if (const AstCell* const cellp = pinCellParamp(nodep)) {
+                        instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep(), cellp);
+                    }
+                }
+                if (instDtp) {
+                    // Hold under the Pattern so the type has a back pointer while widthed
+                    patternp->childDTypep(instDtp);
+                    // Convert BracketArrayDType
+                    userIterate(patternp->childDTypep(), WidthVP{SELF, BOTH}.p());
+                    userIterateChildren(nodep, WidthVP{patternp->childDTypep(), BOTH}.p());
+                } else {
+                    // Convert BracketArrayDType
+                    userIterate(modVarp->childDTypep(),
+                                WidthVP{SELF, BOTH}.p());  // May relink pointed to node
+                    AstNodeDType* const setDtp = modVarp->childDTypep();
+                    if (!patternp->childDTypep()) patternp->childDTypep(setDtp->cloneTree(false));
+                    userIterateChildren(nodep, WidthVP{setDtp, BOTH}.p());
+                }
                 didWidth = true;
             }
             if (!didWidth) userIterateChildren(nodep, WidthVP{SELF, BOTH}.p());

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -235,7 +235,10 @@ class WidthVisitor final : public VNVisitor {
     const AstCell* m_cellp = nullptr;  // Current cell for arrayed instantiations
     const AstPin* m_paramPinsp = nullptr;  // Parameter pin list of enclosing construct
     bool m_paramPinMapValid = false;  // m_paramPinMap is built for m_paramPinsp
+    const AstPin* m_paramPinMapBuiltFor = nullptr;  // Pins m_paramPinMap was built for
     std::map<const AstVar*, const AstPin*> m_paramPinMap;  // Parameter var -> overriding pin
+    // Type parameter -> overriding pin
+    std::map<const AstParamTypeDType*, const AstPin*> m_paramPinPTypeMap;
     const AstEnumItem* m_enumItemp = nullptr;  // Current enum item
     AstNodeFTask* m_ftaskp = nullptr;  // Current function/task
     AstClass* m_cgClassp = nullptr;  // Current covergroup class
@@ -279,20 +282,30 @@ class WidthVisitor final : public VNVisitor {
         WidthVisitor& m_visitor;
         const AstPin* const m_savedPinsp;
         const bool m_savedValid;
+        const AstPin* const m_savedBuiltFor;
+        // Swap the maps aside rather than copy them, as VL_RESTORER_CLEAR would.
+        std::map<const AstVar*, const AstPin*> m_savedMap;
+        std::map<const AstParamTypeDType*, const AstPin*> m_savedPTypeMap;
 
     public:
         ParamPinScope(WidthVisitor& visitor, const AstPin* pinsp)
             : m_visitor{visitor}
             , m_savedPinsp{visitor.m_paramPinsp}
-            , m_savedValid{visitor.m_paramPinMapValid} {
+            , m_savedValid{visitor.m_paramPinMapValid}
+            , m_savedBuiltFor{visitor.m_paramPinMapBuiltFor} {
+            m_savedMap.swap(visitor.m_paramPinMap);
+            m_savedPTypeMap.swap(visitor.m_paramPinPTypeMap);
             m_visitor.m_paramPinsp = pinsp;
             m_visitor.m_paramPinMapValid = false;
         }
         ~ParamPinScope() {
             m_visitor.m_paramPinsp = m_savedPinsp;
-            // If this scope built a map it clobbered any outer one, which must be rebuilt
-            m_visitor.m_paramPinMapValid = m_visitor.m_paramPinMapValid ? false : m_savedValid;
+            m_visitor.m_paramPinMapValid = m_savedValid;
+            m_visitor.m_paramPinMapBuiltFor = m_savedBuiltFor;
+            m_visitor.m_paramPinMap.swap(m_savedMap);
+            m_visitor.m_paramPinPTypeMap.swap(m_savedPTypeMap);
         }
+        VL_UNCOPYABLE(ParamPinScope);
     };
 
     static void packIfUnpacked(AstNodeExpr* const nodep) {
@@ -7056,35 +7069,98 @@ class WidthVisitor final : public VNVisitor {
         if (!m_paramPinMapValid) {
             m_paramPinMapValid = true;
             m_paramPinMap.clear();
+            m_paramPinPTypeMap.clear();
             for (const AstPin* pp = m_paramPinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                if (pp->modVarp() && pp->exprp()) m_paramPinMap.emplace(pp->modVarp(), pp);
+                if (!pp->exprp()) continue;
+                if (pp->modVarp()) m_paramPinMap.emplace(pp->modVarp(), pp);
+                if (pp->modPTypep()) m_paramPinPTypeMap.emplace(pp->modPTypep(), pp);
             }
+            m_paramPinMapBuiltFor = m_paramPinsp;
         }
+        UASSERT(m_paramPinMapBuiltFor == m_paramPinsp, "Parameter pin map not for current pins");
         return m_paramPinMap;
+    }
+    // Map each type parameter to the pin overriding it
+    const std::map<const AstParamTypeDType*, const AstPin*>& paramPinPTypeMap() {
+        paramPinMap();
+        return m_paramPinPTypeMap;
+    }
+    // Cache of parameter values already resolved for the current instance
+    using ParamValueMap = std::map<const AstVar*, AstNode*>;
+    AstNode* instanceParamValuep(AstVar* varp, ParamValueMap& cache,
+                                 std::set<const AstVar*>& inProgress) {
+        const auto it = cache.find(varp);
+        if (it != cache.end()) return it->second;
+        // Bail on self reference
+        if (!inProgress.emplace(varp).second) return nullptr;
+        const std::map<const AstVar*, const AstPin*>& pinMap = paramPinMap();
+        const auto pinIt = pinMap.find(varp);
+        AstNode* const sourcep = pinIt != pinMap.end() ? pinIt->second->exprp() : varp->valuep();
+        AstNode* valuep = nullptr;
+        if (sourcep) {
+            AstVar* const holderp
+                = new AstVar{varp->fileline(), VVarType::MODULETEMP, "__Vpinparam",
+                             VFlagChildDType{}, varp->subDTypep()->cloneTree(false)};
+            holderp->valuep(sourcep->cloneTree(false));
+            instanceParamSubst(holderp, cache, inProgress);
+            if (!holderp->exists([](const AstVarRef*) { return true; })) {
+                V3Const::constifyParamsNoWarnEdit(holderp);
+                valuep = VN_CAST(holderp->valuep(), Const);
+                if (valuep) valuep->unlinkFrBack();
+            }
+            VL_DO_DANGLING(holderp->deleteTree(), holderp);
+        }
+        inProgress.erase(varp);
+        cache.emplace(varp, valuep);
+        return valuep;
+    }
+    void instanceParamSubst(AstNode* nodep, ParamValueMap& cache,
+                            std::set<const AstVar*>& inProgress) {
+        nodep->foreach([this, &cache, &inProgress](AstVarRef* refp) {
+            AstVar* const targetp = refp->varp();
+            if (!targetp || !targetp->isGParam()) return;
+            AstNode* const valuep = instanceParamValuep(targetp, cache, inProgress);
+            if (!valuep) return;
+            refp->replaceWith(valuep->cloneTree(false));
+            VL_DO_DANGLING(refp->deleteTree(), refp);
+        });  // LCOV_EXCL_LINE
+        instanceParamTypeSubst(nodep);
+    }
+    void instanceParamTypeSubst(AstNode* nodep) {
+        // Collect then replace in reverse
+        std::vector<std::pair<AstRefDType*, AstNodeDType*>> replacements;
+        nodep->foreach([this, &replacements](AstRefDType* refp) {
+            const AstParamTypeDType* const ptypep = VN_CAST(refp->refDTypep(), ParamTypeDType);
+            if (!ptypep) return;
+            const std::map<const AstParamTypeDType*, const AstPin*>& pinMap = paramPinPTypeMap();
+            const auto it = pinMap.find(ptypep);
+            AstNodeDType* const substp = it != pinMap.end()
+                                             ? VN_CAST(it->second->exprp(), NodeDType)
+                                             : ptypep->subDTypep();
+            if (substp) replacements.emplace_back(refp, substp);
+        });
+        for (auto it = replacements.rbegin(); it != replacements.rend(); ++it) {
+            AstRefDType* const refp = it->first;
+            refp->replaceWith(it->second->cloneTree(false));
+            VL_DO_DANGLING(refp->deleteTree(), refp);
+        }
     }
     // Copy a parameter's data type with this instance's parameter overrides substituted in
     AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp) {
         if (!templateDtp->exists(
                 [](const AstVarRef* refp) { return refp->varp() && refp->varp()->isGParam(); })) {
-            return nullptr;  // Not parameter dependent
+            return nullptr;
         }
-        const std::map<const AstVar*, const AstPin*>& pinMap = paramPinMap();
         AstNodeDType* const clonep = templateDtp->cloneTree(false);
         // Hold under a temporary Var so edited nodes have a back pointer
         AstVar* const holderp = new AstVar{templateDtp->fileline(), VVarType::MODULETEMP,
                                            "__Vpindtype", VFlagChildDType{}, clonep};
-        holderp->foreach([&pinMap](AstVarRef* refp) {
-            const AstVar* const targetp = refp->varp();
-            if (!targetp || !targetp->isGParam()) return;
-            AstNode* replacep = nullptr;
-            const auto it = pinMap.find(targetp);
-            if (it != pinMap.end()) replacep = it->second->exprp()->cloneTree(false);
-            // Not overridden by this instance, so the default applies
-            if (!replacep && targetp->valuep()) replacep = targetp->valuep()->cloneTree(false);
-            if (!replacep) return;
-            refp->replaceWith(replacep);
-            VL_DO_DANGLING(refp->deleteTree(), refp);
-        });  // LCOV_EXCL_LINE
+        ParamValueMap cache;
+        std::set<const AstVar*> inProgress;
+        instanceParamSubst(holderp, cache, inProgress);
+        for (const auto& pair : cache) {
+            if (pair.second) pair.second->deleteTree();
+        }
         AstNodeDType* const resultp = holderp->childDTypep();
         resultp->unlinkFrBack();
         VL_DO_DANGLING(holderp->deleteTree(), holderp);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -233,6 +233,9 @@ class WidthVisitor final : public VNVisitor {
     AstNode* m_seqUnsupp = nullptr;  // Property has unsupported node
     bool m_hasSExpr = false;  // Property has a sequence expression
     const AstCell* m_cellp = nullptr;  // Current cell for arrayed instantiations
+    const AstPin* m_paramPinsp = nullptr;  // Parameter pin list of enclosing construct
+    bool m_paramPinMapValid = false;  // m_paramPinMap is built for m_paramPinsp
+    std::map<const AstVar*, const AstPin*> m_paramPinMap;  // Parameter var -> overriding pin
     const AstEnumItem* m_enumItemp = nullptr;  // Current enum item
     AstNodeFTask* m_ftaskp = nullptr;  // Current function/task
     AstClass* m_cgClassp = nullptr;  // Current covergroup class
@@ -270,6 +273,27 @@ class WidthVisitor final : public VNVisitor {
     }
 
     StreamUse currentStreamUse() const { return m_vup ? m_vup->streamUse() : STREAM_USE_NONE; }
+
+    // Note the parameter pins of the construct being iterated, restoring on scope exit
+    class ParamPinScope final {
+        WidthVisitor& m_visitor;
+        const AstPin* const m_savedPinsp;
+        const bool m_savedValid;
+
+    public:
+        ParamPinScope(WidthVisitor& visitor, const AstPin* pinsp)
+            : m_visitor{visitor}
+            , m_savedPinsp{visitor.m_paramPinsp}
+            , m_savedValid{visitor.m_paramPinMapValid} {
+            m_visitor.m_paramPinsp = pinsp;
+            m_visitor.m_paramPinMapValid = false;
+        }
+        ~ParamPinScope() {
+            m_visitor.m_paramPinsp = m_savedPinsp;
+            // If this scope built a map it clobbered any outer one, which must be rebuilt
+            m_visitor.m_paramPinMapValid = m_visitor.m_paramPinMapValid ? false : m_savedValid;
+        }
+    };
 
     static void packIfUnpacked(AstNodeExpr* const nodep) {
         if (AstUnpackArrayDType* const unpackDTypep = VN_CAST(nodep->dtypep(), UnpackArrayDType)) {
@@ -2677,7 +2701,10 @@ class WidthVisitor final : public VNVisitor {
             // We had to use AstRefDType for this construct as pointers to this type
             // in type table are still correct (which they wouldn't be if we replaced the node)
         }
-        userIterateChildren(nodep, nullptr);
+        {
+            const ParamPinScope paramPins{*this, nodep->paramsp()};
+            userIterateChildren(nodep, nullptr);
+        }
         if (nodep->subDTypep()) {
             // Normally iterateEditMoveDTypep iterate would work, but the refs are under
             // the TypeDef which will upset iterateEditMoveDTypep as it can't find it under
@@ -3801,6 +3828,7 @@ class WidthVisitor final : public VNVisitor {
     void visit(AstIfaceRefDType* nodep) override {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5, "   IFACEREF " << nodep);
+        const ParamPinScope paramPins{*this, nodep->paramsp()};
         userIterateChildren(nodep, m_vup);
         nodep->dtypep(nodep);
         UINFO(4, "dtWidthed " << nodep);
@@ -3902,6 +3930,7 @@ class WidthVisitor final : public VNVisitor {
     }
     void visit(AstClassOrPackageRef* nodep) override {
         if (nodep->didWidthAndSet()) return;
+        const ParamPinScope paramPins{*this, nodep->paramsp()};
         userIterateChildren(nodep, nullptr);
     }
     void visit(AstDot* nodep) override {
@@ -7022,31 +7051,34 @@ class WidthVisitor final : public VNVisitor {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
     }
-    static const AstCell* pinCellParamp(const AstPin* pinp) {
-        const AstNode* headp = pinp;
-        while (headp->backp() && headp->backp()->nextp() == headp) headp = headp->backp();
-        const AstCell* const cellp = VN_CAST(headp->backp(), Cell);
-        return cellp && cellp->paramsp() == headp ? cellp : nullptr;
+    // Map each parameter to the pin overriding it, built once per parameter pin list
+    const std::map<const AstVar*, const AstPin*>& paramPinMap() {
+        if (!m_paramPinMapValid) {
+            m_paramPinMapValid = true;
+            m_paramPinMap.clear();
+            for (const AstPin* pp = m_paramPinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
+                if (pp->modVarp() && pp->exprp()) m_paramPinMap.emplace(pp->modVarp(), pp);
+            }
+        }
+        return m_paramPinMap;
     }
-    static AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp, const AstCell* cellp) {
+    // Copy a parameter's data type with this instance's parameter overrides substituted in
+    AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp) {
         if (!templateDtp->exists(
                 [](const AstVarRef* refp) { return refp->varp() && refp->varp()->isGParam(); })) {
             return nullptr;  // Not parameter dependent
         }
+        const std::map<const AstVar*, const AstPin*>& pinMap = paramPinMap();
         AstNodeDType* const clonep = templateDtp->cloneTree(false);
         // Hold under a temporary Var so edited nodes have a back pointer
         AstVar* const holderp = new AstVar{templateDtp->fileline(), VVarType::MODULETEMP,
                                            "__Vpindtype", VFlagChildDType{}, clonep};
-        holderp->foreach([cellp](AstVarRef* refp) {
-            AstVar* const targetp = refp->varp();
+        holderp->foreach([&pinMap](AstVarRef* refp) {
+            const AstVar* const targetp = refp->varp();
             if (!targetp || !targetp->isGParam()) return;
             AstNode* replacep = nullptr;
-            for (AstPin* pp = cellp->paramsp(); pp; pp = VN_AS(pp->nextp(), Pin)) {
-                if (pp->modVarp() == targetp) {
-                    if (pp->exprp()) replacep = pp->exprp()->cloneTree(false);
-                    break;
-                }
-            }
+            const auto it = pinMap.find(targetp);
+            if (it != pinMap.end()) replacep = it->second->exprp()->cloneTree(false);
             // Not overridden by this instance, so the default applies
             if (!replacep && targetp->valuep()) replacep = targetp->valuep()->cloneTree(false);
             if (!replacep) return;
@@ -7066,11 +7098,10 @@ class WidthVisitor final : public VNVisitor {
             bool didWidth = false;
             if (AstPattern* const patternp = VN_CAST(nodep->exprp(), Pattern)) {
                 const AstVar* const modVarp = nodep->modVarp();
+                // Width against a per-instance type copy, as the template's has defaults (#6284)
                 AstNodeDType* instDtp = nullptr;
-                if (!patternp->childDTypep()) {
-                    if (const AstCell* const cellp = pinCellParamp(nodep)) {
-                        instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep(), cellp);
-                    }
+                if (!patternp->childDTypep() && m_paramPinsp) {
+                    instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep());
                 }
                 if (instDtp) {
                     // Hold under the Pattern so the type has a back pointer while widthed
@@ -7233,6 +7264,7 @@ class WidthVisitor final : public VNVisitor {
             if (nodep->rangep()) userIterateAndNext(nodep->rangep(), WidthVP{SELF, BOTH}.p());
             userIterateAndNext(nodep->pinsp(), nullptr);
         }
+        const ParamPinScope paramPins{*this, nodep->paramsp()};
         userIterateAndNext(nodep->paramsp(), nullptr);
     }
     void visit(AstGatePin* nodep) override {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7105,8 +7105,10 @@ class WidthVisitor final : public VNVisitor {
             instanceParamSubst(holderp, cache, inProgress);
             if (!holderp->exists([](const AstVarRef*) { return true; })) {
                 V3Const::constifyParamsNoWarnEdit(holderp);
-                valuep = VN_CAST(holderp->valuep(), Const);
-                if (valuep) valuep->unlinkFrBack();
+                AstNode* const foldedp = holderp->valuep();
+                if (VN_IS(foldedp, Const) || VN_IS(foldedp, InitArray)) {
+                    valuep = foldedp->unlinkFrBack();
+                }
             }
             VL_DO_DANGLING(holderp->deleteTree(), holderp);
         }
@@ -7138,7 +7140,7 @@ class WidthVisitor final : public VNVisitor {
                                              ? VN_CAST(it->second->exprp(), NodeDType)
                                              : ptypep->subDTypep();
             if (substp) replacements.emplace_back(refp, substp);
-        });
+        });  // LCOV_EXCL_LINE
         for (auto it = replacements.rbegin(); it != replacements.rend(); ++it) {
             AstRefDType* const refp = it->first;
             refp->replaceWith(it->second->cloneTree(false));

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -76,6 +76,7 @@
 #include "V3LinkLValue.h"
 #include "V3MemberMap.h"
 #include "V3Number.h"
+#include "V3Param.h"
 #include "V3Randomize.h"
 #include "V3String.h"
 #include "V3Task.h"
@@ -213,81 +214,6 @@ public:
 #define accept in_WidthVisitor_use_AstNode_iterate_instead_of_AstNode_accept
 
 //######################################################################
-// Parameter pin state, shared between the width visitor and its RAII scope guard
-
-class ParamPinMap final {
-    // Map each parameter/type-parameter of the construct being iterated to the pin
-    // overriding it.  Rebuilt lazily whenever the active pin list changes.
-    const AstPin* m_pinsp = nullptr;  // Parameter pin list of enclosing construct
-    bool m_valid = false;  // Maps are built for m_pinsp
-    const AstPin* m_builtFor = nullptr;  // Pins the maps were built for
-    std::map<const AstVar*, const AstPin*> m_map;  // Parameter var -> overriding pin
-    // Type parameter -> overriding pin
-    std::map<const AstParamTypeDType*, const AstPin*> m_ptypeMap;
-
-    void build() {
-        if (!m_valid) {
-            m_valid = true;
-            m_map.clear();
-            m_ptypeMap.clear();
-            for (const AstPin* pp = m_pinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                if (!pp->exprp()) continue;
-                if (pp->modVarp()) m_map.emplace(pp->modVarp(), pp);
-                if (pp->modPTypep()) m_ptypeMap.emplace(pp->modPTypep(), pp);
-            }
-            m_builtFor = m_pinsp;
-        }
-        UASSERT(m_builtFor == m_pinsp, "Parameter pin map not for current pins");
-    }
-
-public:
-    const AstPin* pinsp() const { return m_pinsp; }
-    // Map each parameter to the pin overriding it, built once per parameter pin list
-    const std::map<const AstVar*, const AstPin*>& map() {
-        build();
-        return m_map;
-    }
-    // Map each type parameter to the pin overriding it
-    const std::map<const AstParamTypeDType*, const AstPin*>& ptypeMap() {
-        build();
-        return m_ptypeMap;
-    }
-
-    friend class ParamPinScope;
-};
-
-// Note the parameter pins of the construct being iterated, restoring on scope exit
-class ParamPinScope final {
-    ParamPinMap& m_mapr;
-    const AstPin* const m_savedPinsp;
-    const bool m_savedValid;
-    const AstPin* const m_savedBuiltFor;
-    // Swap the maps aside rather than copy them, as VL_RESTORER_CLEAR would.
-    std::map<const AstVar*, const AstPin*> m_savedMap;
-    std::map<const AstParamTypeDType*, const AstPin*> m_savedPTypeMap;
-
-public:
-    ParamPinScope(ParamPinMap& mapr, const AstPin* pinsp)
-        : m_mapr{mapr}
-        , m_savedPinsp{mapr.m_pinsp}
-        , m_savedValid{mapr.m_valid}
-        , m_savedBuiltFor{mapr.m_builtFor} {
-        m_savedMap.swap(mapr.m_map);
-        m_savedPTypeMap.swap(mapr.m_ptypeMap);
-        m_mapr.m_pinsp = pinsp;
-        m_mapr.m_valid = false;
-    }
-    ~ParamPinScope() {
-        m_mapr.m_pinsp = m_savedPinsp;
-        m_mapr.m_valid = m_savedValid;
-        m_mapr.m_builtFor = m_savedBuiltFor;
-        m_mapr.m_map.swap(m_savedMap);
-        m_mapr.m_ptypeMap.swap(m_savedPTypeMap);
-    }
-    VL_UNCOPYABLE(ParamPinScope);
-};
-
-//######################################################################
 
 class WidthVisitor final : public VNVisitor {
     // TYPES
@@ -308,7 +234,7 @@ class WidthVisitor final : public VNVisitor {
     AstNode* m_seqUnsupp = nullptr;  // Property has unsupported node
     bool m_hasSExpr = false;  // Property has a sequence expression
     const AstCell* m_cellp = nullptr;  // Current cell for arrayed instantiations
-    ParamPinMap m_paramPins;  // Parameter pin -> overriding pin maps
+    const AstPin* m_paramPinsp = nullptr;  // Parameter pin list of enclosing construct
     const AstEnumItem* m_enumItemp = nullptr;  // Current enum item
     AstNodeFTask* m_ftaskp = nullptr;  // Current function/task
     AstClass* m_cgClassp = nullptr;  // Current covergroup class
@@ -2754,7 +2680,8 @@ class WidthVisitor final : public VNVisitor {
             // in type table are still correct (which they wouldn't be if we replaced the node)
         }
         {
-            const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
+            VL_RESTORER(m_paramPinsp);
+            m_paramPinsp = nodep->paramsp();
             userIterateChildren(nodep, nullptr);
         }
         if (nodep->subDTypep()) {
@@ -3880,7 +3807,8 @@ class WidthVisitor final : public VNVisitor {
     void visit(AstIfaceRefDType* nodep) override {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5, "   IFACEREF " << nodep);
-        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
+        VL_RESTORER(m_paramPinsp);
+        m_paramPinsp = nodep->paramsp();
         userIterateChildren(nodep, m_vup);
         nodep->dtypep(nodep);
         UINFO(4, "dtWidthed " << nodep);
@@ -3982,7 +3910,8 @@ class WidthVisitor final : public VNVisitor {
     }
     void visit(AstClassOrPackageRef* nodep) override {
         if (nodep->didWidthAndSet()) return;
-        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
+        VL_RESTORER(m_paramPinsp);
+        m_paramPinsp = nodep->paramsp();
         userIterateChildren(nodep, nullptr);
     }
     void visit(AstDot* nodep) override {
@@ -7103,71 +7032,8 @@ class WidthVisitor final : public VNVisitor {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
     }
-    // Cache of parameter values already resolved for the current instance
-    using ParamValueMap = std::map<const AstVar*, AstNode*>;
-    AstNode* instanceParamValuep(AstVar* varp, ParamValueMap& cache,
-                                 std::set<const AstVar*>& inProgress) {
-        const auto it = cache.find(varp);
-        if (it != cache.end()) return it->second;
-        // Bail on self reference
-        if (!inProgress.emplace(varp).second) return nullptr;
-        const std::map<const AstVar*, const AstPin*>& pinMap = m_paramPins.map();
-        const auto pinIt = pinMap.find(varp);
-        AstNode* const sourcep = pinIt != pinMap.end() ? pinIt->second->exprp() : varp->valuep();
-        AstNode* valuep = nullptr;
-        if (sourcep) {
-            AstVar* const holderp
-                = new AstVar{varp->fileline(), VVarType::MODULETEMP, "__Vpinparam",
-                             VFlagChildDType{}, varp->subDTypep()->cloneTree(false)};
-            holderp->valuep(sourcep->cloneTree(false));
-            instanceParamSubst(holderp, cache, inProgress);
-            if (!holderp->exists([](const AstVarRef*) { return true; })) {
-                V3Const::constifyParamsNoWarnEdit(holderp);
-                AstNode* const foldedp = holderp->valuep();
-                if (VN_IS(foldedp, Const) || VN_IS(foldedp, InitArray)) {
-                    valuep = foldedp->unlinkFrBack();
-                }
-            }
-            VL_DO_DANGLING(holderp->deleteTree(), holderp);
-        }
-        inProgress.erase(varp);
-        cache.emplace(varp, valuep);
-        return valuep;
-    }
-    void instanceParamSubst(AstNode* nodep, ParamValueMap& cache,
-                            std::set<const AstVar*>& inProgress) {
-        nodep->foreach([this, &cache, &inProgress](AstVarRef* refp) {
-            AstVar* const targetp = refp->varp();
-            if (!targetp || !targetp->isGParam()) return;
-            AstNode* const valuep = instanceParamValuep(targetp, cache, inProgress);
-            if (!valuep) return;
-            refp->replaceWith(valuep->cloneTree(false));
-            VL_DO_DANGLING(refp->deleteTree(), refp);
-        });  // LCOV_EXCL_LINE
-        instanceParamTypeSubst(nodep);
-    }
-    void instanceParamTypeSubst(AstNode* nodep) {
-        // Collect then replace in reverse
-        std::vector<std::pair<AstRefDType*, AstNodeDType*>> replacements;
-        nodep->foreach([this, &replacements](AstRefDType* refp) {
-            const AstParamTypeDType* const ptypep = VN_CAST(refp->refDTypep(), ParamTypeDType);
-            if (!ptypep) return;
-            const std::map<const AstParamTypeDType*, const AstPin*>& pinMap
-                = m_paramPins.ptypeMap();
-            const auto it = pinMap.find(ptypep);
-            AstNodeDType* const substp = it != pinMap.end()
-                                             ? VN_CAST(it->second->exprp(), NodeDType)
-                                             : ptypep->subDTypep();
-            if (substp) replacements.emplace_back(refp, substp);
-        });  // LCOV_EXCL_LINE
-        for (auto it = replacements.rbegin(); it != replacements.rend(); ++it) {
-            AstRefDType* const refp = it->first;
-            refp->replaceWith(it->second->cloneTree(false));
-            VL_DO_DANGLING(refp->deleteTree(), refp);
-        }
-    }
     // Copy a parameter's data type with this instance's parameter overrides substituted in
-    AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp) {
+    AstNodeDType* instanceParamDTypep(AstNodeDType* templateDtp, const AstPin* pinsp) {
         if (!templateDtp->exists(
                 [](const AstVarRef* refp) { return refp->varp() && refp->varp()->isGParam(); })) {
             return nullptr;
@@ -7176,12 +7042,7 @@ class WidthVisitor final : public VNVisitor {
         // Hold under a temporary Var so edited nodes have a back pointer
         AstVar* const holderp = new AstVar{templateDtp->fileline(), VVarType::MODULETEMP,
                                            "__Vpindtype", VFlagChildDType{}, clonep};
-        ParamValueMap cache;
-        std::set<const AstVar*> inProgress;
-        instanceParamSubst(holderp, cache, inProgress);
-        for (const auto& pair : cache) {
-            if (pair.second) pair.second->deleteTree();
-        }
+        V3Param::substituteParams(holderp, pinsp);
         AstNodeDType* const resultp = holderp->childDTypep();
         resultp->unlinkFrBack();
         VL_DO_DANGLING(holderp->deleteTree(), holderp);
@@ -7197,8 +7058,8 @@ class WidthVisitor final : public VNVisitor {
                 const AstVar* const modVarp = nodep->modVarp();
                 // Width against a per-instance type copy, as the template's has defaults (#6284)
                 AstNodeDType* instDtp = nullptr;
-                if (!patternp->childDTypep() && m_paramPins.pinsp()) {
-                    instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep());
+                if (!patternp->childDTypep() && m_paramPinsp) {
+                    instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep(), m_paramPinsp);
                 }
                 if (instDtp) {
                     // Hold under the Pattern so the type has a back pointer while widthed
@@ -7361,7 +7222,8 @@ class WidthVisitor final : public VNVisitor {
             if (nodep->rangep()) userIterateAndNext(nodep->rangep(), WidthVP{SELF, BOTH}.p());
             userIterateAndNext(nodep->pinsp(), nullptr);
         }
-        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
+        VL_RESTORER(m_paramPinsp);
+        m_paramPinsp = nodep->paramsp();
         userIterateAndNext(nodep->paramsp(), nullptr);
     }
     void visit(AstGatePin* nodep) override {

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -7084,7 +7084,7 @@ class WidthVisitor final : public VNVisitor {
             if (!replacep) return;
             refp->replaceWith(replacep);
             VL_DO_DANGLING(refp->deleteTree(), refp);
-        });
+        });  // LCOV_EXCL_LINE
         AstNodeDType* const resultp = holderp->childDTypep();
         resultp->unlinkFrBack();
         VL_DO_DANGLING(holderp->deleteTree(), holderp);

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -213,6 +213,81 @@ public:
 #define accept in_WidthVisitor_use_AstNode_iterate_instead_of_AstNode_accept
 
 //######################################################################
+// Parameter pin state, shared between the width visitor and its RAII scope guard
+
+class ParamPinMap final {
+    // Map each parameter/type-parameter of the construct being iterated to the pin
+    // overriding it.  Rebuilt lazily whenever the active pin list changes.
+    const AstPin* m_pinsp = nullptr;  // Parameter pin list of enclosing construct
+    bool m_valid = false;  // Maps are built for m_pinsp
+    const AstPin* m_builtFor = nullptr;  // Pins the maps were built for
+    std::map<const AstVar*, const AstPin*> m_map;  // Parameter var -> overriding pin
+    // Type parameter -> overriding pin
+    std::map<const AstParamTypeDType*, const AstPin*> m_ptypeMap;
+
+    void build() {
+        if (!m_valid) {
+            m_valid = true;
+            m_map.clear();
+            m_ptypeMap.clear();
+            for (const AstPin* pp = m_pinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
+                if (!pp->exprp()) continue;
+                if (pp->modVarp()) m_map.emplace(pp->modVarp(), pp);
+                if (pp->modPTypep()) m_ptypeMap.emplace(pp->modPTypep(), pp);
+            }
+            m_builtFor = m_pinsp;
+        }
+        UASSERT(m_builtFor == m_pinsp, "Parameter pin map not for current pins");
+    }
+
+public:
+    const AstPin* pinsp() const { return m_pinsp; }
+    // Map each parameter to the pin overriding it, built once per parameter pin list
+    const std::map<const AstVar*, const AstPin*>& map() {
+        build();
+        return m_map;
+    }
+    // Map each type parameter to the pin overriding it
+    const std::map<const AstParamTypeDType*, const AstPin*>& ptypeMap() {
+        build();
+        return m_ptypeMap;
+    }
+
+    friend class ParamPinScope;
+};
+
+// Note the parameter pins of the construct being iterated, restoring on scope exit
+class ParamPinScope final {
+    ParamPinMap& m_mapr;
+    const AstPin* const m_savedPinsp;
+    const bool m_savedValid;
+    const AstPin* const m_savedBuiltFor;
+    // Swap the maps aside rather than copy them, as VL_RESTORER_CLEAR would.
+    std::map<const AstVar*, const AstPin*> m_savedMap;
+    std::map<const AstParamTypeDType*, const AstPin*> m_savedPTypeMap;
+
+public:
+    ParamPinScope(ParamPinMap& mapr, const AstPin* pinsp)
+        : m_mapr{mapr}
+        , m_savedPinsp{mapr.m_pinsp}
+        , m_savedValid{mapr.m_valid}
+        , m_savedBuiltFor{mapr.m_builtFor} {
+        m_savedMap.swap(mapr.m_map);
+        m_savedPTypeMap.swap(mapr.m_ptypeMap);
+        m_mapr.m_pinsp = pinsp;
+        m_mapr.m_valid = false;
+    }
+    ~ParamPinScope() {
+        m_mapr.m_pinsp = m_savedPinsp;
+        m_mapr.m_valid = m_savedValid;
+        m_mapr.m_builtFor = m_savedBuiltFor;
+        m_mapr.m_map.swap(m_savedMap);
+        m_mapr.m_ptypeMap.swap(m_savedPTypeMap);
+    }
+    VL_UNCOPYABLE(ParamPinScope);
+};
+
+//######################################################################
 
 class WidthVisitor final : public VNVisitor {
     // TYPES
@@ -233,12 +308,7 @@ class WidthVisitor final : public VNVisitor {
     AstNode* m_seqUnsupp = nullptr;  // Property has unsupported node
     bool m_hasSExpr = false;  // Property has a sequence expression
     const AstCell* m_cellp = nullptr;  // Current cell for arrayed instantiations
-    const AstPin* m_paramPinsp = nullptr;  // Parameter pin list of enclosing construct
-    bool m_paramPinMapValid = false;  // m_paramPinMap is built for m_paramPinsp
-    const AstPin* m_paramPinMapBuiltFor = nullptr;  // Pins m_paramPinMap was built for
-    std::map<const AstVar*, const AstPin*> m_paramPinMap;  // Parameter var -> overriding pin
-    // Type parameter -> overriding pin
-    std::map<const AstParamTypeDType*, const AstPin*> m_paramPinPTypeMap;
+    ParamPinMap m_paramPins;  // Parameter pin -> overriding pin maps
     const AstEnumItem* m_enumItemp = nullptr;  // Current enum item
     AstNodeFTask* m_ftaskp = nullptr;  // Current function/task
     AstClass* m_cgClassp = nullptr;  // Current covergroup class
@@ -276,37 +346,6 @@ class WidthVisitor final : public VNVisitor {
     }
 
     StreamUse currentStreamUse() const { return m_vup ? m_vup->streamUse() : STREAM_USE_NONE; }
-
-    // Note the parameter pins of the construct being iterated, restoring on scope exit
-    class ParamPinScope final {
-        WidthVisitor& m_visitor;
-        const AstPin* const m_savedPinsp;
-        const bool m_savedValid;
-        const AstPin* const m_savedBuiltFor;
-        // Swap the maps aside rather than copy them, as VL_RESTORER_CLEAR would.
-        std::map<const AstVar*, const AstPin*> m_savedMap;
-        std::map<const AstParamTypeDType*, const AstPin*> m_savedPTypeMap;
-
-    public:
-        ParamPinScope(WidthVisitor& visitor, const AstPin* pinsp)
-            : m_visitor{visitor}
-            , m_savedPinsp{visitor.m_paramPinsp}
-            , m_savedValid{visitor.m_paramPinMapValid}
-            , m_savedBuiltFor{visitor.m_paramPinMapBuiltFor} {
-            m_savedMap.swap(visitor.m_paramPinMap);
-            m_savedPTypeMap.swap(visitor.m_paramPinPTypeMap);
-            m_visitor.m_paramPinsp = pinsp;
-            m_visitor.m_paramPinMapValid = false;
-        }
-        ~ParamPinScope() {
-            m_visitor.m_paramPinsp = m_savedPinsp;
-            m_visitor.m_paramPinMapValid = m_savedValid;
-            m_visitor.m_paramPinMapBuiltFor = m_savedBuiltFor;
-            m_visitor.m_paramPinMap.swap(m_savedMap);
-            m_visitor.m_paramPinPTypeMap.swap(m_savedPTypeMap);
-        }
-        VL_UNCOPYABLE(ParamPinScope);
-    };
 
     static void packIfUnpacked(AstNodeExpr* const nodep) {
         if (AstUnpackArrayDType* const unpackDTypep = VN_CAST(nodep->dtypep(), UnpackArrayDType)) {
@@ -2715,7 +2754,7 @@ class WidthVisitor final : public VNVisitor {
             // in type table are still correct (which they wouldn't be if we replaced the node)
         }
         {
-            const ParamPinScope paramPins{*this, nodep->paramsp()};
+            const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
             userIterateChildren(nodep, nullptr);
         }
         if (nodep->subDTypep()) {
@@ -3841,7 +3880,7 @@ class WidthVisitor final : public VNVisitor {
     void visit(AstIfaceRefDType* nodep) override {
         if (nodep->didWidthAndSet()) return;  // This node is a dtype & not both PRELIMed+FINALed
         UINFO(5, "   IFACEREF " << nodep);
-        const ParamPinScope paramPins{*this, nodep->paramsp()};
+        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
         userIterateChildren(nodep, m_vup);
         nodep->dtypep(nodep);
         UINFO(4, "dtWidthed " << nodep);
@@ -3943,7 +3982,7 @@ class WidthVisitor final : public VNVisitor {
     }
     void visit(AstClassOrPackageRef* nodep) override {
         if (nodep->didWidthAndSet()) return;
-        const ParamPinScope paramPins{*this, nodep->paramsp()};
+        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
         userIterateChildren(nodep, nullptr);
     }
     void visit(AstDot* nodep) override {
@@ -7064,27 +7103,6 @@ class WidthVisitor final : public VNVisitor {
         assertAtStatement(nodep);
         iterateCheckBool(nodep, "Property", nodep->propp(), BOTH);  // it's like an if() condition.
     }
-    // Map each parameter to the pin overriding it, built once per parameter pin list
-    const std::map<const AstVar*, const AstPin*>& paramPinMap() {
-        if (!m_paramPinMapValid) {
-            m_paramPinMapValid = true;
-            m_paramPinMap.clear();
-            m_paramPinPTypeMap.clear();
-            for (const AstPin* pp = m_paramPinsp; pp; pp = VN_AS(pp->nextp(), Pin)) {
-                if (!pp->exprp()) continue;
-                if (pp->modVarp()) m_paramPinMap.emplace(pp->modVarp(), pp);
-                if (pp->modPTypep()) m_paramPinPTypeMap.emplace(pp->modPTypep(), pp);
-            }
-            m_paramPinMapBuiltFor = m_paramPinsp;
-        }
-        UASSERT(m_paramPinMapBuiltFor == m_paramPinsp, "Parameter pin map not for current pins");
-        return m_paramPinMap;
-    }
-    // Map each type parameter to the pin overriding it
-    const std::map<const AstParamTypeDType*, const AstPin*>& paramPinPTypeMap() {
-        paramPinMap();
-        return m_paramPinPTypeMap;
-    }
     // Cache of parameter values already resolved for the current instance
     using ParamValueMap = std::map<const AstVar*, AstNode*>;
     AstNode* instanceParamValuep(AstVar* varp, ParamValueMap& cache,
@@ -7093,7 +7111,7 @@ class WidthVisitor final : public VNVisitor {
         if (it != cache.end()) return it->second;
         // Bail on self reference
         if (!inProgress.emplace(varp).second) return nullptr;
-        const std::map<const AstVar*, const AstPin*>& pinMap = paramPinMap();
+        const std::map<const AstVar*, const AstPin*>& pinMap = m_paramPins.map();
         const auto pinIt = pinMap.find(varp);
         AstNode* const sourcep = pinIt != pinMap.end() ? pinIt->second->exprp() : varp->valuep();
         AstNode* valuep = nullptr;
@@ -7134,7 +7152,8 @@ class WidthVisitor final : public VNVisitor {
         nodep->foreach([this, &replacements](AstRefDType* refp) {
             const AstParamTypeDType* const ptypep = VN_CAST(refp->refDTypep(), ParamTypeDType);
             if (!ptypep) return;
-            const std::map<const AstParamTypeDType*, const AstPin*>& pinMap = paramPinPTypeMap();
+            const std::map<const AstParamTypeDType*, const AstPin*>& pinMap
+                = m_paramPins.ptypeMap();
             const auto it = pinMap.find(ptypep);
             AstNodeDType* const substp = it != pinMap.end()
                                              ? VN_CAST(it->second->exprp(), NodeDType)
@@ -7178,7 +7197,7 @@ class WidthVisitor final : public VNVisitor {
                 const AstVar* const modVarp = nodep->modVarp();
                 // Width against a per-instance type copy, as the template's has defaults (#6284)
                 AstNodeDType* instDtp = nullptr;
-                if (!patternp->childDTypep() && m_paramPinsp) {
+                if (!patternp->childDTypep() && m_paramPins.pinsp()) {
                     instDtp = instanceParamDTypep(nodep->modVarp()->childDTypep());
                 }
                 if (instDtp) {
@@ -7342,7 +7361,7 @@ class WidthVisitor final : public VNVisitor {
             if (nodep->rangep()) userIterateAndNext(nodep->rangep(), WidthVP{SELF, BOTH}.p());
             userIterateAndNext(nodep->pinsp(), nullptr);
         }
-        const ParamPinScope paramPins{*this, nodep->paramsp()};
+        const ParamPinScope paramPins{m_paramPins, nodep->paramsp()};
         userIterateAndNext(nodep->paramsp(), nullptr);
     }
     void visit(AstGatePin* nodep) override {

--- a/test_regress/t/t_param_pattern4.py
+++ b/test_regress/t/t_param_pattern4.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_param_pattern4.v
+++ b/test_regress/t/t_param_pattern4.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// Unpacked array parameter whose size depends on an earlier parameter that is
+// also overridden by the same instantiation.
+module dut #(
+    parameter int ARRAY_LEN = 3,
+    parameter int ARRAY_PARAM[ARRAY_LEN] = '{2, 2, 4}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+module t;
+  int o_default;
+  int o_wide;
+
+  dut u_default (.o_sum(o_default));
+
+  dut #(
+      .ARRAY_LEN(4),
+      .ARRAY_PARAM('{2, 2, 2, 4})
+  ) u_wide (.o_sum(o_wide));
+
+  initial begin
+    if (o_default !== 8) $stop;
+    if (o_wide !== 10) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_param_pattern4.v
+++ b/test_regress/t/t_param_pattern4.v
@@ -20,6 +20,23 @@ module dut #(
   assign o_sum = sum;
 endmodule
 
+// Two parameters sized by the same earlier parameter, so one instantiation
+// substitutes into two separate patterns
+module dut2 #(
+    parameter int ARRAY_LEN = 3,
+    parameter int ARRAY_A[ARRAY_LEN] = '{1, 1, 1},
+    parameter int ARRAY_B[ARRAY_LEN] = '{1, 1, 1}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_A[i] + ARRAY_B[i];
+  end
+  assign o_sum = sum;
+endmodule
+
 // Same, for an interface
 interface Ifc #(
     parameter int ARRAY_LEN = 3,
@@ -47,6 +64,9 @@ module t;
   int o_default;
   int o_wide;
   int o_narrow;
+  int o_deflen;
+  int o_two;
+  int o_emptylen;
 
   dut u_default (.o_sum(o_default));
 
@@ -64,6 +84,30 @@ module t;
       .o_sum(o_narrow)
   );
 
+  // Overrides the array but not its size, so the size uses the default
+  dut #(
+      .ARRAY_PARAM('{5, 6, 7})
+  ) u_deflen (
+      .o_sum(o_deflen)
+  );
+
+  // Both patterns resolve against the same overriding pins
+  dut2 #(
+      .ARRAY_LEN(2),
+      .ARRAY_A('{1, 2}),
+      .ARRAY_B('{3, 4})
+  ) u_two (
+      .o_sum(o_two)
+  );
+
+  // Empty override, so the size still comes from the default
+  dut #(
+      .ARRAY_LEN(),
+      .ARRAY_PARAM('{5, 6, 7})
+  ) u_emptylen (
+      .o_sum(o_emptylen)
+  );
+
   Ifc i_default ();
   Ifc #(
       .ARRAY_LEN(4),
@@ -74,10 +118,14 @@ module t;
     if (o_default !== 8) $stop;
     if (o_wide !== 10) $stop;
     if (o_narrow !== 6) $stop;
+    if (o_deflen !== 18) $stop;
+    if (o_two !== 10) $stop;
+    if (o_emptylen !== 18) $stop;
     if (i_default.sum !== 8) $stop;
     if (i_wide.sum !== 10) $stop;
     if (Cls#()::sum() !== 8) $stop;
     if (Cls#(4, '{2, 2, 2, 4})::sum() !== 10) $stop;
+    if (Cls#(.ARRAY_PARAM('{5, 6, 7}))::sum() !== 18) $stop;
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_param_pattern4.v
+++ b/test_regress/t/t_param_pattern4.v
@@ -37,16 +37,85 @@ module dut2 #(
   assign o_sum = sum;
 endmodule
 
+// The array's size parameter is not overridden, and its default references a
+// further parameter that is, so substitution has to chain
+module dut3 #(
+    parameter int ARRAY_LEN = 2,
+    parameter int ARRAY_LEN2 = ARRAY_LEN,
+    parameter int ARRAY_PARAM[ARRAY_LEN2] = '{3, 5}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN2; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+// Each default references the previous one twice, so substituting without folding
+// each parameter's value would grow the data type exponentially.
+module dut4 #(
+    parameter int L0 = 1,
+    parameter int L1 = (L0 + L0) / 2,
+    parameter int L2 = (L1 + L1) / 2,
+    parameter int L3 = (L2 + L2) / 2,
+    parameter int L4 = (L3 + L3) / 2,
+    parameter int L5 = (L4 + L4) / 2,
+    parameter int L6 = (L5 + L5) / 2,
+    parameter int L7 = (L6 + L6) / 2,
+    parameter int L8 = (L7 + L7) / 2,
+    parameter int L9 = (L8 + L8) / 2,
+    parameter int L10 = (L9 + L9) / 2,
+    parameter int L11 = (L10 + L10) / 2,
+    parameter int L12 = (L11 + L11) / 2,
+    parameter int L13 = (L12 + L12) / 2,
+    parameter int L14 = (L13 + L13) / 2,
+    parameter int L15 = (L14 + L14) / 2,
+    parameter int L16 = (L15 + L15) / 2,
+    parameter int L17 = (L16 + L16) / 2,
+    parameter int L18 = (L17 + L17) / 2,
+    parameter int L19 = (L18 + L18) / 2,
+    parameter int L20 = (L19 + L19) / 2,
+    parameter int ARRAY_PARAM[L20] = '{default: 1}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < L20; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+// The array's element type is a type parameter, so substitution must retarget the
+// type reference too, else it is left pointing into the template module
+module dut5 #(
+    parameter type T = byte,
+    parameter int ARRAY_LEN = 2,
+    parameter T ARRAY_PARAM[ARRAY_LEN] = '{3, 5}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += int'(ARRAY_PARAM[i]);
+  end
+  assign o_sum = sum;
+endmodule
+
 // Same, for an interface
 interface Ifc #(
     parameter int ARRAY_LEN = 3,
     parameter int ARRAY_PARAM[ARRAY_LEN] = '{2, 2, 4}
 );
-  int sum;
-  always_comb begin
-    sum = 0;
-    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
-  end
+  function automatic int getSum();
+    getSum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) getSum += ARRAY_PARAM[i];
+  endfunction
 endinterface
 
 // Same, for a class
@@ -67,6 +136,12 @@ module t;
   int o_deflen;
   int o_two;
   int o_emptylen;
+  int o_chain;
+  int o_chaindef;
+  int o_exp;
+  int o_type;
+  int o_typedef;
+  int o_typelen;
 
   dut u_default (.o_sum(o_default));
 
@@ -108,6 +183,55 @@ module t;
       .o_sum(o_emptylen)
   );
 
+  // ARRAY_LEN2 keeps its default, which resolves through the overridden ARRAY_LEN
+  dut3 #(
+      .ARRAY_LEN(4),
+      .ARRAY_PARAM('{1, 2, 3, 4})
+  ) u_chain (
+      .o_sum(o_chain)
+  );
+
+  dut3 u_chaindef (.o_sum(o_chaindef));
+
+  dut4 #(
+      .L0(4),
+      .ARRAY_PARAM('{1, 2, 3, 4})
+  ) u_exp (
+      .o_sum(o_exp)
+  );
+
+  // Type parameter overridden, along with the size
+  dut5 #(
+      .T(int),
+      .ARRAY_LEN(3),
+      .ARRAY_PARAM('{1, 2, 3})
+  ) u_type (
+      .o_sum(o_type)
+  );
+
+  // Type parameter keeps its default while the size is overridden
+  dut5 #(
+      .ARRAY_LEN(4),
+      .ARRAY_PARAM('{1, 2, 3, 4})
+  ) u_typedef (
+      .o_sum(o_typedef)
+  );
+
+  // Type parameter overridden while the size keeps its default
+  dut5 #(
+      .T(int),
+      .ARRAY_PARAM('{5, 6})
+  ) u_typelen (
+      .o_sum(o_typelen)
+  );
+
+  // Virtual interface handle to a parameterized interface, a distinct path from
+  // the interface instantiation above
+  virtual Ifc #(
+      .ARRAY_LEN(4),
+      .ARRAY_PARAM('{2, 2, 2, 4})
+  ) v_wide;
+
   Ifc i_default ();
   Ifc #(
       .ARRAY_LEN(4),
@@ -121,8 +245,16 @@ module t;
     if (o_deflen !== 18) $stop;
     if (o_two !== 10) $stop;
     if (o_emptylen !== 18) $stop;
-    if (i_default.sum !== 8) $stop;
-    if (i_wide.sum !== 10) $stop;
+    if (o_chain !== 10) $stop;
+    if (o_chaindef !== 8) $stop;
+    if (o_exp !== 10) $stop;
+    if (o_type !== 6) $stop;
+    if (o_typedef !== 10) $stop;
+    if (o_typelen !== 11) $stop;
+    if (i_default.getSum() !== 8) $stop;
+    if (i_wide.getSum() !== 10) $stop;
+    v_wide = i_wide;
+    if (v_wide.getSum() !== 10) $stop;
     if (Cls#()::sum() !== 8) $stop;
     if (Cls#(4, '{2, 2, 2, 4})::sum() !== 10) $stop;
     if (Cls#(.ARRAY_PARAM('{5, 6, 7}))::sum() !== 18) $stop;

--- a/test_regress/t/t_param_pattern4.v
+++ b/test_regress/t/t_param_pattern4.v
@@ -20,20 +20,64 @@ module dut #(
   assign o_sum = sum;
 endmodule
 
+// Same, for an interface
+interface Ifc #(
+    parameter int ARRAY_LEN = 3,
+    parameter int ARRAY_PARAM[ARRAY_LEN] = '{2, 2, 4}
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
+  end
+endinterface
+
+// Same, for a class
+class Cls #(
+    parameter int ARRAY_LEN = 3,
+    parameter int ARRAY_PARAM[ARRAY_LEN] = '{2, 2, 4}
+);
+  static function int sum();
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
+  endfunction
+endclass
+
 module t;
   int o_default;
   int o_wide;
+  int o_narrow;
 
   dut u_default (.o_sum(o_default));
 
   dut #(
       .ARRAY_LEN(4),
       .ARRAY_PARAM('{2, 2, 2, 4})
-  ) u_wide (.o_sum(o_wide));
+  ) u_wide (
+      .o_sum(o_wide)
+  );
+
+  dut #(
+      .ARRAY_LEN(2),
+      .ARRAY_PARAM('{2, 4})
+  ) u_narrow (
+      .o_sum(o_narrow)
+  );
+
+  Ifc i_default ();
+  Ifc #(
+      .ARRAY_LEN(4),
+      .ARRAY_PARAM('{2, 2, 2, 4})
+  ) i_wide ();
 
   initial begin
     if (o_default !== 8) $stop;
     if (o_wide !== 10) $stop;
+    if (o_narrow !== 6) $stop;
+    if (i_default.sum !== 8) $stop;
+    if (i_wide.sum !== 10) $stop;
+    if (Cls#()::sum() !== 8) $stop;
+    if (Cls#(4, '{2, 2, 2, 4})::sum() !== 10) $stop;
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_param_pattern4.v
+++ b/test_regress/t/t_param_pattern4.v
@@ -107,6 +107,58 @@ module dut5 #(
   assign o_sum = sum;
 endmodule
 
+package pkg;
+  typedef int my_t;
+  parameter int PLEN = 3;
+endpackage
+
+// The element type is a typedef reached through a package, so the data type holds a
+// type reference that is not a type parameter
+module dut6 #(
+    parameter int ARRAY_LEN = 2,
+    parameter pkg::my_t ARRAY_PARAM[ARRAY_LEN] = '{1, 1}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+// The size comes from a package parameter, so the data type references a parameter that
+// no pin on this instantiation can override
+module dut7 #(
+    parameter int ARRAY_PARAM[pkg::PLEN] = '{1, 1, 1}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < pkg::PLEN; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+// The size selects an element of an earlier unpacked array parameter, so the override's
+// value is an InitArray rather than a constant (IEEE 1800-2023 23.10.3)
+module dut8 #(
+    parameter int SZ[2] = '{2, 3},
+    parameter int ARRAY_PARAM[SZ[0]] = '{1, 1}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < SZ[0]; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
 // Same, for an interface
 interface Ifc #(
     parameter int ARRAY_LEN = 3,
@@ -142,6 +194,12 @@ module t;
   int o_type;
   int o_typedef;
   int o_typelen;
+  int o_pkgtype;
+  int o_pkglen;
+  int o_locallen;
+  int o_unpackedlen;
+
+  localparam int LOCAL_LEN = 3;
 
   dut u_default (.o_sum(o_default));
 
@@ -225,6 +283,40 @@ module t;
       .o_sum(o_typelen)
   );
 
+  // Element type is a package typedef, so the copied data type holds a type reference
+  // that is not a type parameter and must be left alone
+  dut6 #(
+      .ARRAY_LEN(3),
+      .ARRAY_PARAM('{1, 2, 3})
+  ) u_pkgtype (
+      .o_sum(o_pkgtype)
+  );
+
+  // Size is a package parameter, which no pin here overrides
+  dut7 #(
+      .ARRAY_PARAM('{4, 5, 6})
+  ) u_pkglen (
+      .o_sum(o_pkglen)
+  );
+
+  // Size overridden with a reference to a localparam of the instantiating scope, which
+  // is not itself a parameter and so is folded rather than substituted
+  dut #(
+      .ARRAY_LEN(LOCAL_LEN),
+      .ARRAY_PARAM('{1, 2, 3})
+  ) u_locallen (
+      .o_sum(o_locallen)
+  );
+
+  // Size selects an element of an earlier unpacked array parameter, which is overridden
+  // here, so the size must come from the override rather than the declared default
+  dut8 #(
+      .SZ('{3, 4}),
+      .ARRAY_PARAM('{1, 2, 3})
+  ) u_unpackedlen (
+      .o_sum(o_unpackedlen)
+  );
+
   // Virtual interface handle to a parameterized interface, a distinct path from
   // the interface instantiation above
   virtual Ifc #(
@@ -251,6 +343,10 @@ module t;
     if (o_type !== 6) $stop;
     if (o_typedef !== 10) $stop;
     if (o_typelen !== 11) $stop;
+    if (o_pkgtype !== 6) $stop;
+    if (o_pkglen !== 15) $stop;
+    if (o_locallen !== 6) $stop;
+    if (o_unpackedlen !== 6) $stop;
     if (i_default.getSum() !== 8) $stop;
     if (i_wide.getSum() !== 10) $stop;
     v_wide = i_wide;

--- a/test_regress/t/t_param_pattern4_bad.out
+++ b/test_regress/t/t_param_pattern4_bad.out
@@ -1,0 +1,9 @@
+%Error: t/t_param_pattern4_bad.v:11:19: Variable's initial value is circular: 'N'
+   11 |     parameter int N = N + 1,
+      |                   ^
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_param_pattern4_bad.v:12:22: Size of range is '[0]', must be positive integer (IEEE 1800-2023 7.4.2)
+                                      : ... note: In instance 't'
+   12 |     parameter int ARR[N] = '{1, 1}
+      |                      ^
+%Error: Exiting due to

--- a/test_regress/t/t_param_pattern4_bad.py
+++ b/test_regress/t/t_param_pattern4_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_param_pattern4_bad.v
+++ b/test_regress/t/t_param_pattern4_bad.v
@@ -1,0 +1,22 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// A parameter whose data type depends on a parameter whose own value is circular.  The
+// reference is left in place rather than substituted, so the usual circular value check
+// reports it instead of the substitution recursing forever.
+module dut_circ #(
+    parameter int N = N + 1,
+    parameter int ARR[N] = '{1, 1}
+) (
+    output int o
+);
+  assign o = ARR[0];
+endmodule
+
+module t;
+  int o_circ;
+  dut_circ #(.ARR('{1, 2})) u_circ (.o(o_circ));
+endmodule

--- a/test_regress/t/t_param_pattern4_nodefault_bad.out
+++ b/test_regress/t/t_param_pattern4_nodefault_bad.out
@@ -1,0 +1,18 @@
+%Error: t/t_param_pattern4_nodefault_bad.v:11:31: Expecting expression to be constant, but variable isn't const: 'ARRAY_LEN'
+                                                : ... note: In instance 't'
+   11 |     parameter int ARRAY_PARAM[ARRAY_LEN] = '{1, 1}
+      |                               ^~~~~~~~~
+        ... See the manual at https://verilator.org/verilator_doc.html?v=latest for more assistance.
+%Error: t/t_param_pattern4_nodefault_bad.v:11:31: right side of bit range isn't a two-state constant (IEEE 1800-2023 6.9.1)
+                                                : ... note: In instance 't'
+   11 |     parameter int ARRAY_PARAM[ARRAY_LEN] = '{1, 1}
+      |                               ^~~~~~~~~
+%Error: t/t_param_pattern4_nodefault_bad.v:20:22: Assignment pattern with too many elements
+                                                : ... note: In instance 't'
+   20 |   dut #(.ARRAY_PARAM('{1, 2, 3})) u (.o(o));
+      |                      ^~
+%Error: t/t_param_pattern4_nodefault_bad.v:10:19: Parameter without default value is never given value (IEEE 1800-2023 6.20.1): 'ARRAY_LEN'
+                                                : ... note: In instance 't.u'
+   10 |     parameter int ARRAY_LEN,
+      |                   ^~~~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_param_pattern4_nodefault_bad.py
+++ b/test_regress/t/t_param_pattern4_nodefault_bad.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(fails=True, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_param_pattern4_nodefault_bad.v
+++ b/test_regress/t/t_param_pattern4_nodefault_bad.v
@@ -1,0 +1,21 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// The array's size parameter has no default and is not overridden either, so this
+// instance has no value at all to substitute for it.
+module dut #(
+    parameter int ARRAY_LEN,
+    parameter int ARRAY_PARAM[ARRAY_LEN] = '{1, 1}
+) (
+    output int o
+);
+  assign o = ARRAY_PARAM[0];
+endmodule
+
+module t;
+  int o;
+  dut #(.ARRAY_PARAM('{1, 2, 3})) u (.o(o));
+endmodule

--- a/test_regress/t/t_param_pattern5.py
+++ b/test_regress/t/t_param_pattern5.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile()
+
+test.execute()
+
+test.passes()

--- a/test_regress/t/t_param_pattern5.v
+++ b/test_regress/t/t_param_pattern5.v
@@ -1,0 +1,42 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// An assignment pattern that carries its own data type, overriding a parameter whose
+// declared type depends on an earlier parameter.  The pattern's type is used as-is, so
+// no per-instance copy of the declared type is made.  Kept apart from t_param_pattern4
+// as this must be the first such pin widthed to exercise that path.
+typedef int arr_t[3];
+
+module dut #(
+    parameter int ARRAY_LEN = 3,
+    parameter int ARRAY_PARAM[ARRAY_LEN] = '{2, 2, 4}
+) (
+    output int o_sum
+);
+  int sum;
+  always_comb begin
+    sum = 0;
+    for (int i = 0; i < ARRAY_LEN; ++i) sum += ARRAY_PARAM[i];
+  end
+  assign o_sum = sum;
+endmodule
+
+module t;
+  int o_typedpat;
+
+  dut #(
+      .ARRAY_LEN(3),
+      .ARRAY_PARAM(arr_t'{1, 2, 3})
+  ) u_typedpat (
+      .o_sum(o_typedpat)
+  );
+
+  initial begin
+    if (o_typedpat !== 6) $stop;
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Without the fix the test will throw:
```
%Error: t/t_param_pattern4.v:31:20: Assignment pattern with too many elements
                                  : ... note: In instance 't'
   31 |       .ARRAY_PARAM('{2, 2, 2, 4})
```

This checks to see if cell pin params are dependent on sibling params and then builds a new dtype if necessary.

Just ran into this one.  Not sure if it should be considered for #8254 , but I'm flagging since it is a bug fix.
