### PR TITLE
Fix use-after-free of captured interface typedef in deleted generate (#8076 repair)

### DIFF
--- a/src/V3Param.cpp
+++ b/src/V3Param.cpp
@@ -3269,6 +3269,7 @@ class ParamVisitor final : public VNVisitor {
             } else {
                 nodep->unlinkFrBack();
             }
+            V3LinkDotIfaceCapture::purgeDeletedSubtree(nodep);
             VL_DO_DANGLING(nodep->deleteTree(), nodep);
             // Normal edit rules will now recurse the replacement
         } else {

--- a/test_regress/t/t_iface_typedef_capture_uaf.v
+++ b/test_regress/t/t_iface_typedef_capture_uaf.v
@@ -38,6 +38,22 @@ module avmm_autopipeline (
   always_comb slave.req = internal_req;
 endmodule
 
+module genif_body #(
+    parameter bit ENABLE = 1
+) (
+    avmm_if.slave master,
+    avmm_if.master slave
+);
+  if (ENABLE) begin : gen_on
+    typedef master.request_t request_t;
+    request_t internal_req;
+    assign internal_req = master.req;
+    always_comb slave.req = internal_req;
+  end else begin : gen_off
+    always_comb slave.req = '0;
+  end
+endmodule
+
 module t;
   for (genvar g = 0; g < 2; ++g) begin : gen_block
     avmm_if #(.DW(32 * (g + 1))) m_if ();
@@ -48,8 +64,17 @@ module t;
     );
   end
 
+  avmm_if #(.DW(32)) on_m_if ();
+  avmm_if #(.DW(32)) on_s_if ();
+  avmm_if #(.DW(64)) off_m_if ();
+  avmm_if #(.DW(64)) off_s_if ();
+  // ENABLE=0 deletes the generate branch holding the captured typedef
+  genif_body #(.ENABLE(1)) body_on (.master(on_m_if), .slave(on_s_if));
+  genif_body #(.ENABLE(0)) body_off (.master(off_m_if), .slave(off_s_if));
+
   initial begin
     #1;
+    `checkd($bits(body_on.gen_on.internal_req), 33);
     `checkd($bits(gen_block[0].pipe.internal_req), 33);
     `checkd($bits(gen_block[1].pipe.internal_req), 65);
     $write("*-* All Finished *-*\n");


### PR DESCRIPTION
Follow-up to [verilator#8076](https://github.com/verilator/verilator/pull/8076), which added purgeDeletedSubtree but wired it into only one call site (deleteTreeCaptured in V3Width). V3Param never purged.

`ParamVisitor::visit(AstGenIf)` splices in the taken generate branch, then deletes the `AstGenIf` - which still holds the untaken branch. A dotted interface typedef there (IEEE 1800-2023 6.18) has its ledger-captured `AstRefDType` freed with it. `finalizeIfaceCapture()` nulls entries missing from the live-node snapshot, so a stale entry is usually harmless; once the freed slot is reallocated to a live node it passes that check and resolveCapturedRefs() dereferences it:
```
%Error: Internal Error: V3LinkDotIfaceCapture.cpp:971:
        could not retarget captured typedef '32'h6' in 'avmm_if__D20_A18_B3'
```
Fix: purge the ledger before the subtree is freed, after the taken branch has been unlinked, matching V3Width.

I've updated `t_iface_typedef_capture_uaf` to include this case.

PR prepared with Claude Code