### PR TITLE
Fix assignment pattern default fill of an array of unpacked structs

### DIFF
--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -5773,6 +5773,8 @@ class WidthVisitor final : public VNVisitor {
                 if (it == patmap.end()) {  // Default or default_type assignment
                     patp = defaultPatp_patternUOrStruct(nodep, memp, vdtypep, defaultp, dtypemap);
                     pushDeletep(patp);
+                    patp = defaultPatp_forDType(patp, memp->virtRefDTypep());
+                    pushDeletep(patp);
                 } else {
                     patp = it->second;  // Member assignment
                 }
@@ -5858,11 +5860,13 @@ class WidthVisitor final : public VNVisitor {
         return newp;
     }
 
-    AstPatMember* defaultPatp_patternArray(AstPatMember* defaultp, AstNodeDType* elemDTypep) {
+    AstPatMember* defaultPatp_forDType(AstPatMember* defaultp, AstNodeDType* elemDTypep) {
         AstNodeExpr* const valuep = defaultp->lhssp()->cloneTree(false);
         AstNodeDType* const elemDTypeSkipRefp = elemDTypep->skipRefp();
+        const AstStructDType* const structp = VN_CAST(elemDTypeSkipRefp, StructDType);
+        const bool unpackedStruct = structp && !structp->packed();
 
-        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType)) {
+        if (!VN_IS(elemDTypeSkipRefp, UnpackArrayDType) && !unpackedStruct) {
             VL_DO_DANGLING(pushDeletep(valuep), valuep);
             return defaultp->cloneTree(false);
         }
@@ -5871,9 +5875,14 @@ class WidthVisitor final : public VNVisitor {
             return defaultp->cloneTree(false);
         }
         if (!valuep->dtypep()) userIterate(valuep, WidthVP{SELF, BOTH}.p());
-        if (valuep->dtypep()
-            && AstNode::computeCastable(valuep->dtypep()->skipRefp(), elemDTypeSkipRefp, nullptr)
-                   .isAssignable()) {
+        bool wholeElement = unpackedStruct;
+        if (AstNodeDType* const valueDTypep = valuep->dtypep()) {
+            wholeElement = unpackedStruct ? !valueDTypep->skipRefp()->isIntegralOrPacked()
+                                          : AstNode::computeCastable(valueDTypep->skipRefp(),
+                                                                     elemDTypeSkipRefp, nullptr)
+                                                .isAssignable();
+        }
+        if (wholeElement) {
             VL_DO_DANGLING(pushDeletep(valuep), valuep);
             return defaultp->cloneTree(false);
         }
@@ -5899,7 +5908,7 @@ class WidthVisitor final : public VNVisitor {
             const auto it = patmap.find(ent);
             if (it == patmap.end()) {
                 if (defaultp) {
-                    newpatp = defaultPatp_patternArray(defaultp, arrayDtp->subDTypep());
+                    newpatp = defaultPatp_forDType(defaultp, arrayDtp->subDTypep());
                     patp = newpatp;
                 } else if (!(VN_IS(arrayDtp, UnpackArrayDType) && !allConstant && isConcat)) {
                     // If arrayDtp is an unpacked array and item is not constant,

--- a/test_regress/t/t_array_pattern_default_recursive.v
+++ b/test_regress/t/t_array_pattern_default_recursive.v
@@ -6,10 +6,38 @@
 
 module t;
 
+  typedef struct {
+    int         i;
+    logic [7:0] b;
+  } unpacked_t;
+
+  typedef struct {
+    int         x;
+    logic [3:0] y;
+  } inner_t;
+
+  typedef struct {
+    inner_t in;
+    int     sub[2];
+  } nested_t;
+
+  typedef struct packed {
+    int         i;
+    logic [7:0] b;
+  } packed_t;
+
   int arr_default_scalar[4][4];
   int row[4];
   int arr_default_array[2][4];
   int arr_mixed_default[2][3];
+  unpacked_t arr_default_ustruct[3];
+  unpacked_t arr_default_ustruct_2d[2][3];
+  unpacked_t ustruct;
+  unpacked_t arr_default_ustruct_var[3];
+  packed_t arr_default_pstruct[3];
+  nested_t arr_nested[2];
+  nested_t nested_scalar;
+  unpacked_t arr_nested_default[3];
 
   initial begin
     arr_default_scalar = '{default: 0};
@@ -30,6 +58,52 @@ module t;
     if (arr_mixed_default[1][0] != 2) $stop;
     if (arr_mixed_default[1][1] != 2) $stop;
     if (arr_mixed_default[1][2] != 2) $stop;
+
+    arr_default_ustruct = '{default: '0};
+    foreach (arr_default_ustruct[i]) begin
+      if (arr_default_ustruct[i].i != 0) $stop;
+      if (arr_default_ustruct[i].b != 0) $stop;
+    end
+
+    arr_default_ustruct_2d = '{default: '1};
+    foreach (arr_default_ustruct_2d[i, j]) begin
+      if (arr_default_ustruct_2d[i][j].i != -1) $stop;
+      if (arr_default_ustruct_2d[i][j].b != 8'hff) $stop;
+    end
+
+    ustruct = '{i: 1, b: 8'h23};
+    arr_default_ustruct_var = '{default: ustruct};
+    foreach (arr_default_ustruct_var[i]) begin
+      if (arr_default_ustruct_var[i].i != 1) $stop;
+      if (arr_default_ustruct_var[i].b != 8'h23) $stop;
+    end
+
+    arr_default_pstruct = '{default: '0};
+    foreach (arr_default_pstruct[i]) begin
+      if (arr_default_pstruct[i].i != 0) $stop;
+      if (arr_default_pstruct[i].b != 0) $stop;
+    end
+
+    // Nested unpacked aggregates must fill member-wise, not take the value whole
+    nested_scalar = '{default: '1};
+    if (nested_scalar.in.x != -1) $stop;
+    if (nested_scalar.in.y != 4'hf) $stop;
+    if (nested_scalar.sub[0] != -1) $stop;
+    if (nested_scalar.sub[1] != -1) $stop;
+
+    arr_nested = '{default: '1};
+    foreach (arr_nested[i]) begin
+      if (arr_nested[i].in.x != -1) $stop;
+      if (arr_nested[i].in.y != 4'hf) $stop;
+      if (arr_nested[i].sub[0] != -1) $stop;
+      if (arr_nested[i].sub[1] != -1) $stop;
+    end
+
+    arr_nested_default = '{default: '{default: '1}};
+    foreach (arr_nested_default[i]) begin
+      if (arr_nested_default[i].i != -1) $stop;
+      if (arr_nested_default[i].b != 8'hff) $stop;
+    end
 
     $write("*-* All Finished *-*\n");
     $finish;


### PR DESCRIPTION
`'{default: '0}` into an unpacked array of unpacked structs emits a whole-element assignment, lowering to `elem = 0u` against the generated struct class:

```
error: no match for 'operator=' (operand types are
  'Vt_t__DOT__unpacked_t__struct__0' and 'unsigned int')
```

IEEE 1800-2023 10.9.1 requires a recursive descent into an array of structures. `defaultPatp_patternArray` misses it because `computeCastable` models unpacked structs as numeric, so a bare fill token looks assignable; it now builds the nested pattern and `patternUOrStruct` fills member-wise. A pattern value, or one of the element's own type, still assigns whole. Unpacked unions are left as they were, recursing initializes every member, which also fails to compile.

PR prepared with Claude Code.