### PR TITLE
Optimize DFG vertex iteration callables

### DIFF
--- a/src/V3Dfg.h
+++ b/src/V3Dfg.h
@@ -247,7 +247,10 @@ public:
     // Calls given function 'f' for each source vertex of this vertex. If 'f'
     // returns true, further sources are not iterated and this method returns
     // true itself. Unconnected source edges are not iterated.
-    bool foreachSource(std::function<bool(DfgVertex&)> f) {
+    template <typename T_Callable>
+    bool foreachSource(T_Callable&& f) {
+        static_assert(vlstd::is_invocable_r<bool, T_Callable, DfgVertex&>::value,
+                      "T_Callable 'f' must have a signature compatible with 'bool(DfgVertex&)'");
         for (const std::unique_ptr<DfgEdge>& edgep : m_inputps) {
             if (DfgVertex* const srcp = edgep->srcp()) {
                 if (f(*srcp)) return true;
@@ -259,9 +262,13 @@ public:
     // Calls given function 'f' for each source vertex of this vertex. If 'f'
     // returns true, further sources are not iterated and this method returns
     // true itself. Unconnected source edges are not iterated.
-    bool foreachSource(std::function<bool(const DfgVertex&)> f) const {
+    template <typename T_Callable>
+    bool foreachSource(T_Callable&& f) const {
+        static_assert(
+            vlstd::is_invocable_r<bool, T_Callable, const DfgVertex&>::value,
+            "T_Callable 'f' must have a signature compatible with 'bool(const DfgVertex&)'");
         for (const std::unique_ptr<DfgEdge>& edgep : m_inputps) {
-            if (DfgVertex* const srcp = edgep->srcp()) {
+            if (const DfgVertex* const srcp = edgep->srcp()) {
                 if (f(*srcp)) return true;
             }
         }
@@ -272,7 +279,10 @@ public:
     // returns true, further sinks are not iterated and this method returns
     // true itself. Unlinking/deleting the given sink during iteration is safe,
     // but not other sinks of this vertex.
-    bool foreachSink(std::function<bool(DfgVertex&)> f) {
+    template <typename T_Callable>
+    bool foreachSink(T_Callable&& f) {
+        static_assert(vlstd::is_invocable_r<bool, T_Callable, DfgVertex&>::value,
+                      "T_Callable 'f' must have a signature compatible with 'bool(DfgVertex&)'");
         for (const DfgEdge* const edgep : m_sinks.unlinkable()) {
             if (f(*edgep->dstp())) return true;
         }
@@ -282,7 +292,11 @@ public:
     // Calls given function 'f' for each sink vertex of this vertex. If 'f'
     // returns true, further sinks are not iterated and this method returns
     // true itself.
-    bool foreachSink(std::function<bool(const DfgVertex&)> f) const {
+    template <typename T_Callable>
+    bool foreachSink(T_Callable&& f) const {
+        static_assert(
+            vlstd::is_invocable_r<bool, T_Callable, const DfgVertex&>::value,
+            "T_Callable 'f' must have a signature compatible with 'bool(const DfgVertex&)'");
         for (const DfgEdge& edge : m_sinks) {
             if (f(*edge.dstp())) return true;
         }

--- a/src/V3DfgVertices.h
+++ b/src/V3DfgVertices.h
@@ -485,28 +485,47 @@ public:
         return vtxp;
     }
 
-    bool foreachDriver(std::function<bool(DfgVertex&, uint32_t, FileLine*)> f) {
+    template <typename T_Callable,
+              std::enable_if_t<vlstd::is_invocable_r<bool, T_Callable, DfgVertex&, uint32_t,
+                                                     FileLine*>::value,  //
+                               int>
+              = 0>
+    bool foreachDriver(T_Callable&& f) {
         const size_t n = nInputs();
         for (size_t i = 0; i < n; ++i) {
             if (f(*inputp(i), m_driverData[i].m_lo, m_driverData[i].m_flp)) return true;
         }
         return false;
     }
-    bool foreachDriver(std::function<bool(const DfgVertex&, uint32_t, FileLine*)> f) const {
+    template <typename T_Callable,
+              std::enable_if_t<vlstd::is_invocable_r<bool, T_Callable, const DfgVertex&, uint32_t,
+                                                     FileLine*>::value,
+                               int>
+              = 0>
+    bool foreachDriver(T_Callable&& f) const {
         const size_t n = nInputs();
         for (size_t i = 0; i < n; ++i) {
             if (f(*inputp(i), m_driverData[i].m_lo, m_driverData[i].m_flp)) return true;
         }
         return false;
     }
-    bool foreachDriver(std::function<bool(DfgVertex&, uint32_t)> f) {
+    template <
+        typename T_Callable,
+        std::enable_if_t<vlstd::is_invocable_r<bool, T_Callable, DfgVertex&, uint32_t>::value,  //
+                         int>
+        = 0>
+    bool foreachDriver(T_Callable&& f) {
         const size_t n = nInputs();
         for (size_t i = 0; i < n; ++i) {
             if (f(*inputp(i), m_driverData[i].m_lo)) return true;
         }
         return false;
     }
-    bool foreachDriver(std::function<bool(const DfgVertex&, uint32_t)> f) const {
+    template <typename T_Callable,
+              std::enable_if_t<
+                  vlstd::is_invocable_r<bool, T_Callable, const DfgVertex&, uint32_t>::value, int>
+              = 0>
+    bool foreachDriver(T_Callable&& f) const {
         const size_t n = nInputs();
         for (size_t i = 0; i < n; ++i) {
             if (f(*inputp(i), m_driverData[i].m_lo)) return true;


### PR DESCRIPTION
Use templated callables for DfgVertex::foreachSource/foreachSink and DfgVertexSplice::foreachDriver similar to how AstNode::foreach does. This allows the compiler to inline lambdas.
