### PR TITLE
Fix incorrect reference to sync/async in SYNCASYNCNET warning

### DIFF
--- a/src/V3DfgDfgToAst.cpp
+++ b/src/V3DfgDfgToAst.cpp
@@ -316,13 +316,14 @@ class DfgToAstVisitor final : DfgVisitor {
             if (DfgAstRd* const rVtxp = vtx.cast<DfgAstRd>()) {
                 // Render the driver
                 AstNodeExpr* const exprp = convertDfgVertexToAstNodeExpr(rVtxp->srcp());
-                // If it's the same as the reference, do not repalce it so FileLines are preserved
+                // If it's the same as the reference, do not replace it so FileLines are preserved
                 if (exprp->sameTree(rVtxp->exprp())) {
                     VL_DO_DANGLING(exprp->deleteTree(), exprp);
                     continue;
                 }
                 // Replace the reference with the expression
                 if (VN_IS(exprp, VarRef)) {
+                    exprp->fileline(rVtxp->exprp()->fileline());
                     ++m_ctx.m_varRefsSubstituted;
                 } else {
                     ++m_ctx.m_expressionsInlined;

--- a/test_regress/t/t_lint_syncasyncnet_bad.out
+++ b/test_regress/t/t_lint_syncasyncnet_bad.out
@@ -1,10 +1,17 @@
-%Warning-SYNCASYNCNET: t/t_lint_syncasyncnet_bad.v:9:11: Signal flopped as both synchronous and async: 'rst_both_l'
-                       t/t_lint_syncasyncnet_bad.v:50:13: ... Location of async usage
-   50 |     q4 <= (~rst_both_l) ? 1'b0 : d;
+%Warning-SYNCASYNCNET: t/t_lint_syncasyncnet_bad.v:17:11: Signal flopped as both synchronous and async: 'rst_both_l'
+                       t/t_lint_syncasyncnet_bad.v:59:13: ... Location of async usage
+   59 |     q4 <= (~rst_both_l) ? 1'b0 : d;
       |             ^~~~~~~~~~
-                       t/t_lint_syncasyncnet_bad.v:31:12: ... Location of sync usage
-   31 |     q2 <= (rst_both_l) ? d : 1'b0;
+                       t/t_lint_syncasyncnet_bad.v:40:12: ... Location of sync usage
+   40 |     q2 <= (rst_both_l) ? d : 1'b0;
       |            ^~~~~~~~~~
                        ... For warning description see https://verilator.org/warn/SYNCASYNCNET?v=latest
                        ... Use "/* verilator lint_off SYNCASYNCNET */" and lint_on around source to disable this message.
+%Warning-SYNCASYNCNET: t/t_lint_syncasyncnet_bad.v:20:11: Signal flopped as both synchronous and async: 'rst_both_b'
+                       t/t_lint_syncasyncnet_bad.v:74:9: ... Location of async usage
+   74 |     if (rst_both_b) begin
+      |         ^~~~~~~~~~
+                       t/t_lint_syncasyncnet_bad.v:12:37: ... Location of sync usage
+   12 |   assert property (@(posedge clk_b) rst_b);
+      |                                     ^~~~~
 %Error: Exiting due to

--- a/test_regress/t/t_lint_syncasyncnet_bad.v
+++ b/test_regress/t/t_lint_syncasyncnet_bad.v
@@ -4,11 +4,20 @@
 // SPDX-FileCopyrightText: 2010 Wilson Snyder
 // SPDX-License-Identifier: CC0-1.0
 
+module b (
+  input clk_b,
+  input rst_b
+);
+/* verilator no_inline_module */
+  assert property (@(posedge clk_b) rst_b);
+endmodule
+
 module t (
     input clk,
     input rst_both_l,
     input rst_sync_l,
     input rst_async_l,
+    input rst_both_b,
     input d
 );
 
@@ -54,6 +63,17 @@ module t (
   always @(posedge clk or negedge rst_both_l) begin
     q5 <= (~rst_both_l) ? 1'b0 : d;
     if (0 && q3 && q4 && q5);
+  end
+
+  b t_b (
+    .clk_b(clk),
+    .rst_b(rst_both_b)
+  );
+  reg q6;
+  always_ff @(negedge rst_both_b) begin
+    if (rst_both_b) begin
+      q6 <= q6;
+    end
   end
 
   // Issue #7980 - should not cause a warning

--- a/test_regress/t/t_lint_syncasyncnet_bad2.out
+++ b/test_regress/t/t_lint_syncasyncnet_bad2.out
@@ -1,0 +1,10 @@
+%Warning-SYNCASYNCNET: t/t_lint_syncasyncnet_bad2.v:9:9: Signal flopped as both synchronous and async: 'rst_ni'
+                       t/t_lint_syncasyncnet_bad2.v:15:10: ... Location of async usage
+   15 |     if (!rst_ni) begin
+      |          ^~~~~~
+                       t/t_lint_syncasyncnet_bad2.v:19:53: ... Location of sync usage
+   19 |   NextStateCheck: assert property (@(posedge clk_i) rst_ni);
+      |                                                     ^~~~~~
+                       ... For warning description see https://verilator.org/warn/SYNCASYNCNET?v=latest
+                       ... Use "/* verilator lint_off SYNCASYNCNET */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_lint_syncasyncnet_bad2.py
+++ b/test_regress/t/t_lint_syncasyncnet_bad2.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('linter')
+
+test.lint(verilator_flags2=["-Wall -Wno-DECLFILENAME"],
+          fails=True,
+          expect_filename=test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_lint_syncasyncnet_bad2.v
+++ b/test_regress/t/t_lint_syncasyncnet_bad2.v
@@ -1,0 +1,20 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+module t (
+  input clk_i,
+  input rst_ni
+);
+/* verilator no_inline_module */
+// no-inline to root module
+  logic lfsr_d;
+  always_ff @(negedge rst_ni) begin
+    if (!rst_ni) begin
+      lfsr_d <= lfsr_d;
+    end
+  end
+  NextStateCheck: assert property (@(posedge clk_i) rst_ni);
+endmodule


### PR DESCRIPTION
This PR fixes incorrect reference to sync/async usage in `SYNCASYNCNET` warning.

An example causing this issue (**master**):
~~~systemverilog
/* verilator lint_off DECLFILENAME */
module cdl_prim_lfsr (
/* verilator lint_on DECLFILENAME */
  input clk_i,
  input rst_ni
);
/* verilator no_inline_module */
  logic lfsr_d;
  always_ff @(negedge rst_ni) begin
    if (!rst_ni) begin
      lfsr_d <= lfsr_d;
    end
  end
  NextStateCheck: assert property (@(posedge clk_i) rst_ni);
endmodule
~~~
Warning message (compiled with `-Wall`):
~~~error
%Warning-SYNCASYNCNET: test.v:5:9: Signal flopped as both synchronous and async: 'rst_ni'
                       test.v:5:9: ... Location of async usage
    5 |   input rst_ni
      |         ^~~~~~
                       test.v:5:9: ... Location of sync usage
    5 |   input rst_ni
      |         ^~~~~~
~~~
The warning points to the declaration, not the place where the problem occurred.

This problem happens because in `dfg-optimize` stage old `VARREF`s with right `fileline`s are replaced with a new ones after the optimization. It happens inside `DfgToAstVisitor`.

`DfgToAstVisitor::visit`:
~~~cpp
void visit(DfgVarPacked* vtxp) override {
    m_resultp = new AstVarRef{vtxp->fileline(), vtxp->vscp(), VAccess::READ};
}
~~~
New `VARREF` gets its `fileline` from `vtxp`. `vtxp` is created in `AstToDfgVisitor::getVarVertex`:
~~~cpp
DfgVertexVar* getVarVertex(AstVarScope* varp) {
    if (!varp->user2p()) {
        // TODO: fix this up when removing the different flavours of DfgVar
        const AstNodeDType* const dtypep = varp->dtypep()->skipRefp();
        DfgVertexVar* const vtxp
            = VN_IS(dtypep, UnpackArrayDType)
                  ? static_cast<DfgVertexVar*>(new DfgVarArray{m_dfg, varp})
                  : static_cast<DfgVertexVar*>(new DfgVarPacked{m_dfg, varp});
        varp->user2p(vtxp);
    }
    return varp->user2u().template to<DfgVertexVar*>();
}
~~~
so it gets the `fileline` from `AstVarScope`, and `VARSCOPE`s have `fileline`s pointing to the variable declaration (because multiple `VARREF`s can use same `VARSCOPE`). The PR's solution is to take the `fileline` from the original `VARREF` right before the swap (inside `DfgToAstVisitor` constructor) and give it to the new `VARREF`.