### PR TITLE
Diagnose real-element array comparisons in constraints at compile time (#8273)

### DIFF
--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -1969,6 +1969,18 @@ class ConstraintExprVisitor final : public VNVisitor {
     void visit(AstShiftRS* nodep) override { handleShift(nodep); }
     void visit(AstNodeBiop* nodep) override {
         if (editFormat(nodep)) return;
+        // A whole-array ==/!= reaches emitSMT() unconditionally non-empty
+        // (it's a fixed template, not type-checked), so a real-element
+        // array's malformed width sails through to a solver-side error
+        // instead of failing cleanly here, unlike the scalar real case
+        // (an EQD node, whose emitSMT() is the empty default).
+        if (VN_IS(nodep, Eq) || VN_IS(nodep, Neq)) {
+            if (arrayElementDTypep(nodep->lhsp()->dtypep())->isDouble()) {
+                nodep->v3warn(E_UNSUPPORTED,
+                              "Unsupported: real-element array compared in a constraint");
+                return;
+            }
+        }
         editSMT(nodep, nodep->lhsp(), nodep->rhsp());
     }
     void visit(AstNodeUniop* nodep) override {

--- a/test_regress/t/t_constraint_real_array_eq_unsup.out
+++ b/test_regress/t/t_constraint_real_array_eq_unsup.out
@@ -1,0 +1,10 @@
+%Error-UNSUPPORTED: t/t_constraint_real_array_eq_unsup.v:14:24: Unsupported: real-element array compared in a constraint
+                                                              : ... note: In instance 't'
+   14 |   constraint c { frame == target; }
+      |                        ^~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error-UNSUPPORTED: t/t_constraint_real_array_eq_unsup.v:24:24: Unsupported: real-element array compared in a constraint
+                                                              : ... note: In instance 't'
+   24 |   constraint c { frame != target; }
+      |                        ^~
+%Error: Exiting due to

--- a/test_regress/t/t_constraint_real_array_eq_unsup.py
+++ b/test_regress/t/t_constraint_real_array_eq_unsup.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('vlt')
+
+test.lint(fails=test.vlt_all, expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_constraint_real_array_eq_unsup.v
+++ b/test_regress/t/t_constraint_real_array_eq_unsup.v
@@ -1,0 +1,40 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// A scalar rand real reaching an == in a constraint is already a clean
+// compile-time E_UNSUPPORTED (see t_constraint_unsup.v); an array of real
+// took the whole-array-comparison path instead, which has no type check
+// of its own and only failed later at the solver.
+class C1;
+  rand real frame[2];
+  real target[2];
+  constraint c { frame == target; }
+  function new();
+    target[0] = 1.5;
+    target[1] = 2.5;
+  endfunction
+endclass
+
+class C2;
+  rand real frame[2];
+  real target[2];
+  constraint c { frame != target; }
+  function new();
+    target[0] = 1.5;
+    target[1] = 2.5;
+  endfunction
+endclass
+
+module t;
+  initial begin
+    C1 obj1;
+    C2 obj2;
+    obj1 = new;
+    obj2 = new;
+    if (obj1.randomize() == 0) $stop;
+    if (obj2.randomize() == 0) $stop;
+  end
+endmodule


### PR DESCRIPTION
Fixes #8273 

A real-element array compared with ==/!= in a constraint compiled cleanly but failed at runtime with a cryptic solver sort-mismatch — unlike the scalar real case, which already gets a clean E_UNSUPPORTED at compile time. Root cause: the scalar comparison lowers to an AstEqD node whose emitSMT() is the empty default, so the existing emptiness check catches it; the array comparison lowers to a plain AstEq/AstNeq instead, whose emitSMT() is a fixed non-empty template with no operand-type check, so the malformed width sailed through to the solver. Added a check ahead of editSMT() in visit(AstNodeBiop*) that diagnoses E_UNSUPPORTED when an ==/!= operand's array element type is isDouble(). New regression test covers both == and !=.