### PR TITLE
Internals: Move wrapTop before V3Coverage

### DIFF
--- a/src/V3Assert.cpp
+++ b/src/V3Assert.cpp
@@ -433,20 +433,20 @@ class AssertVisitor final : public VNVisitor {
         if (!m_monitorNumVarp) {
             m_monitorNumVarp = new AstVar{nodep->fileline(), VVarType::MODULETEMP, "__VmonitorNum",
                                           nodep->findUInt64DType()};
-            v3Global.rootp()->dollarUnitPkgAddp()->addStmtsp(m_monitorNumVarp);
+            v3Global.rootp()->dollarUnitPkgp()->addStmtsp(m_monitorNumVarp);
         }
         AstVarRef* const varrefp = new AstVarRef{nodep->fileline(), m_monitorNumVarp, access};
-        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgAddp());
+        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgp());
         return varrefp;
     }
     AstVarRef* newMonitorOffVarRefp(const AstNode* nodep, VAccess access) {
         if (!m_monitorOffVarp) {
             m_monitorOffVarp = new AstVar{nodep->fileline(), VVarType::MODULETEMP, "__VmonitorOff",
                                           nodep->findBitDType()};
-            v3Global.rootp()->dollarUnitPkgAddp()->addStmtsp(m_monitorOffVarp);
+            v3Global.rootp()->dollarUnitPkgp()->addStmtsp(m_monitorOffVarp);
         }
         AstVarRef* const varrefp = new AstVarRef{nodep->fileline(), m_monitorOffVarp, access};
-        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgAddp());
+        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgp());
         return varrefp;
     }
     static AstIf* newIfAssertOn(AstNode* bodyp, VAssertDirectiveType directiveType,

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -313,7 +313,6 @@ class AstNodeModule VL_NOT_FINAL : public AstNode {
     bool m_hasParameterList : 1;  // Has #() for parameter declaration
     bool m_hierBlock : 1;  // Hierarchical Block marked by HIER_BLOCK pragma
     bool m_hierParams : 1;  // Block containing params for parameterized hier blocks
-    bool m_internal : 1;  // Internally created
     bool m_recursive : 1;  // Recursive module
     bool m_recursiveClone : 1;  // If recursive, what module it clones, otherwise nullptr
     bool m_parameterizedTemplate : 1;  // True when at least one specialized clone exists;
@@ -335,7 +334,6 @@ protected:
         , m_hasParameterList{false}
         , m_hierBlock{false}
         , m_hierParams{false}
-        , m_internal{false}
         , m_recursive{false}
         , m_recursiveClone{false}
         , m_parameterizedTemplate{false}
@@ -379,8 +377,6 @@ public:
     void hierBlock(bool flag) { m_hierBlock = flag; }
     bool hierParams() const { return m_hierParams; }
     void hierParams(bool flag) { m_hierParams = flag; }
-    bool internal() const { return m_internal; }
-    void internal(bool flag) { m_internal = flag; }
     bool recursive() const { return m_recursive; }
     void recursive(bool flag) { m_recursive = flag; }
     void recursiveClone(bool flag) { m_recursiveClone = flag; }
@@ -1492,7 +1488,7 @@ public:
     void astConstOrigParamName(const AstConst* nodep, const string& name);
     void astConstOrigParamNameErase(const AstConst* nodep);
     AstPackage* dollarUnitPkgp() const { return m_dollarUnitPkgp; }
-    AstPackage* dollarUnitPkgAddp();
+    void dollarUnitPkgp(AstPackage* const packagep) { m_dollarUnitPkgp = packagep; }
     AstCFunc* evalFuncp(VEval eval) const { return m_evalFuncps[eval]; }
     void evalFuncp(VEval eval, AstCFunc* funcp) { m_evalFuncps[eval] = funcp; }
     AstCFunc* dumpTriggersFuncp(VEval eval) const { return m_dumpTriggersFuncps[eval]; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1907,9 +1907,15 @@ AstNodeBiop* AstNeq::newTyped(FileLine* fl, AstNodeExpr* lhsp, AstNodeExpr* rhsp
 AstNetlist::AstNetlist()
     : ASTGEN_SUPER_Netlist(new FileLine{FileLine::builtInFilename()})
     , m_typeTablep{new AstTypeTable{fileline()}}
-    , m_constPoolp{new AstConstPool{fileline()}} {
+    , m_constPoolp{new AstConstPool{fileline()}}
+    , m_dollarUnitPkgp{new AstPackage{fileline(), AstPackage::dollarUnitName(), "work"}} {
     addMiscsp(m_typeTablep);
     addMiscsp(m_constPoolp);
+    // packages are always libraries; don't want to make them a "top"
+    m_dollarUnitPkgp->level(1);
+    m_dollarUnitPkgp->inLibrary(true);
+    m_dollarUnitPkgp->modTrace(false);  // may reconsider later
+    addModulesp(m_dollarUnitPkgp);
 }
 void AstNetlist::addEvalStats(const std::string& phase) {
     if (!v3Global.opt.stats()) return;
@@ -1975,18 +1981,6 @@ void AstNetlist::deleteContents() {
     if (op3p()) op3p()->unlinkFrBackWithNext()->deleteTree();
     if (op4p()) op4p()->unlinkFrBackWithNext()->deleteTree();
 #undef VN_DELETE_ONE
-}
-AstPackage* AstNetlist::dollarUnitPkgAddp() {
-    if (!m_dollarUnitPkgp) {
-        m_dollarUnitPkgp = new AstPackage{fileline(), AstPackage::dollarUnitName(), "work"};
-        // packages are always libraries; don't want to make them a "top"
-        m_dollarUnitPkgp->level(1);
-        m_dollarUnitPkgp->inLibrary(true);
-        m_dollarUnitPkgp->modTrace(false);  // may reconsider later
-        m_dollarUnitPkgp->internal(true);
-        addModulesp(m_dollarUnitPkgp);
-    }
-    return m_dollarUnitPkgp;
 }
 void AstNetlist::dump(std::ostream& str) const {
     Super::dump(str);

--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -283,7 +283,7 @@ class CoverageVisitor final : public VNVisitor {
         VL_RESTORER_COPY(m_funcTemps);
         createHandle(nodep);
         m_modp = nodep;
-        m_state.m_inModOff = false;  // Haven't made top shell, so tops are real tops
+        m_state.m_inModOff = nodep->isTop();  // Already made top shell, no coverage for it
         if (!origModp) {
             // No blocks cross (non-nested) modules, so save some memory
             m_varnames.clear();

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -400,7 +400,10 @@ class DeadVisitor final : public VNVisitor {
             AstNodeModule* nextmodp;
             for (AstNodeModule* modp = v3Global.rootp()->modulesp(); modp; modp = nextmodp) {
                 nextmodp = VN_AS(modp->nextp(), NodeModule);
-                if (modp->dead() || (!modp->isTop() && modp->user1() == 0 && !modp->internal())) {
+                // Keep $unit until m_elimCells stages. Note v3Global.opt.serializeOnly()
+                // won't reach this stage, and will always have an empty $unit. That's ok.
+                const bool keep = !m_elimCells && modp == v3Global.rootp()->dollarUnitPkgp();
+                if (modp->dead() || (!modp->isTop() && modp->user1() == 0 && !keep)) {
                     // > 2 because L1 is the wrapper, L2 is the top user module
                     UINFO(4, "  Dead module " << modp);
                     // And its children may now be killable too; correct counts
@@ -409,6 +412,9 @@ class DeadVisitor final : public VNVisitor {
                         modp->foreach([](const AstCell* cellp) {  //
                             cellp->modp()->user1Inc(-1);
                         });
+                    }
+                    if (modp == v3Global.rootp()->dollarUnitPkgp()) {
+                        v3Global.rootp()->dollarUnitPkgp(nullptr);
                     }
                     deleting(modp);
                     retry = true;

--- a/src/V3LinkCells.cpp
+++ b/src/V3LinkCells.cpp
@@ -467,7 +467,7 @@ class LinkCellsVisitor final : public VNVisitor {
             if (nodep->fileline()->filebasenameNoExt() != nodep->prettyName()
                 && !v3Global.opt.isLibraryFile(nodep->fileline()->filename(), nodep->libname())
                 && !VN_IS(nodep, NotFoundModule) && !nodep->recursiveClone()
-                && !nodep->internal()) {
+                && nodep != v3Global.rootp()->dollarUnitPkgp()) {
                 // We only complain once per file, otherwise library-like files
                 // have a huge mess of warnings
                 const auto itFoundPair = m_declfnWarned.insert(nodep->fileline()->filename());

--- a/src/V3LinkDot.cpp
+++ b/src/V3LinkDot.cpp
@@ -1216,7 +1216,14 @@ class LinkDotFindVisitor final : public VNVisitor {
         // (sorted before this is called).
         // This may not be the module with isTop() set, as early in the steps,
         // wrapTop may have not been created yet.
-        if (!nodep->modulesp()) nodep->v3error("No top level module found");
+        // $unit always exists, so nothing else, and nothing in it, means nothing was given
+        AstNodeModule* const modulesp = nodep->modulesp();
+        UASSERT_OBJ(modulesp, nodep, "$unit should always be in the netlist");
+        if (!modulesp->nextp()) {
+            UASSERT_OBJ(modulesp == v3Global.rootp()->dollarUnitPkgp(), modulesp,
+                        "Sole module should be $unit");
+            if (!modulesp->stmtsp()) nodep->v3error("No top level module found");
+        }
         for (AstNodeModule* modp = nodep->modulesp(); modp && modp->isTop();
              modp = VN_AS(modp->nextp(), NodeModule)) {
             UINFO(8, "Top Module: " << modp);
@@ -1405,7 +1412,7 @@ class LinkDotFindVisitor final : public VNVisitor {
     }
     void visit(AstClassOrPackageRef* nodep) override {  // FindVisitor::
         if (!nodep->classOrPackageNodep() && nodep->name() == "$unit") {
-            nodep->classOrPackageNodep(v3Global.rootp()->dollarUnitPkgAddp());
+            nodep->classOrPackageNodep(v3Global.rootp()->dollarUnitPkgp());
         }
         iterateChildren(nodep);
     }

--- a/src/V3LinkJump.cpp
+++ b/src/V3LinkJump.cpp
@@ -211,7 +211,7 @@ class LinkJumpVisitor final : public VNVisitor {
         if (!processQueuep->lifetime().isStatic() || processQueuep->isTemp()) {
             return new AstVarRef{fl, processQueuep, access};
         }
-        AstPackage* const topPkgp = v3Global.rootp()->dollarUnitPkgAddp();
+        AstPackage* const topPkgp = v3Global.rootp()->dollarUnitPkgp();
         return new AstVarRef{fl, topPkgp, processQueuep, access};
     }
     static AstStmtExpr* getQueuePushProcessSelfp(FileLine* const fl, AstVar* const processQueuep) {
@@ -275,7 +275,7 @@ class LinkJumpVisitor final : public VNVisitor {
         AstNodeModule* const ownerp = findOwnerModulep(nodep);
 
         if (VN_IS(ownerp, Package) || VN_IS(ownerp, Class)) {
-            AstPackage* const topPkgp = v3Global.rootp()->dollarUnitPkgAddp();
+            AstPackage* const topPkgp = v3Global.rootp()->dollarUnitPkgp();
             AstVar* const processQueuep = newProcessQueuep(nodep, fl, VVarType::VAR);
             processQueuep->lifetime(VLifetime::STATIC_EXPLICIT);
             topPkgp->addStmtsp(processQueuep);

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -291,7 +291,7 @@ public:
     size_t flexPpInputToLex(char* buf, size_t max_size) { return ppInputToLex(buf, max_size); }
 
     //==== Symbol tables
-    AstPackage* unitPackage(FileLine* /*fl*/) { return parsep()->rootp()->dollarUnitPkgAddp(); }
+    AstPackage* unitPackage(FileLine* /*fl*/) { return parsep()->rootp()->dollarUnitPkgp(); }
 
     // CONSTRUCTORS
     V3ParseImp(AstNetlist* rootp, VInFilter* filterp)

--- a/src/V3Randomize.cpp
+++ b/src/V3Randomize.cpp
@@ -3957,7 +3957,7 @@ class RandomizeVisitor final : public VNVisitor {
         varp->isStatic(true);
         varp->valuep(initp);
         // Add to root, as don't know module we are in, and aids later structure sharing
-        v3Global.rootp()->dollarUnitPkgAddp()->addStmtsp(varp);
+        v3Global.rootp()->dollarUnitPkgp()->addStmtsp(varp);
 
         UASSERT_OBJ(nodep->itemsp(), nodep, "Enum without items");
         for (AstEnumItem* itemp = nodep->itemsp(); itemp;
@@ -4130,7 +4130,7 @@ class RandomizeVisitor final : public VNVisitor {
                                                       EnumDType)) {
                 AstVarRef* const tabRefp
                     = new AstVarRef{fl, enumValueTabp(enumDtp), VAccess::READ};
-                tabRefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgAddp());
+                tabRefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgp());
                 AstNodeExpr* const randp
                     = newRandValue(fl, randcVarp, exprp->findBasicDType(VBasicDTypeKwd::UINT32));
                 AstNodeExpr* const moddivp = new AstModDiv{

--- a/src/V3Width.cpp
+++ b/src/V3Width.cpp
@@ -9919,7 +9919,7 @@ class WidthVisitor final : public VNVisitor {
             varp->isStatic(true);
             varp->valuep(initp);
             // Add to root, as don't know module we are in, and aids later structure sharing
-            v3Global.rootp()->dollarUnitPkgAddp()->addStmtsp(varp);
+            v3Global.rootp()->dollarUnitPkgp()->addStmtsp(varp);
             // Element 0 is a non-index and has speced values
             initp->addValuep(dimensionValue(nodep->fileline(), nodep, attrType, 0));
             for (unsigned i = 1; i < msbdim + 1; ++i) {
@@ -9988,7 +9988,7 @@ class WidthVisitor final : public VNVisitor {
             varp->isStatic(true);
             varp->valuep(initp);
             // Add to root, as don't know module we are in, and aids later structure sharing
-            v3Global.rootp()->dollarUnitPkgAddp()->addStmtsp(varp);
+            v3Global.rootp()->dollarUnitPkgp()->addStmtsp(varp);
 
             // Default for all unspecified values
             if (attrType == VAttrType::ENUM_NAME) {
@@ -10285,7 +10285,7 @@ class WidthVisitor final : public VNVisitor {
     }
     static AstVarRef* newVarRefDollarUnit(AstVar* nodep) {
         AstVarRef* const varrefp = new AstVarRef{nodep->fileline(), nodep, VAccess::READ};
-        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgAddp());
+        varrefp->classOrPackagep(v3Global.rootp()->dollarUnitPkgp());
         return varrefp;
     }
     AstNode* nodeForUnsizedWarning(AstNode* nodep) {

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -233,11 +233,22 @@ static void process() {
             v3Global.vlExit(0);
         }
 
-        // Insert generic non-FSM coverage before dead code elimination and
-        // inlining, or those opportunities may be optimized away. FSM
-        // coverage is handled later in V3FsmDetect, after scoping has created
-        // the AST context needed to recover and lower FSMs reliably.
-        if (v3Global.opt.coverageNonFsm()) V3Coverage::coverage(v3Global.rootp());
+        if (!v3Global.opt.serializeOnly() || v3Global.opt.flatten()) {
+            // Add top level wrapper with instance pointing to old top
+            // Move packages to under new top
+            // Must do this after we know parameters and dtypes (as don't clone dtype decls)
+            V3LinkLevel::wrapTop(v3Global.rootp());
+        } else {
+            V3LinkLevel::nonWrapTop(v3Global.rootp());
+        }
+
+        if (!v3Global.opt.serializeOnly()) {
+            // Insert generic code coverage before dead code elimination and
+            // inlining, or those opportunities may be optimized away. FSM
+            // coverage is handled later in V3FsmDetect, after scoping has created
+            // the AST context needed to recover and lower FSMs reliably.
+            if (v3Global.opt.coverageNonFsm()) V3Coverage::coverage(v3Global.rootp());
+        }
 
         // Functional coverage code generation
         //    Generate code for covergroups/coverpoints
@@ -267,15 +278,6 @@ static void process() {
         V3AssertPre::assertPreAll(v3Global.rootp());
         //
         V3Assert::assertAll(v3Global.rootp());
-
-        if (!(v3Global.opt.serializeOnly() && !v3Global.opt.flatten())) {
-            // Add top level wrapper with instance pointing to old top
-            // Move packages to under new top
-            // Must do this after we know parameters and dtypes (as don't clone dtype decls)
-            V3LinkLevel::wrapTop(v3Global.rootp());
-        } else {
-            V3LinkLevel::nonWrapTop(v3Global.rootp());
-        }
 
         // Propagate constants into expressions
         if (v3Global.opt.fConstBeforeDfg()) V3Const::constifyAllLint(v3Global.rootp());

--- a/test_regress/t/t_debug_emitv.out
+++ b/test_regress/t/t_debug_emitv.out
@@ -1007,229 +1007,6 @@ module Vt_debug_emitv_t;
     Vt_debug_emitv_cg_cross cg_cross_instVt_debug_emitv_cg_cross;
     cg_cross_inst = new();
 endmodule
-package Vt_debug_emitv_std;
-    class Vt_debug_emitv_semaphore;
-        int signed m_keyCount;
-        int signed m_nextKeyCount;
-        m_nextKeyCount = 32'hffffffff;
-        longint m_ticket;
-        m_ticket = 64'h0;
-        longint m_nextTicket;
-        m_nextTicket = 64'h0;
-        function new;
-            input int signed keyCount;
-            m_keyCount = keyCount;
-        endfunction
-        task put;
-            input int signed keyCount;
-            m_keyCount = (m_keyCount + keyCount);
-        endtask
-        task get;
-            longint __Vincrement1;
-            input int signed keyCount;
-            longint ticket;
-            begin : label3
-                ticket = /*CRESET*/;
-                if (((m_keyCount >= keyCount) && (m_nextKeyCount 
-                                                  > 
-                                                  m_keyCount))) begin
-                    begin
-                        m_keyCount = (m_keyCount - 
-                                      keyCount);
-                        disable label3;
-                    end
-                end
-                __Vincrement1 = m_nextTicket;
-                m_nextTicket = (m_nextTicket + 64'h1);
-                ticket = __Vincrement1;
-                wait((m_ticket == ticket));
-                m_nextKeyCount = keyCount;
-                wait((m_keyCount >= keyCount));
-                m_keyCount = (m_keyCount - keyCount);
-                m_ticket = (m_ticket + 64'h1);
-            end
-        endtask
-        function try_get;
-            input int signed keyCount;
-            begin : label4
-                try_get = /*CRESET*/;
-                if ((m_keyCount < keyCount)) begin
-                    try_get = 'sh0;
-                    disable label4;
-                end
-                m_keyCount = (m_keyCount - keyCount);
-                try_get = 'sh1;
-                disable label4;
-            end
-        endfunction
-    endclass
-    class Vt_debug_emitv_process;
-        typedef enum int signed{
-            FINISHED = 32'h0,
-            RUNNING = 32'h1,
-            WAITING = 32'h2,
-            SUSPENDED = 32'h3,
-            KILLED = 32'h4
-        } state;
-        VlProcessRef m_process;
-        function self;
-            Vt_debug_emitv_process pVt_debug_emitv_process;
-            begin : label5
-                self = /*CRESET*/;
-                p = new();
-                $c(p.m_process = vlProcess;);
-                self = p;
-                disable label5;
-            end
-        endfunction
-        task set_status;
-            input int signed s;
-            $c(m_process->state(s););
-        endtask
-        function status;
-            begin : label6
-                status = /*CRESET*/;
-                status = ($c(m_process->state()));
-                disable label6;
-            end
-        endfunction
-        task kill;
-            set_status(process::KILLED);
-        endtask
-        task suspend;
-            $error("std::process::suspend() not supported");
-            $stop;
-        endtask
-        task resume;
-            set_status(process::RUNNING);
-        endtask
-        task await;
-            wait(((status() == process::FINISHED) || 
-                  (status() == process::KILLED)));
-        endtask
-        task killQueue;
-            ref Vt_debug_emitv_process processQueue[$]Vt_debug_emitv_process;
-            begin : unnamedblk1_1
-                int signed __Vrepeat0;
-                __Vrepeat0 = processQueue.size();
-                while ((__Vrepeat0 > 32'h0)) begin
-                    begin : unnamedblk1
-                        Vt_debug_emitv_process pVt_debug_emitv_process;
-                        p = processQueue.pop_front();
-                        if ((null != p)) begin
-                            kill();
-                        end
-                    end
-                    __Vrepeat0 = (__Vrepeat0 - 32'h1);
-                end
-            end
-        endtask
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-
-        ???? // SYSTEMCSECTION
-        function get_randstate;
-            string s;
-            begin : label7
-                get_randstate = /*CRESET*/;
-                s = string'($c(0));
-                $c(s = m_process->randstate(););
-                get_randstate = s;
-                disable label7;
-            end
-        endfunction
-        task set_randstate;
-            input string s;
-            $c(m_process->randstate(s););
-        endtask
-        function new;
-        endfunction
-        process::FINISHEDprocess::KILLEDprocess::RUNNINGprocess::SUSPENDEDprocess::WAITINGendclass
-    function randomize;
-        randomize = 'sh0;
-    endfunction
-    typedef struct {
-        string name;
-        int signed weight;
-        int signed goal;
-        string comment;
-        int signed at_least;
-        int signed auto_bin_max;
-        int signed cross_num_print_missing;
-        bit cross_retain_auto_bins;
-        bit detect_overlap;
-        bit per_instance;
-        bit get_inst_coverage;
-    } vl_covergroup_options_t;
-    typedef struct {
-        int signed weight;
-        int signed goal;
-        string comment;
-        int signed at_least;
-        int signed auto_bin_max;
-        bit detect_overlap;
-    } vl_coverpoint_options_t;
-    typedef struct {
-        int signed weight;
-        int signed goal;
-        string comment;
-        int signed at_least;
-        int signed cross_num_print_missing;
-        bit cross_retain_auto_bins;
-    } vl_cross_options_t;
-    typedef struct {
-        int signed weight;
-        int signed goal;
-        string comment;
-        bit strobe;
-        bit merge_instances;
-        bit distribute_first;
-        real real_interval;
-    } vl_covergroup_type_options_t;
-    typedef struct {
-        int signed weight;
-        int signed goal;
-        string comment;
-        real real_interval;
-    } vl_coverpoint_type_options_t;
-    typedef struct {
-        int signed weight;
-        int signed goal;
-        string comment;
-    } vl_cross_type_options_t;
-endpackage
 package Vt_debug_emitv___024unit;
     class Vt_debug_emitv_Cls;
         bit cg_clk;
@@ -1353,13 +1130,236 @@ package Vt_debug_emitv___024unit;
     function rand_restricted;
         input Vt_debug_emitv_Cls objVt_debug_emitv_Cls;
         input int signed member;
-        begin : label8
+        begin : label3
             rand_restricted = randomize() with (
                 ???? // CONSTRAINTEXPR
                 (__Vrandwith_obj.rmember1 < member)) ;
-            disable label8;
+            disable label3;
         end
     endfunction
+endpackage
+package Vt_debug_emitv_std;
+    class Vt_debug_emitv_semaphore;
+        int signed m_keyCount;
+        int signed m_nextKeyCount;
+        m_nextKeyCount = 32'hffffffff;
+        longint m_ticket;
+        m_ticket = 64'h0;
+        longint m_nextTicket;
+        m_nextTicket = 64'h0;
+        function new;
+            input int signed keyCount;
+            m_keyCount = keyCount;
+        endfunction
+        task put;
+            input int signed keyCount;
+            m_keyCount = (m_keyCount + keyCount);
+        endtask
+        task get;
+            longint __Vincrement1;
+            input int signed keyCount;
+            longint ticket;
+            begin : label4
+                ticket = /*CRESET*/;
+                if (((m_keyCount >= keyCount) && (m_nextKeyCount 
+                                                  > 
+                                                  m_keyCount))) begin
+                    begin
+                        m_keyCount = (m_keyCount - 
+                                      keyCount);
+                        disable label4;
+                    end
+                end
+                __Vincrement1 = m_nextTicket;
+                m_nextTicket = (m_nextTicket + 64'h1);
+                ticket = __Vincrement1;
+                wait((m_ticket == ticket));
+                m_nextKeyCount = keyCount;
+                wait((m_keyCount >= keyCount));
+                m_keyCount = (m_keyCount - keyCount);
+                m_ticket = (m_ticket + 64'h1);
+            end
+        endtask
+        function try_get;
+            input int signed keyCount;
+            begin : label5
+                try_get = /*CRESET*/;
+                if ((m_keyCount < keyCount)) begin
+                    try_get = 'sh0;
+                    disable label5;
+                end
+                m_keyCount = (m_keyCount - keyCount);
+                try_get = 'sh1;
+                disable label5;
+            end
+        endfunction
+    endclass
+    class Vt_debug_emitv_process;
+        typedef enum int signed{
+            FINISHED = 32'h0,
+            RUNNING = 32'h1,
+            WAITING = 32'h2,
+            SUSPENDED = 32'h3,
+            KILLED = 32'h4
+        } state;
+        VlProcessRef m_process;
+        function self;
+            Vt_debug_emitv_process pVt_debug_emitv_process;
+            begin : label6
+                self = /*CRESET*/;
+                p = new();
+                $c(p.m_process = vlProcess;);
+                self = p;
+                disable label6;
+            end
+        endfunction
+        task set_status;
+            input int signed s;
+            $c(m_process->state(s););
+        endtask
+        function status;
+            begin : label7
+                status = /*CRESET*/;
+                status = ($c(m_process->state()));
+                disable label7;
+            end
+        endfunction
+        task kill;
+            set_status(process::KILLED);
+        endtask
+        task suspend;
+            $error("std::process::suspend() not supported");
+            $stop;
+        endtask
+        task resume;
+            set_status(process::RUNNING);
+        endtask
+        task await;
+            wait(((status() == process::FINISHED) || 
+                  (status() == process::KILLED)));
+        endtask
+        task killQueue;
+            ref Vt_debug_emitv_process processQueue[$]Vt_debug_emitv_process;
+            begin : unnamedblk1_1
+                int signed __Vrepeat0;
+                __Vrepeat0 = processQueue.size();
+                while ((__Vrepeat0 > 32'h0)) begin
+                    begin : unnamedblk1
+                        Vt_debug_emitv_process pVt_debug_emitv_process;
+                        p = processQueue.pop_front();
+                        if ((null != p)) begin
+                            kill();
+                        end
+                    end
+                    __Vrepeat0 = (__Vrepeat0 - 32'h1);
+                end
+            end
+        endtask
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+
+        ???? // SYSTEMCSECTION
+        function get_randstate;
+            string s;
+            begin : label8
+                get_randstate = /*CRESET*/;
+                s = string'($c(0));
+                $c(s = m_process->randstate(););
+                get_randstate = s;
+                disable label8;
+            end
+        endfunction
+        task set_randstate;
+            input string s;
+            $c(m_process->randstate(s););
+        endtask
+        function new;
+        endfunction
+        process::FINISHEDprocess::KILLEDprocess::RUNNINGprocess::SUSPENDEDprocess::WAITINGendclass
+    function randomize;
+        randomize = 'sh0;
+    endfunction
+    typedef struct {
+        string name;
+        int signed weight;
+        int signed goal;
+        string comment;
+        int signed at_least;
+        int signed auto_bin_max;
+        int signed cross_num_print_missing;
+        bit cross_retain_auto_bins;
+        bit detect_overlap;
+        bit per_instance;
+        bit get_inst_coverage;
+    } vl_covergroup_options_t;
+    typedef struct {
+        int signed weight;
+        int signed goal;
+        string comment;
+        int signed at_least;
+        int signed auto_bin_max;
+        bit detect_overlap;
+    } vl_coverpoint_options_t;
+    typedef struct {
+        int signed weight;
+        int signed goal;
+        string comment;
+        int signed at_least;
+        int signed cross_num_print_missing;
+        bit cross_retain_auto_bins;
+    } vl_cross_options_t;
+    typedef struct {
+        int signed weight;
+        int signed goal;
+        string comment;
+        bit strobe;
+        bit merge_instances;
+        bit distribute_first;
+        real real_interval;
+    } vl_covergroup_type_options_t;
+    typedef struct {
+        int signed weight;
+        int signed goal;
+        string comment;
+        real real_interval;
+    } vl_coverpoint_type_options_t;
+    typedef struct {
+        int signed weight;
+        int signed goal;
+        string comment;
+    } vl_cross_type_options_t;
 endpackage
 interface Vt_debug_emitv_Iface;
     input logic clk;

--- a/test_regress/t/t_export_packed_struct2.cpp
+++ b/test_regress/t/t_export_packed_struct2.cpp
@@ -57,8 +57,8 @@ endclass  //cls
 #define EXPORTED_UNION_NAME(UNION_NAME, NUMBER) \
     CONCAT5(VM_PREFIX, _, UNION_NAME, __union__, NUMBER)
 #define SUB_T EXPORTED_UNION_NAME(sub_t, 0)
-#define IN_T EXPORTED_STRUCT_NAME(in_t, 0)
-#define IN2_T EXPORTED_STRUCT_NAME(in_t, 1)
+#define IN_T EXPORTED_STRUCT_NAME(in_t, 1)
+#define IN2_T EXPORTED_STRUCT_NAME(in_t, 0)
 #define OUT_T EXPORTED_STRUCT_NAME(out_t, 0)
 
 int errors = 0;

--- a/test_regress/t/t_json_only_begin_hier.out
+++ b/test_regress/t/t_json_only_begin_hier.out
@@ -1,54 +1,55 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"test","addr":"(E)","loc":"d,21:8,21:12","origName":"test","verilogName":"test","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"test","addr":"(F)","loc":"d,21:8,21:12","origName":"test","verilogName":"test","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"N","addr":"(F)","loc":"d,22:10,22:11","dtypep":"(G)","origName":"N","verilogName":"N","direction":"NONE","declDirection":"NONE","isUsedLoopIdx":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"GENVAR","dtypeName":"integer"},
-    {"type":"GENBLOCK","name":"FOR_GENERATE","addr":"(H)","loc":"d,24:5,24:8","implied":true},
-    {"type":"GENBLOCK","name":"FOR_GENERATE[0]","addr":"(I)","loc":"d,25:14,25:24",
+    {"type":"VAR","name":"N","addr":"(G)","loc":"d,22:10,22:11","dtypep":"(H)","origName":"N","verilogName":"N","direction":"NONE","declDirection":"NONE","isUsedLoopIdx":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"GENVAR","dtypeName":"integer"},
+    {"type":"GENBLOCK","name":"FOR_GENERATE","addr":"(I)","loc":"d,24:5,24:8","implied":true},
+    {"type":"GENBLOCK","name":"FOR_GENERATE[0]","addr":"(J)","loc":"d,25:14,25:24",
      "itemsp": [
-      {"type":"CELL","name":"submod_for","addr":"(J)","loc":"d,25:14,25:24","modName":"submod","origName":"submod_for","verilogName":"submod_for","modp":"(K)"},
-      {"type":"GENBLOCK","name":"genblk1","addr":"(L)","loc":"d,26:14,26:19","unnamed":true,
+      {"type":"CELL","name":"submod_for","addr":"(K)","loc":"d,25:14,25:24","modName":"submod","origName":"submod_for","verilogName":"submod_for","modp":"(L)"},
+      {"type":"GENBLOCK","name":"genblk1","addr":"(M)","loc":"d,26:14,26:19","unnamed":true,
        "itemsp": [
-        {"type":"CELL","name":"submod_2","addr":"(M)","loc":"d,27:16,27:24","modName":"submod","origName":"submod_2","verilogName":"submod_2","modp":"(K)"}
+        {"type":"CELL","name":"submod_2","addr":"(N)","loc":"d,27:16,27:24","modName":"submod","origName":"submod_2","verilogName":"submod_2","modp":"(L)"}
       ]},
-      {"type":"CELL","name":"submod_3","addr":"(N)","loc":"d,29:14,29:22","modName":"submod","origName":"submod_3","verilogName":"submod_3","modp":"(K)"}
+      {"type":"CELL","name":"submod_3","addr":"(O)","loc":"d,29:14,29:22","modName":"submod","origName":"submod_3","verilogName":"submod_3","modp":"(L)"}
     ]},
-    {"type":"GENBLOCK","name":"FOR_GENERATE[1]","addr":"(O)","loc":"d,25:14,25:24",
+    {"type":"GENBLOCK","name":"FOR_GENERATE[1]","addr":"(P)","loc":"d,25:14,25:24",
      "itemsp": [
-      {"type":"CELL","name":"submod_for","addr":"(P)","loc":"d,25:14,25:24","modName":"submod","origName":"submod_for","verilogName":"submod_for","modp":"(K)"},
-      {"type":"GENBLOCK","name":"genblk1","addr":"(Q)","loc":"d,26:14,26:19","unnamed":true,
+      {"type":"CELL","name":"submod_for","addr":"(Q)","loc":"d,25:14,25:24","modName":"submod","origName":"submod_for","verilogName":"submod_for","modp":"(L)"},
+      {"type":"GENBLOCK","name":"genblk1","addr":"(R)","loc":"d,26:14,26:19","unnamed":true,
        "itemsp": [
-        {"type":"CELL","name":"submod_2","addr":"(R)","loc":"d,27:16,27:24","modName":"submod","origName":"submod_2","verilogName":"submod_2","modp":"(K)"}
+        {"type":"CELL","name":"submod_2","addr":"(S)","loc":"d,27:16,27:24","modName":"submod","origName":"submod_2","verilogName":"submod_2","modp":"(L)"}
       ]},
-      {"type":"CELL","name":"submod_3","addr":"(S)","loc":"d,29:14,29:22","modName":"submod","origName":"submod_3","verilogName":"submod_3","modp":"(K)"}
+      {"type":"CELL","name":"submod_3","addr":"(T)","loc":"d,29:14,29:22","modName":"submod","origName":"submod_3","verilogName":"submod_3","modp":"(L)"}
     ]}
   ]},
-  {"type":"MODULE","name":"submod","addr":"(K)","loc":"d,10:8,10:14","origName":"submod","verilogName":"submod","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"},
+  {"type":"MODULE","name":"submod","addr":"(L)","loc":"d,10:8,10:14","origName":"submod","verilogName":"submod","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"GENBLOCK","name":"submod_gen","addr":"(T)","loc":"d,11:18,11:28",
+    {"type":"GENBLOCK","name":"submod_gen","addr":"(U)","loc":"d,11:18,11:28",
      "itemsp": [
-      {"type":"VAR","name":"l1_sig","addr":"(U)","loc":"d,12:10,12:16","dtypep":"(V)","origName":"l1_sig","verilogName":"l1_sig","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-      {"type":"GENBLOCK","name":"nested_gen","addr":"(W)","loc":"d,13:20,13:30",
+      {"type":"VAR","name":"l1_sig","addr":"(V)","loc":"d,12:10,12:16","dtypep":"(W)","origName":"l1_sig","verilogName":"l1_sig","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+      {"type":"GENBLOCK","name":"nested_gen","addr":"(X)","loc":"d,13:20,13:30",
        "itemsp": [
-        {"type":"CELL","name":"submod_nested","addr":"(X)","loc":"d,14:15,14:28","modName":"submod2","origName":"submod_nested","verilogName":"submod_nested","modp":"(Y)"}
+        {"type":"CELL","name":"submod_nested","addr":"(Y)","loc":"d,14:15,14:28","modName":"submod2","origName":"submod_nested","verilogName":"submod_nested","modp":"(Z)"}
       ]},
-      {"type":"CELL","name":"submod_l1","addr":"(Z)","loc":"d,16:13,16:22","modName":"submod2","origName":"submod_l1","verilogName":"submod_l1","modp":"(Y)"}
+      {"type":"CELL","name":"submod_l1","addr":"(AB)","loc":"d,16:13,16:22","modName":"submod2","origName":"submod_l1","verilogName":"submod_l1","modp":"(Z)"}
     ]},
-    {"type":"CELL","name":"submod_l0","addr":"(AB)","loc":"d,18:11,18:20","modName":"submod2","origName":"submod_l0","verilogName":"submod_l0","modp":"(Y)"}
+    {"type":"CELL","name":"submod_l0","addr":"(BB)","loc":"d,18:11,18:20","modName":"submod2","origName":"submod_l0","verilogName":"submod_l0","modp":"(Z)"}
   ]},
-  {"type":"MODULE","name":"submod2","addr":"(Y)","loc":"d,7:8,7:15","origName":"submod2","verilogName":"submod2","level":3,"depth":3,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
+  {"type":"MODULE","name":"submod2","addr":"(Z)","loc":"d,7:8,7:15","origName":"submod2","verilogName":"submod2","level":3,"depth":3,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"integer","addr":"(G)","loc":"d,22:10,22:11","dtypep":"(G)","keyword":"integer","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(V)","loc":"d,12:10,12:16","dtypep":"(V)","keyword":"logic","generic":true}
+    {"type":"BASICDTYPE","name":"integer","addr":"(H)","loc":"d,22:10,22:11","dtypep":"(H)","keyword":"integer","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(W)","loc":"d,12:10,12:16","dtypep":"(W)","keyword":"logic","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(BB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(CB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CB)","loc":"a,0:0,0:0","modp":"(BB)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(DB)","loc":"a,0:0,0:0","modp":"(CB)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_first.out
+++ b/test_regress/t/t_json_only_first.out
@@ -1,169 +1,170 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"t","addr":"(E)","loc":"d,7:8,7:9","origName":"t","verilogName":"t","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"t","addr":"(F)","loc":"d,7:8,7:9","origName":"t","verilogName":"t","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"q","addr":"(F)","loc":"d,16:21,16:22","dtypep":"(G)","origName":"q","verilogName":"q","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"clk","addr":"(H)","loc":"d,14:9,14:12","dtypep":"(I)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"d","addr":"(J)","loc":"d,15:15,15:16","dtypep":"(G)","origName":"d","verilogName":"d","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"between","addr":"(K)","loc":"d,18:15,18:22","dtypep":"(G)","origName":"between","verilogName":"between","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"direct_named","addr":"(L)","loc":"d,19:9,19:21","dtypep":"(I)","origName":"direct_named","verilogName":"direct_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"computed_named","addr":"(M)","loc":"d,20:9,20:23","dtypep":"(I)","origName":"computed_named","verilogName":"computed_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"anonymous_expr","addr":"(N)","loc":"d,21:9,21:23","dtypep":"(I)","origName":"anonymous_expr","verilogName":"anonymous_expr","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"S_IDLE","addr":"(O)","loc":"d,23:26,23:32","dtypep":"(P)","origName":"S_IDLE","verilogName":"S_IDLE","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"q","addr":"(G)","loc":"d,16:21,16:22","dtypep":"(H)","origName":"q","verilogName":"q","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"clk","addr":"(I)","loc":"d,14:9,14:12","dtypep":"(J)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"d","addr":"(K)","loc":"d,15:15,15:16","dtypep":"(H)","origName":"d","verilogName":"d","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"between","addr":"(L)","loc":"d,18:15,18:22","dtypep":"(H)","origName":"between","verilogName":"between","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"direct_named","addr":"(M)","loc":"d,19:9,19:21","dtypep":"(J)","origName":"direct_named","verilogName":"direct_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"computed_named","addr":"(N)","loc":"d,20:9,20:23","dtypep":"(J)","origName":"computed_named","verilogName":"computed_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"anonymous_expr","addr":"(O)","loc":"d,21:9,21:23","dtypep":"(J)","origName":"anonymous_expr","verilogName":"anonymous_expr","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"S_IDLE","addr":"(P)","loc":"d,23:26,23:32","dtypep":"(Q)","origName":"S_IDLE","verilogName":"S_IDLE","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h0","addr":"(Q)","loc":"d,23:35,23:40","dtypep":"(R)"}
+      {"type":"CONST","name":"2'h0","addr":"(R)","loc":"d,23:35,23:40","dtypep":"(S)"}
     ]},
-    {"type":"VAR","name":"S_FETCH","addr":"(S)","loc":"d,24:26,24:33","dtypep":"(P)","origName":"S_FETCH","verilogName":"S_FETCH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"S_FETCH","addr":"(T)","loc":"d,24:26,24:33","dtypep":"(Q)","origName":"S_FETCH","verilogName":"S_FETCH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h1","addr":"(T)","loc":"d,24:36,24:41","dtypep":"(R)"}
+      {"type":"CONST","name":"2'h1","addr":"(U)","loc":"d,24:36,24:41","dtypep":"(S)"}
     ]},
-    {"type":"VAR","name":"S_EXEC","addr":"(U)","loc":"d,25:26,25:32","dtypep":"(P)","origName":"S_EXEC","verilogName":"S_EXEC","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"S_EXEC","addr":"(V)","loc":"d,25:26,25:32","dtypep":"(Q)","origName":"S_EXEC","verilogName":"S_EXEC","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h2","addr":"(V)","loc":"d,25:43,25:44","dtypep":"(P)"}
+      {"type":"CONST","name":"2'h2","addr":"(W)","loc":"d,25:43,25:44","dtypep":"(Q)"}
     ]},
-    {"type":"ALWAYS","addr":"(W)","loc":"d,27:23,27:24","keyword":"cont_assign",
+    {"type":"ALWAYS","addr":"(X)","loc":"d,27:23,27:24","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(X)","loc":"d,27:23,27:24","dtypep":"(I)",
+      {"type":"ASSIGNW","addr":"(Y)","loc":"d,27:23,27:24","dtypep":"(J)",
        "rhsp": [
-        {"type":"EQ","addr":"(Y)","loc":"d,27:32,27:34","dtypep":"(Z)",
+        {"type":"EQ","addr":"(Z)","loc":"d,27:32,27:34","dtypep":"(AB)",
          "lhsp": [
-          {"type":"CONST","name":"2'h0","addr":"(AB)","loc":"d,27:35,27:41","dtypep":"(P)","origParamName":"S_IDLE"}
+          {"type":"CONST","name":"2'h0","addr":"(BB)","loc":"d,27:35,27:41","dtypep":"(Q)","origParamName":"S_IDLE"}
         ],
          "rhsp": [
-          {"type":"SEL","addr":"(BB)","loc":"d,27:26,27:27","dtypep":"(P)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+          {"type":"SEL","addr":"(CB)","loc":"d,27:26,27:27","dtypep":"(Q)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
            "fromp": [
-            {"type":"VARREF","name":"d","addr":"(CB)","loc":"d,27:25,27:26","dtypep":"(G)","access":"RD","varp":"(J)"}
+            {"type":"VARREF","name":"d","addr":"(DB)","loc":"d,27:25,27:26","dtypep":"(H)","access":"RD","varp":"(K)"}
           ],
            "lsbp": [
-            {"type":"CONST","name":"2'h0","addr":"(DB)","loc":"d,27:29,27:30","dtypep":"(EB)"}
+            {"type":"CONST","name":"2'h0","addr":"(EB)","loc":"d,27:29,27:30","dtypep":"(FB)"}
           ]}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"direct_named","addr":"(FB)","loc":"d,27:10,27:22","dtypep":"(I)","access":"WR","varp":"(L)"}
+        {"type":"VARREF","name":"direct_named","addr":"(GB)","loc":"d,27:10,27:22","dtypep":"(J)","access":"WR","varp":"(M)"}
       ]}
     ]},
-    {"type":"ALWAYS","addr":"(GB)","loc":"d,28:25,28:26","keyword":"cont_assign",
+    {"type":"ALWAYS","addr":"(HB)","loc":"d,28:25,28:26","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(HB)","loc":"d,28:25,28:26","dtypep":"(I)",
+      {"type":"ASSIGNW","addr":"(IB)","loc":"d,28:25,28:26","dtypep":"(J)",
        "rhsp": [
-        {"type":"EQ","addr":"(IB)","loc":"d,28:34,28:36","dtypep":"(Z)",
+        {"type":"EQ","addr":"(JB)","loc":"d,28:34,28:36","dtypep":"(AB)",
          "lhsp": [
-          {"type":"CONST","name":"2'h2","addr":"(JB)","loc":"d,28:37,28:43","dtypep":"(P)","origParamName":"S_EXEC"}
+          {"type":"CONST","name":"2'h2","addr":"(KB)","loc":"d,28:37,28:43","dtypep":"(Q)","origParamName":"S_EXEC"}
         ],
          "rhsp": [
-          {"type":"SEL","addr":"(KB)","loc":"d,28:28,28:29","dtypep":"(P)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+          {"type":"SEL","addr":"(LB)","loc":"d,28:28,28:29","dtypep":"(Q)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
            "fromp": [
-            {"type":"VARREF","name":"d","addr":"(LB)","loc":"d,28:27,28:28","dtypep":"(G)","access":"RD","varp":"(J)"}
+            {"type":"VARREF","name":"d","addr":"(MB)","loc":"d,28:27,28:28","dtypep":"(H)","access":"RD","varp":"(K)"}
           ],
            "lsbp": [
-            {"type":"CONST","name":"2'h0","addr":"(MB)","loc":"d,28:31,28:32","dtypep":"(EB)"}
+            {"type":"CONST","name":"2'h0","addr":"(NB)","loc":"d,28:31,28:32","dtypep":"(FB)"}
           ]}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"computed_named","addr":"(NB)","loc":"d,28:10,28:24","dtypep":"(I)","access":"WR","varp":"(M)"}
+        {"type":"VARREF","name":"computed_named","addr":"(OB)","loc":"d,28:10,28:24","dtypep":"(J)","access":"WR","varp":"(N)"}
       ]}
     ]},
-    {"type":"ALWAYS","addr":"(OB)","loc":"d,29:25,29:26","keyword":"cont_assign",
+    {"type":"ALWAYS","addr":"(PB)","loc":"d,29:25,29:26","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(PB)","loc":"d,29:25,29:26","dtypep":"(I)",
+      {"type":"ASSIGNW","addr":"(QB)","loc":"d,29:25,29:26","dtypep":"(J)",
        "rhsp": [
-        {"type":"EQ","addr":"(QB)","loc":"d,29:34,29:36","dtypep":"(Z)",
+        {"type":"EQ","addr":"(RB)","loc":"d,29:34,29:36","dtypep":"(AB)",
          "lhsp": [
-          {"type":"CONST","name":"2'h2","addr":"(RB)","loc":"d,29:46,29:47","dtypep":"(R)"}
+          {"type":"CONST","name":"2'h2","addr":"(SB)","loc":"d,29:46,29:47","dtypep":"(S)"}
         ],
          "rhsp": [
-          {"type":"SEL","addr":"(SB)","loc":"d,29:28,29:29","dtypep":"(P)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+          {"type":"SEL","addr":"(TB)","loc":"d,29:28,29:29","dtypep":"(Q)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
            "fromp": [
-            {"type":"VARREF","name":"d","addr":"(TB)","loc":"d,29:27,29:28","dtypep":"(G)","access":"RD","varp":"(J)"}
+            {"type":"VARREF","name":"d","addr":"(UB)","loc":"d,29:27,29:28","dtypep":"(H)","access":"RD","varp":"(K)"}
           ],
            "lsbp": [
-            {"type":"CONST","name":"2'h0","addr":"(UB)","loc":"d,29:31,29:32","dtypep":"(EB)"}
+            {"type":"CONST","name":"2'h0","addr":"(VB)","loc":"d,29:31,29:32","dtypep":"(FB)"}
           ]}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"anonymous_expr","addr":"(VB)","loc":"d,29:10,29:24","dtypep":"(I)","access":"WR","varp":"(N)"}
+        {"type":"VARREF","name":"anonymous_expr","addr":"(WB)","loc":"d,29:10,29:24","dtypep":"(J)","access":"WR","varp":"(O)"}
       ]}
     ]},
-    {"type":"CELL","name":"cell1","addr":"(WB)","loc":"d,33:5,33:10","modName":"mod1__W4","origName":"cell1","verilogName":"cell1","modp":"(XB)",
+    {"type":"CELL","name":"cell1","addr":"(XB)","loc":"d,33:5,33:10","modName":"mod1__W4","origName":"cell1","verilogName":"cell1","modp":"(YB)",
      "pinsp": [
-      {"type":"PIN","name":"q","addr":"(YB)","loc":"d,34:8,34:9","svDotName":true,"modVarp":"(ZB)",
+      {"type":"PIN","name":"q","addr":"(ZB)","loc":"d,34:8,34:9","svDotName":true,"modVarp":"(AC)",
        "exprp": [
-        {"type":"VARREF","name":"between","addr":"(AC)","loc":"d,34:10,34:17","dtypep":"(G)","access":"WR","varp":"(K)"}
+        {"type":"VARREF","name":"between","addr":"(BC)","loc":"d,34:10,34:17","dtypep":"(H)","access":"WR","varp":"(L)"}
       ]},
-      {"type":"PIN","name":"clk","addr":"(BC)","loc":"d,35:8,35:11","svDotName":true,"modVarp":"(CC)",
+      {"type":"PIN","name":"clk","addr":"(CC)","loc":"d,35:8,35:11","svDotName":true,"modVarp":"(DC)",
        "exprp": [
-        {"type":"VARREF","name":"clk","addr":"(DC)","loc":"d,35:12,35:15","dtypep":"(I)","access":"RD","varp":"(H)"}
+        {"type":"VARREF","name":"clk","addr":"(EC)","loc":"d,35:12,35:15","dtypep":"(J)","access":"RD","varp":"(I)"}
       ]},
-      {"type":"PIN","name":"d","addr":"(EC)","loc":"d,36:8,36:9","svDotName":true,"modVarp":"(FC)",
+      {"type":"PIN","name":"d","addr":"(FC)","loc":"d,36:8,36:9","svDotName":true,"modVarp":"(GC)",
        "exprp": [
-        {"type":"VARREF","name":"d","addr":"(GC)","loc":"d,36:10,36:11","dtypep":"(G)","access":"RD","varp":"(J)"}
+        {"type":"VARREF","name":"d","addr":"(HC)","loc":"d,36:10,36:11","dtypep":"(H)","access":"RD","varp":"(K)"}
       ]}
     ]},
-    {"type":"CELL","name":"cell2","addr":"(HC)","loc":"d,39:8,39:13","modName":"mod2","origName":"cell2","verilogName":"cell2","modp":"(IC)",
+    {"type":"CELL","name":"cell2","addr":"(IC)","loc":"d,39:8,39:13","modName":"mod2","origName":"cell2","verilogName":"cell2","modp":"(JC)",
      "pinsp": [
-      {"type":"PIN","name":"d","addr":"(JC)","loc":"d,40:8,40:9","svDotName":true,"modVarp":"(KC)",
+      {"type":"PIN","name":"d","addr":"(KC)","loc":"d,40:8,40:9","svDotName":true,"modVarp":"(LC)",
        "exprp": [
-        {"type":"VARREF","name":"between","addr":"(LC)","loc":"d,40:10,40:17","dtypep":"(G)","access":"RD","varp":"(K)"}
+        {"type":"VARREF","name":"between","addr":"(MC)","loc":"d,40:10,40:17","dtypep":"(H)","access":"RD","varp":"(L)"}
       ]},
-      {"type":"PIN","name":"q","addr":"(MC)","loc":"d,41:8,41:9","svDotName":true,"modVarp":"(NC)",
+      {"type":"PIN","name":"q","addr":"(NC)","loc":"d,41:8,41:9","svDotName":true,"modVarp":"(OC)",
        "exprp": [
-        {"type":"VARREF","name":"q","addr":"(OC)","loc":"d,41:10,41:11","dtypep":"(G)","access":"WR","varp":"(F)"}
+        {"type":"VARREF","name":"q","addr":"(PC)","loc":"d,41:10,41:11","dtypep":"(H)","access":"WR","varp":"(G)"}
       ]},
-      {"type":"PIN","name":"clk","addr":"(PC)","loc":"d,42:8,42:11","svDotName":true,"modVarp":"(QC)",
+      {"type":"PIN","name":"clk","addr":"(QC)","loc":"d,42:8,42:11","svDotName":true,"modVarp":"(RC)",
        "exprp": [
-        {"type":"VARREF","name":"clk","addr":"(RC)","loc":"d,42:12,42:15","dtypep":"(I)","access":"RD","varp":"(H)"}
+        {"type":"VARREF","name":"clk","addr":"(SC)","loc":"d,42:12,42:15","dtypep":"(J)","access":"RD","varp":"(I)"}
       ]}
     ]}
   ]},
-  {"type":"MODULE","name":"mod2","addr":"(IC)","loc":"d,61:8,61:12","origName":"mod2","verilogName":"mod2","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"},
+  {"type":"MODULE","name":"mod2","addr":"(JC)","loc":"d,61:8,61:12","origName":"mod2","verilogName":"mod2","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"clk","addr":"(QC)","loc":"d,62:11,62:14","dtypep":"(I)","origName":"clk","verilogName":"clk","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"d","addr":"(KC)","loc":"d,63:17,63:18","dtypep":"(G)","origName":"d","verilogName":"d","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"q","addr":"(NC)","loc":"d,64:23,64:24","dtypep":"(G)","origName":"q","verilogName":"q","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"ALWAYS","addr":"(SC)","loc":"d,67:12,67:13","keyword":"cont_assign",
+    {"type":"VAR","name":"clk","addr":"(RC)","loc":"d,62:11,62:14","dtypep":"(J)","origName":"clk","verilogName":"clk","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"d","addr":"(LC)","loc":"d,63:17,63:18","dtypep":"(H)","origName":"d","verilogName":"d","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"q","addr":"(OC)","loc":"d,64:23,64:24","dtypep":"(H)","origName":"q","verilogName":"q","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"ALWAYS","addr":"(TC)","loc":"d,67:12,67:13","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(TC)","loc":"d,67:12,67:13","dtypep":"(G)",
+      {"type":"ASSIGNW","addr":"(UC)","loc":"d,67:12,67:13","dtypep":"(H)",
        "rhsp": [
-        {"type":"VARREF","name":"d","addr":"(UC)","loc":"d,67:14,67:15","dtypep":"(G)","access":"RD","varp":"(KC)"}
+        {"type":"VARREF","name":"d","addr":"(VC)","loc":"d,67:14,67:15","dtypep":"(H)","access":"RD","varp":"(LC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"q","addr":"(VC)","loc":"d,67:10,67:11","dtypep":"(G)","access":"WR","varp":"(NC)"}
+        {"type":"VARREF","name":"q","addr":"(WC)","loc":"d,67:10,67:11","dtypep":"(H)","access":"WR","varp":"(OC)"}
       ]}
     ]}
   ]},
-  {"type":"MODULE","name":"mod1__W4","addr":"(XB)","loc":"d,47:8,47:12","origName":"mod1","verilogName":"mod1","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mod1__W4","addr":"(YB)","loc":"d,47:8,47:12","origName":"mod1","verilogName":"mod1","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"WIDTH","addr":"(WC)","loc":"d,48:15,48:20","dtypep":"(XC)","origName":"WIDTH","verilogName":"WIDTH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"GPARAM","dtypeName":"logic","isGParam":true,"isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"WIDTH","addr":"(XC)","loc":"d,48:15,48:20","dtypep":"(YC)","origName":"WIDTH","verilogName":"WIDTH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"GPARAM","dtypeName":"logic","isGParam":true,"isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"32'sh4","addr":"(YC)","loc":"d,32:14,32:15","dtypep":"(ZC)"}
+      {"type":"CONST","name":"32'sh4","addr":"(ZC)","loc":"d,32:14,32:15","dtypep":"(AD)"}
     ]},
-    {"type":"VAR","name":"clk","addr":"(CC)","loc":"d,50:11,50:14","dtypep":"(I)","origName":"clk","verilogName":"clk","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"d","addr":"(FC)","loc":"d,51:23,51:24","dtypep":"(G)","origName":"d","verilogName":"d","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"q","addr":"(ZB)","loc":"d,52:30,52:31","dtypep":"(G)","origName":"q","verilogName":"q","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"IGNORED","addr":"(AD)","loc":"d,55:14,55:21","dtypep":"(XC)","origName":"IGNORED","verilogName":"IGNORED","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"clk","addr":"(DC)","loc":"d,50:11,50:14","dtypep":"(J)","origName":"clk","verilogName":"clk","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"d","addr":"(GC)","loc":"d,51:23,51:24","dtypep":"(H)","origName":"d","verilogName":"d","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"q","addr":"(AC)","loc":"d,52:30,52:31","dtypep":"(H)","origName":"q","verilogName":"q","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"IGNORED","addr":"(BD)","loc":"d,55:14,55:21","dtypep":"(YC)","origName":"IGNORED","verilogName":"IGNORED","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"32'sh1","addr":"(BD)","loc":"d,55:24,55:25","dtypep":"(ZC)"}
+      {"type":"CONST","name":"32'sh1","addr":"(CD)","loc":"d,55:24,55:25","dtypep":"(AD)"}
     ]},
-    {"type":"ALWAYS","addr":"(CD)","loc":"d,57:3,57:9","keyword":"always",
+    {"type":"ALWAYS","addr":"(DD)","loc":"d,57:3,57:9","keyword":"always",
      "sentreep": [
-      {"type":"SENTREE","addr":"(DD)","loc":"d,57:10,57:11",
+      {"type":"SENTREE","addr":"(ED)","loc":"d,57:10,57:11",
        "sensesp": [
-        {"type":"SENITEM","addr":"(ED)","loc":"d,57:12,57:19","edgeType":"POS",
+        {"type":"SENITEM","addr":"(FD)","loc":"d,57:12,57:19","edgeType":"POS",
          "sensp": [
-          {"type":"VARREF","name":"clk","addr":"(FD)","loc":"d,57:20,57:23","dtypep":"(I)","access":"RD","varp":"(CC)"}
+          {"type":"VARREF","name":"clk","addr":"(GD)","loc":"d,57:20,57:23","dtypep":"(J)","access":"RD","varp":"(DC)"}
         ]}
       ]}
     ],
      "stmtsp": [
-      {"type":"ASSIGNDLY","addr":"(GD)","loc":"d,57:27,57:29","dtypep":"(G)",
+      {"type":"ASSIGNDLY","addr":"(HD)","loc":"d,57:27,57:29","dtypep":"(H)",
        "rhsp": [
-        {"type":"VARREF","name":"d","addr":"(HD)","loc":"d,57:30,57:31","dtypep":"(G)","access":"RD","varp":"(FC)"}
+        {"type":"VARREF","name":"d","addr":"(ID)","loc":"d,57:30,57:31","dtypep":"(H)","access":"RD","varp":"(GC)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"q","addr":"(ID)","loc":"d,57:25,57:26","dtypep":"(G)","access":"WR","varp":"(ZB)"}
+        {"type":"VARREF","name":"q","addr":"(JD)","loc":"d,57:25,57:26","dtypep":"(H)","access":"WR","varp":"(AC)"}
       ]}
     ]}
   ]}
@@ -171,20 +172,20 @@
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"bit","addr":"(R)","loc":"d,23:35,23:40","dtypep":"(R)","keyword":"bit","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(I)","loc":"d,27:32,27:34","dtypep":"(I)","keyword":"logic","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(P)","loc":"d,23:14,23:19","dtypep":"(P)","keyword":"logic","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(XC)","loc":"d,48:15,48:20","dtypep":"(XC)","keyword":"logic","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(G)","loc":"d,16:15,16:16","dtypep":"(G)","keyword":"logic","range":"3:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(EB)","loc":"d,27:26,27:27","dtypep":"(EB)","keyword":"logic","range":"1:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(Z)","loc":"d,27:32,27:34","dtypep":"(Z)","keyword":"bit","generic":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(ZC)","loc":"d,29:48,29:49","dtypep":"(ZC)","keyword":"bit","range":"31:0","generic":true,"signed":true}
+    {"type":"BASICDTYPE","name":"bit","addr":"(S)","loc":"d,23:35,23:40","dtypep":"(S)","keyword":"bit","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(J)","loc":"d,27:32,27:34","dtypep":"(J)","keyword":"logic","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(Q)","loc":"d,23:14,23:19","dtypep":"(Q)","keyword":"logic","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(YC)","loc":"d,48:15,48:20","dtypep":"(YC)","keyword":"logic","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,16:15,16:16","dtypep":"(H)","keyword":"logic","range":"3:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(FB)","loc":"d,27:26,27:27","dtypep":"(FB)","keyword":"logic","range":"1:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(AB)","loc":"d,27:32,27:34","dtypep":"(AB)","keyword":"bit","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(AD)","loc":"d,29:48,29:49","dtypep":"(AD)","keyword":"bit","range":"31:0","generic":true,"signed":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(JD)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(KD)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(KD)","loc":"a,0:0,0:0","modp":"(JD)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(LD)","loc":"a,0:0,0:0","modp":"(KD)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat.out
+++ b/test_regress/t/t_json_only_flat.out
@@ -1,276 +1,278 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"t","typeTablep":"(C)","constPoolp":"(D)","topScopep":"(E)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"t","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","topScopep":"(F)",
  "modulesp": [
-  {"type":"MODULE","name":"$root","addr":"(F)","loc":"d,7:8,7:9","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"$root","addr":"(G)","loc":"d,7:8,7:9","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"q","addr":"(G)","loc":"d,16:21,16:22","dtypep":"(H)","origName":"q","verilogName":"q","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"clk","addr":"(I)","loc":"d,14:9,14:12","dtypep":"(J)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"d","addr":"(K)","loc":"d,15:15,15:16","dtypep":"(H)","origName":"d","verilogName":"d","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.q","addr":"(L)","loc":"d,16:21,16:22","dtypep":"(H)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"t.clk","addr":"(M)","loc":"d,14:9,14:12","dtypep":"(J)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.d","addr":"(N)","loc":"d,15:15,15:16","dtypep":"(H)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.between","addr":"(O)","loc":"d,18:15,18:22","dtypep":"(H)","origName":"between","verilogName":"between","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"t.direct_named","addr":"(P)","loc":"d,19:9,19:21","dtypep":"(J)","origName":"direct_named","verilogName":"direct_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"t.computed_named","addr":"(Q)","loc":"d,20:9,20:23","dtypep":"(J)","origName":"computed_named","verilogName":"computed_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"t.anonymous_expr","addr":"(R)","loc":"d,21:9,21:23","dtypep":"(J)","origName":"anonymous_expr","verilogName":"anonymous_expr","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"t.S_IDLE","addr":"(S)","loc":"d,23:26,23:32","dtypep":"(T)","origName":"S_IDLE","verilogName":"S_IDLE","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"q","addr":"(H)","loc":"d,16:21,16:22","dtypep":"(I)","origName":"q","verilogName":"q","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"clk","addr":"(J)","loc":"d,14:9,14:12","dtypep":"(K)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"d","addr":"(L)","loc":"d,15:15,15:16","dtypep":"(I)","origName":"d","verilogName":"d","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"CELL","name":"$unit","addr":"(M)","loc":"a,0:0,0:0","modName":"__024unit","origName":"__024unit","verilogName":"\\$unit ","modp":"(E)"},
+    {"type":"VAR","name":"t.q","addr":"(N)","loc":"d,16:21,16:22","dtypep":"(I)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"t.clk","addr":"(O)","loc":"d,14:9,14:12","dtypep":"(K)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.d","addr":"(P)","loc":"d,15:15,15:16","dtypep":"(I)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.between","addr":"(Q)","loc":"d,18:15,18:22","dtypep":"(I)","origName":"between","verilogName":"between","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"t.direct_named","addr":"(R)","loc":"d,19:9,19:21","dtypep":"(K)","origName":"direct_named","verilogName":"direct_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"t.computed_named","addr":"(S)","loc":"d,20:9,20:23","dtypep":"(K)","origName":"computed_named","verilogName":"computed_named","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"t.anonymous_expr","addr":"(T)","loc":"d,21:9,21:23","dtypep":"(K)","origName":"anonymous_expr","verilogName":"anonymous_expr","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"t.S_IDLE","addr":"(U)","loc":"d,23:26,23:32","dtypep":"(V)","origName":"S_IDLE","verilogName":"S_IDLE","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h0","addr":"(U)","loc":"d,23:35,23:40","dtypep":"(V)"}
+      {"type":"CONST","name":"2'h0","addr":"(W)","loc":"d,23:35,23:40","dtypep":"(X)"}
     ]},
-    {"type":"VAR","name":"t.S_FETCH","addr":"(W)","loc":"d,24:26,24:33","dtypep":"(T)","origName":"S_FETCH","verilogName":"S_FETCH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"t.S_FETCH","addr":"(Y)","loc":"d,24:26,24:33","dtypep":"(V)","origName":"S_FETCH","verilogName":"S_FETCH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h1","addr":"(X)","loc":"d,24:36,24:41","dtypep":"(V)"}
+      {"type":"CONST","name":"2'h1","addr":"(Z)","loc":"d,24:36,24:41","dtypep":"(X)"}
     ]},
-    {"type":"VAR","name":"t.S_EXEC","addr":"(Y)","loc":"d,25:26,25:32","dtypep":"(T)","origName":"S_EXEC","verilogName":"S_EXEC","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"t.S_EXEC","addr":"(AB)","loc":"d,25:26,25:32","dtypep":"(V)","origName":"S_EXEC","verilogName":"S_EXEC","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"2'h2","addr":"(Z)","loc":"d,25:43,25:44","dtypep":"(T)"}
+      {"type":"CONST","name":"2'h2","addr":"(BB)","loc":"d,25:43,25:44","dtypep":"(V)"}
     ]},
-    {"type":"VAR","name":"t.cell2.clk","addr":"(AB)","loc":"d,62:11,62:14","dtypep":"(J)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell2.d","addr":"(BB)","loc":"d,63:17,63:18","dtypep":"(H)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell2.q","addr":"(CB)","loc":"d,64:23,64:24","dtypep":"(H)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell1.WIDTH","addr":"(DB)","loc":"d,48:15,48:20","dtypep":"(EB)","origName":"WIDTH","verilogName":"WIDTH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"GPARAM","dtypeName":"logic","isGParam":true,"isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"t.cell2.clk","addr":"(CB)","loc":"d,62:11,62:14","dtypep":"(K)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell2.d","addr":"(DB)","loc":"d,63:17,63:18","dtypep":"(I)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell2.q","addr":"(EB)","loc":"d,64:23,64:24","dtypep":"(I)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell1.WIDTH","addr":"(FB)","loc":"d,48:15,48:20","dtypep":"(GB)","origName":"WIDTH","verilogName":"WIDTH","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"GPARAM","dtypeName":"logic","isGParam":true,"isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"32'sh4","addr":"(FB)","loc":"d,32:14,32:15","dtypep":"(GB)"}
+      {"type":"CONST","name":"32'sh4","addr":"(HB)","loc":"d,32:14,32:15","dtypep":"(IB)"}
     ]},
-    {"type":"VAR","name":"t.cell1.clk","addr":"(HB)","loc":"d,50:11,50:14","dtypep":"(J)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell1.d","addr":"(IB)","loc":"d,51:23,51:24","dtypep":"(H)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell1.q","addr":"(JB)","loc":"d,52:30,52:31","dtypep":"(H)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"t.cell1.IGNORED","addr":"(KB)","loc":"d,55:14,55:21","dtypep":"(EB)","origName":"IGNORED","verilogName":"IGNORED","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
+    {"type":"VAR","name":"t.cell1.clk","addr":"(JB)","loc":"d,50:11,50:14","dtypep":"(K)","origName":"clk","verilogName":"clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell1.d","addr":"(KB)","loc":"d,51:23,51:24","dtypep":"(I)","origName":"d","verilogName":"d","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell1.q","addr":"(LB)","loc":"d,52:30,52:31","dtypep":"(I)","origName":"q","verilogName":"q","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"t.cell1.IGNORED","addr":"(MB)","loc":"d,55:14,55:21","dtypep":"(GB)","origName":"IGNORED","verilogName":"IGNORED","direction":"NONE","declDirection":"NONE","isConst":true,"lifetime":"VSTATICI","varType":"LPARAM","dtypeName":"logic","isParam":true,"hasUserInit":true,
      "valuep": [
-      {"type":"CONST","name":"32'sh1","addr":"(LB)","loc":"d,55:24,55:25","dtypep":"(GB)"}
+      {"type":"CONST","name":"32'sh1","addr":"(NB)","loc":"d,55:24,55:25","dtypep":"(IB)"}
     ]},
-    {"type":"TOPSCOPE","addr":"(E)","loc":"d,7:8,7:9",
+    {"type":"TOPSCOPE","addr":"(F)","loc":"d,7:8,7:9",
      "scopep": [
-      {"type":"SCOPE","name":"TOP","addr":"(MB)","loc":"d,7:8,7:9","modp":"(F)",
+      {"type":"SCOPE","name":"TOP","addr":"(OB)","loc":"d,7:8,7:9","modp":"(G)",
        "varsp": [
-        {"type":"VARSCOPE","name":"q","addr":"(NB)","loc":"d,16:21,16:22","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(G)"},
-        {"type":"VARSCOPE","name":"clk","addr":"(OB)","loc":"d,14:9,14:12","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(I)"},
-        {"type":"VARSCOPE","name":"d","addr":"(PB)","loc":"d,15:15,15:16","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(K)"},
-        {"type":"VARSCOPE","name":"t.q","addr":"(QB)","loc":"d,16:21,16:22","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(L)"},
-        {"type":"ALWAYS","addr":"(RB)","loc":"d,16:21,16:22","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"q","addr":"(PB)","loc":"d,16:21,16:22","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(H)"},
+        {"type":"VARSCOPE","name":"clk","addr":"(QB)","loc":"d,14:9,14:12","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(J)"},
+        {"type":"VARSCOPE","name":"d","addr":"(RB)","loc":"d,15:15,15:16","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(L)"},
+        {"type":"VARSCOPE","name":"t.q","addr":"(SB)","loc":"d,16:21,16:22","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(N)"},
+        {"type":"ALWAYS","addr":"(TB)","loc":"d,16:21,16:22","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(SB)","loc":"d,16:21,16:22","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(UB)","loc":"d,16:21,16:22","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"q","addr":"(TB)","loc":"d,16:21,16:22","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(NB)"}
+            {"type":"VARREF","name":"q","addr":"(VB)","loc":"d,16:21,16:22","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(PB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.q","addr":"(UB)","loc":"d,16:21,16:22","dtypep":"(H)","access":"WR","varp":"(L)","varScopep":"(QB)"}
+            {"type":"VARREF","name":"t.q","addr":"(WB)","loc":"d,16:21,16:22","dtypep":"(I)","access":"WR","varp":"(N)","varScopep":"(SB)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.clk","addr":"(VB)","loc":"d,14:9,14:12","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(M)"},
-        {"type":"ALWAYS","addr":"(WB)","loc":"d,14:9,14:12","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.clk","addr":"(XB)","loc":"d,14:9,14:12","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(O)"},
+        {"type":"ALWAYS","addr":"(YB)","loc":"d,14:9,14:12","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(XB)","loc":"d,14:9,14:12","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(ZB)","loc":"d,14:9,14:12","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"clk","addr":"(YB)","loc":"d,14:9,14:12","dtypep":"(J)","access":"RD","varp":"(I)","varScopep":"(OB)"}
+            {"type":"VARREF","name":"clk","addr":"(AC)","loc":"d,14:9,14:12","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"(QB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.clk","addr":"(ZB)","loc":"d,14:9,14:12","dtypep":"(J)","access":"WR","varp":"(M)","varScopep":"(VB)"}
+            {"type":"VARREF","name":"t.clk","addr":"(BC)","loc":"d,14:9,14:12","dtypep":"(K)","access":"WR","varp":"(O)","varScopep":"(XB)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.d","addr":"(AC)","loc":"d,15:15,15:16","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(N)"},
-        {"type":"ALWAYS","addr":"(BC)","loc":"d,15:15,15:16","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.d","addr":"(CC)","loc":"d,15:15,15:16","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(P)"},
+        {"type":"ALWAYS","addr":"(DC)","loc":"d,15:15,15:16","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(CC)","loc":"d,15:15,15:16","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(EC)","loc":"d,15:15,15:16","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"d","addr":"(DC)","loc":"d,15:15,15:16","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"d","addr":"(FC)","loc":"d,15:15,15:16","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.d","addr":"(EC)","loc":"d,15:15,15:16","dtypep":"(H)","access":"WR","varp":"(N)","varScopep":"(AC)"}
+            {"type":"VARREF","name":"t.d","addr":"(GC)","loc":"d,15:15,15:16","dtypep":"(I)","access":"WR","varp":"(P)","varScopep":"(CC)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.between","addr":"(FC)","loc":"d,18:15,18:22","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(O)"},
-        {"type":"VARSCOPE","name":"t.direct_named","addr":"(GC)","loc":"d,19:9,19:21","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(P)"},
-        {"type":"VARSCOPE","name":"t.computed_named","addr":"(HC)","loc":"d,20:9,20:23","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(Q)"},
-        {"type":"VARSCOPE","name":"t.anonymous_expr","addr":"(IC)","loc":"d,21:9,21:23","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(R)"},
-        {"type":"VARSCOPE","name":"t.S_IDLE","addr":"(JC)","loc":"d,23:26,23:32","dtypep":"(T)","isTrace":true,"scopep":"(MB)","varp":"(S)"},
-        {"type":"VARSCOPE","name":"t.S_FETCH","addr":"(KC)","loc":"d,24:26,24:33","dtypep":"(T)","isTrace":true,"scopep":"(MB)","varp":"(W)"},
-        {"type":"VARSCOPE","name":"t.S_EXEC","addr":"(LC)","loc":"d,25:26,25:32","dtypep":"(T)","isTrace":true,"scopep":"(MB)","varp":"(Y)"},
-        {"type":"VARSCOPE","name":"t.cell2.clk","addr":"(MC)","loc":"d,62:11,62:14","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(AB)"},
-        {"type":"ALWAYS","addr":"(NC)","loc":"d,62:11,62:14","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.between","addr":"(HC)","loc":"d,18:15,18:22","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(Q)"},
+        {"type":"VARSCOPE","name":"t.direct_named","addr":"(IC)","loc":"d,19:9,19:21","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(R)"},
+        {"type":"VARSCOPE","name":"t.computed_named","addr":"(JC)","loc":"d,20:9,20:23","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(S)"},
+        {"type":"VARSCOPE","name":"t.anonymous_expr","addr":"(KC)","loc":"d,21:9,21:23","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(T)"},
+        {"type":"VARSCOPE","name":"t.S_IDLE","addr":"(LC)","loc":"d,23:26,23:32","dtypep":"(V)","isTrace":true,"scopep":"(OB)","varp":"(U)"},
+        {"type":"VARSCOPE","name":"t.S_FETCH","addr":"(MC)","loc":"d,24:26,24:33","dtypep":"(V)","isTrace":true,"scopep":"(OB)","varp":"(Y)"},
+        {"type":"VARSCOPE","name":"t.S_EXEC","addr":"(NC)","loc":"d,25:26,25:32","dtypep":"(V)","isTrace":true,"scopep":"(OB)","varp":"(AB)"},
+        {"type":"VARSCOPE","name":"t.cell2.clk","addr":"(OC)","loc":"d,62:11,62:14","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(CB)"},
+        {"type":"ALWAYS","addr":"(PC)","loc":"d,62:11,62:14","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(OC)","loc":"d,62:11,62:14","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(QC)","loc":"d,62:11,62:14","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"clk","addr":"(PC)","loc":"d,62:11,62:14","dtypep":"(J)","access":"RD","varp":"(I)","varScopep":"(OB)"}
+            {"type":"VARREF","name":"clk","addr":"(RC)","loc":"d,62:11,62:14","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"(QB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell2.clk","addr":"(QC)","loc":"d,62:11,62:14","dtypep":"(J)","access":"WR","varp":"(AB)","varScopep":"(MC)"}
+            {"type":"VARREF","name":"t.cell2.clk","addr":"(SC)","loc":"d,62:11,62:14","dtypep":"(K)","access":"WR","varp":"(CB)","varScopep":"(OC)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell2.d","addr":"(RC)","loc":"d,63:17,63:18","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(BB)"},
-        {"type":"ALWAYS","addr":"(SC)","loc":"d,63:17,63:18","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.cell2.d","addr":"(TC)","loc":"d,63:17,63:18","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(DB)"},
+        {"type":"ALWAYS","addr":"(UC)","loc":"d,63:17,63:18","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(TC)","loc":"d,63:17,63:18","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(VC)","loc":"d,63:17,63:18","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"t.between","addr":"(UC)","loc":"d,63:17,63:18","dtypep":"(H)","access":"RD","varp":"(O)","varScopep":"(FC)"}
+            {"type":"VARREF","name":"t.between","addr":"(WC)","loc":"d,63:17,63:18","dtypep":"(I)","access":"RD","varp":"(Q)","varScopep":"(HC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell2.d","addr":"(VC)","loc":"d,63:17,63:18","dtypep":"(H)","access":"WR","varp":"(BB)","varScopep":"(RC)"}
+            {"type":"VARREF","name":"t.cell2.d","addr":"(XC)","loc":"d,63:17,63:18","dtypep":"(I)","access":"WR","varp":"(DB)","varScopep":"(TC)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell2.q","addr":"(WC)","loc":"d,64:23,64:24","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(CB)"},
-        {"type":"ALWAYS","addr":"(XC)","loc":"d,64:23,64:24","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.cell2.q","addr":"(YC)","loc":"d,64:23,64:24","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(EB)"},
+        {"type":"ALWAYS","addr":"(ZC)","loc":"d,64:23,64:24","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(YC)","loc":"d,64:23,64:24","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(AD)","loc":"d,64:23,64:24","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"q","addr":"(ZC)","loc":"d,64:23,64:24","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(NB)"}
+            {"type":"VARREF","name":"q","addr":"(BD)","loc":"d,64:23,64:24","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(PB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell2.q","addr":"(AD)","loc":"d,64:23,64:24","dtypep":"(H)","access":"WR","varp":"(CB)","varScopep":"(WC)"}
+            {"type":"VARREF","name":"t.cell2.q","addr":"(CD)","loc":"d,64:23,64:24","dtypep":"(I)","access":"WR","varp":"(EB)","varScopep":"(YC)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell1.WIDTH","addr":"(BD)","loc":"d,48:15,48:20","dtypep":"(EB)","isTrace":true,"scopep":"(MB)","varp":"(DB)"},
-        {"type":"VARSCOPE","name":"t.cell1.clk","addr":"(CD)","loc":"d,50:11,50:14","dtypep":"(J)","isTrace":true,"scopep":"(MB)","varp":"(HB)"},
-        {"type":"ALWAYS","addr":"(DD)","loc":"d,50:11,50:14","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.cell1.WIDTH","addr":"(DD)","loc":"d,48:15,48:20","dtypep":"(GB)","isTrace":true,"scopep":"(OB)","varp":"(FB)"},
+        {"type":"VARSCOPE","name":"t.cell1.clk","addr":"(ED)","loc":"d,50:11,50:14","dtypep":"(K)","isTrace":true,"scopep":"(OB)","varp":"(JB)"},
+        {"type":"ALWAYS","addr":"(FD)","loc":"d,50:11,50:14","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(ED)","loc":"d,50:11,50:14","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(GD)","loc":"d,50:11,50:14","dtypep":"(K)",
            "rhsp": [
-            {"type":"VARREF","name":"clk","addr":"(FD)","loc":"d,50:11,50:14","dtypep":"(J)","access":"RD","varp":"(I)","varScopep":"(OB)"}
+            {"type":"VARREF","name":"clk","addr":"(HD)","loc":"d,50:11,50:14","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"(QB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell1.clk","addr":"(GD)","loc":"d,50:11,50:14","dtypep":"(J)","access":"WR","varp":"(HB)","varScopep":"(CD)"}
+            {"type":"VARREF","name":"t.cell1.clk","addr":"(ID)","loc":"d,50:11,50:14","dtypep":"(K)","access":"WR","varp":"(JB)","varScopep":"(ED)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell1.d","addr":"(HD)","loc":"d,51:23,51:24","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(IB)"},
-        {"type":"ALWAYS","addr":"(ID)","loc":"d,51:23,51:24","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.cell1.d","addr":"(JD)","loc":"d,51:23,51:24","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(KB)"},
+        {"type":"ALWAYS","addr":"(KD)","loc":"d,51:23,51:24","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(JD)","loc":"d,51:23,51:24","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(LD)","loc":"d,51:23,51:24","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"d","addr":"(KD)","loc":"d,51:23,51:24","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"d","addr":"(MD)","loc":"d,51:23,51:24","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell1.d","addr":"(LD)","loc":"d,51:23,51:24","dtypep":"(H)","access":"WR","varp":"(IB)","varScopep":"(HD)"}
+            {"type":"VARREF","name":"t.cell1.d","addr":"(ND)","loc":"d,51:23,51:24","dtypep":"(I)","access":"WR","varp":"(KB)","varScopep":"(JD)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell1.q","addr":"(MD)","loc":"d,52:30,52:31","dtypep":"(H)","isTrace":true,"scopep":"(MB)","varp":"(JB)"},
-        {"type":"ALWAYS","addr":"(ND)","loc":"d,52:30,52:31","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"t.cell1.q","addr":"(OD)","loc":"d,52:30,52:31","dtypep":"(I)","isTrace":true,"scopep":"(OB)","varp":"(LB)"},
+        {"type":"ALWAYS","addr":"(PD)","loc":"d,52:30,52:31","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(OD)","loc":"d,52:30,52:31","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(QD)","loc":"d,52:30,52:31","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"t.between","addr":"(PD)","loc":"d,52:30,52:31","dtypep":"(H)","access":"RD","varp":"(O)","varScopep":"(FC)"}
+            {"type":"VARREF","name":"t.between","addr":"(RD)","loc":"d,52:30,52:31","dtypep":"(I)","access":"RD","varp":"(Q)","varScopep":"(HC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.cell1.q","addr":"(QD)","loc":"d,52:30,52:31","dtypep":"(H)","access":"WR","varp":"(JB)","varScopep":"(MD)"}
+            {"type":"VARREF","name":"t.cell1.q","addr":"(SD)","loc":"d,52:30,52:31","dtypep":"(I)","access":"WR","varp":"(LB)","varScopep":"(OD)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"t.cell1.IGNORED","addr":"(RD)","loc":"d,55:14,55:21","dtypep":"(EB)","isTrace":true,"scopep":"(MB)","varp":"(KB)"}
+        {"type":"VARSCOPE","name":"t.cell1.IGNORED","addr":"(TD)","loc":"d,55:14,55:21","dtypep":"(GB)","isTrace":true,"scopep":"(OB)","varp":"(MB)"}
       ],
        "blocksp": [
-        {"type":"ALWAYS","addr":"(SD)","loc":"d,27:23,27:24","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(UD)","loc":"d,27:23,27:24","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(TD)","loc":"d,27:23,27:24","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(VD)","loc":"d,27:23,27:24","dtypep":"(K)",
            "rhsp": [
-            {"type":"EQ","addr":"(UD)","loc":"d,27:32,27:34","dtypep":"(VD)",
+            {"type":"EQ","addr":"(WD)","loc":"d,27:32,27:34","dtypep":"(XD)",
              "lhsp": [
-              {"type":"CONST","name":"2'h0","addr":"(WD)","loc":"d,27:35,27:41","dtypep":"(T)","origParamName":"S_IDLE"}
+              {"type":"CONST","name":"2'h0","addr":"(YD)","loc":"d,27:35,27:41","dtypep":"(V)","origParamName":"S_IDLE"}
             ],
              "rhsp": [
-              {"type":"SEL","addr":"(XD)","loc":"d,27:26,27:27","dtypep":"(T)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+              {"type":"SEL","addr":"(ZD)","loc":"d,27:26,27:27","dtypep":"(V)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"d","addr":"(YD)","loc":"d,27:25,27:26","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+                {"type":"VARREF","name":"d","addr":"(AE)","loc":"d,27:25,27:26","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
               ],
                "lsbp": [
-                {"type":"CONST","name":"2'h0","addr":"(ZD)","loc":"d,27:29,27:30","dtypep":"(AE)"}
+                {"type":"CONST","name":"2'h0","addr":"(BE)","loc":"d,27:29,27:30","dtypep":"(CE)"}
               ]}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.direct_named","addr":"(BE)","loc":"d,27:10,27:22","dtypep":"(J)","access":"WR","varp":"(P)","varScopep":"(GC)"}
+            {"type":"VARREF","name":"t.direct_named","addr":"(DE)","loc":"d,27:10,27:22","dtypep":"(K)","access":"WR","varp":"(R)","varScopep":"(IC)"}
           ]}
         ]},
-        {"type":"ALWAYS","addr":"(CE)","loc":"d,28:25,28:26","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(EE)","loc":"d,28:25,28:26","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(DE)","loc":"d,28:25,28:26","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(FE)","loc":"d,28:25,28:26","dtypep":"(K)",
            "rhsp": [
-            {"type":"EQ","addr":"(EE)","loc":"d,28:34,28:36","dtypep":"(VD)",
+            {"type":"EQ","addr":"(GE)","loc":"d,28:34,28:36","dtypep":"(XD)",
              "lhsp": [
-              {"type":"CONST","name":"2'h2","addr":"(FE)","loc":"d,28:37,28:43","dtypep":"(T)","origParamName":"S_EXEC"}
+              {"type":"CONST","name":"2'h2","addr":"(HE)","loc":"d,28:37,28:43","dtypep":"(V)","origParamName":"S_EXEC"}
             ],
              "rhsp": [
-              {"type":"SEL","addr":"(GE)","loc":"d,28:28,28:29","dtypep":"(T)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+              {"type":"SEL","addr":"(IE)","loc":"d,28:28,28:29","dtypep":"(V)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"d","addr":"(HE)","loc":"d,28:27,28:28","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+                {"type":"VARREF","name":"d","addr":"(JE)","loc":"d,28:27,28:28","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
               ],
                "lsbp": [
-                {"type":"CONST","name":"2'h0","addr":"(IE)","loc":"d,28:31,28:32","dtypep":"(AE)"}
+                {"type":"CONST","name":"2'h0","addr":"(KE)","loc":"d,28:31,28:32","dtypep":"(CE)"}
               ]}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.computed_named","addr":"(JE)","loc":"d,28:10,28:24","dtypep":"(J)","access":"WR","varp":"(Q)","varScopep":"(HC)"}
+            {"type":"VARREF","name":"t.computed_named","addr":"(LE)","loc":"d,28:10,28:24","dtypep":"(K)","access":"WR","varp":"(S)","varScopep":"(JC)"}
           ]}
         ]},
-        {"type":"ALWAYS","addr":"(KE)","loc":"d,29:25,29:26","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(ME)","loc":"d,29:25,29:26","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(LE)","loc":"d,29:25,29:26","dtypep":"(J)",
+          {"type":"ASSIGNW","addr":"(NE)","loc":"d,29:25,29:26","dtypep":"(K)",
            "rhsp": [
-            {"type":"EQ","addr":"(ME)","loc":"d,29:34,29:36","dtypep":"(VD)",
+            {"type":"EQ","addr":"(OE)","loc":"d,29:34,29:36","dtypep":"(XD)",
              "lhsp": [
-              {"type":"CONST","name":"2'h2","addr":"(NE)","loc":"d,29:46,29:47","dtypep":"(V)"}
+              {"type":"CONST","name":"2'h2","addr":"(PE)","loc":"d,29:46,29:47","dtypep":"(X)"}
             ],
              "rhsp": [
-              {"type":"SEL","addr":"(OE)","loc":"d,29:28,29:29","dtypep":"(T)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
+              {"type":"SEL","addr":"(QE)","loc":"d,29:28,29:29","dtypep":"(V)","widthConst":2,"declRange":"[3:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"d","addr":"(PE)","loc":"d,29:27,29:28","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+                {"type":"VARREF","name":"d","addr":"(RE)","loc":"d,29:27,29:28","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
               ],
                "lsbp": [
-                {"type":"CONST","name":"2'h0","addr":"(QE)","loc":"d,29:31,29:32","dtypep":"(AE)"}
+                {"type":"CONST","name":"2'h0","addr":"(SE)","loc":"d,29:31,29:32","dtypep":"(CE)"}
               ]}
             ]}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.anonymous_expr","addr":"(RE)","loc":"d,29:10,29:24","dtypep":"(J)","access":"WR","varp":"(R)","varScopep":"(IC)"}
+            {"type":"VARREF","name":"t.anonymous_expr","addr":"(TE)","loc":"d,29:10,29:24","dtypep":"(K)","access":"WR","varp":"(T)","varScopep":"(KC)"}
           ]}
         ]},
-        {"type":"ALWAYS","addr":"(SE)","loc":"d,67:12,67:13","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(UE)","loc":"d,67:12,67:13","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(TE)","loc":"d,67:12,67:13","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(VE)","loc":"d,67:12,67:13","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"t.between","addr":"(UE)","loc":"d,67:14,67:15","dtypep":"(H)","access":"RD","varp":"(O)","varScopep":"(FC)"}
+            {"type":"VARREF","name":"t.between","addr":"(WE)","loc":"d,67:14,67:15","dtypep":"(I)","access":"RD","varp":"(Q)","varScopep":"(HC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"q","addr":"(VE)","loc":"d,67:10,67:11","dtypep":"(H)","access":"WR","varp":"(G)","varScopep":"(NB)"}
+            {"type":"VARREF","name":"q","addr":"(XE)","loc":"d,67:10,67:11","dtypep":"(I)","access":"WR","varp":"(H)","varScopep":"(PB)"}
           ]}
         ]},
-        {"type":"ALWAYS","addr":"(WE)","loc":"d,57:3,57:9","keyword":"always",
+        {"type":"ALWAYS","addr":"(YE)","loc":"d,57:3,57:9","keyword":"always",
          "sentreep": [
-          {"type":"SENTREE","addr":"(XE)","loc":"d,57:10,57:11",
+          {"type":"SENTREE","addr":"(ZE)","loc":"d,57:10,57:11",
            "sensesp": [
-            {"type":"SENITEM","addr":"(YE)","loc":"d,57:12,57:19","edgeType":"POS",
+            {"type":"SENITEM","addr":"(AF)","loc":"d,57:12,57:19","edgeType":"POS",
              "sensp": [
-              {"type":"VARREF","name":"clk","addr":"(ZE)","loc":"d,57:20,57:23","dtypep":"(J)","access":"RD","varp":"(I)","varScopep":"(OB)"}
+              {"type":"VARREF","name":"clk","addr":"(BF)","loc":"d,57:20,57:23","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"(QB)"}
             ]}
           ]}
         ],
          "stmtsp": [
-          {"type":"ASSIGNDLY","addr":"(AF)","loc":"d,57:27,57:29","dtypep":"(H)",
+          {"type":"ASSIGNDLY","addr":"(CF)","loc":"d,57:27,57:29","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"d","addr":"(BF)","loc":"d,57:30,57:31","dtypep":"(H)","access":"RD","varp":"(K)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"d","addr":"(DF)","loc":"d,57:30,57:31","dtypep":"(I)","access":"RD","varp":"(L)","varScopep":"(RB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"t.between","addr":"(CF)","loc":"d,57:25,57:26","dtypep":"(H)","access":"WR","varp":"(O)","varScopep":"(FC)"}
+            {"type":"VARREF","name":"t.between","addr":"(EF)","loc":"d,57:25,57:26","dtypep":"(I)","access":"WR","varp":"(Q)","varScopep":"(HC)"}
           ]}
         ]}
       ]}
     ]}
-  ]}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":3,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"bit","addr":"(V)","loc":"d,23:35,23:40","dtypep":"(V)","keyword":"bit","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(J)","loc":"d,27:32,27:34","dtypep":"(J)","keyword":"logic","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(T)","loc":"d,23:14,23:19","dtypep":"(T)","keyword":"logic","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(EB)","loc":"d,48:15,48:20","dtypep":"(EB)","keyword":"logic","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,16:15,16:16","dtypep":"(H)","keyword":"logic","range":"3:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(AE)","loc":"d,27:26,27:27","dtypep":"(AE)","keyword":"logic","range":"1:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(VD)","loc":"d,27:32,27:34","dtypep":"(VD)","keyword":"bit","generic":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(GB)","loc":"d,29:48,29:49","dtypep":"(GB)","keyword":"bit","range":"31:0","generic":true,"signed":true}
+    {"type":"BASICDTYPE","name":"bit","addr":"(X)","loc":"d,23:35,23:40","dtypep":"(X)","keyword":"bit","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,27:32,27:34","dtypep":"(K)","keyword":"logic","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(V)","loc":"d,23:14,23:19","dtypep":"(V)","keyword":"logic","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(GB)","loc":"d,48:15,48:20","dtypep":"(GB)","keyword":"logic","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(I)","loc":"d,16:15,16:16","dtypep":"(I)","keyword":"logic","range":"3:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(CE)","loc":"d,27:26,27:27","dtypep":"(CE)","keyword":"logic","range":"1:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(XD)","loc":"d,27:32,27:34","dtypep":"(XD)","keyword":"bit","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(IB)","loc":"d,29:48,29:49","dtypep":"(IB)","keyword":"bit","range":"31:0","generic":true,"signed":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(DF)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(FF)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(EF)","loc":"a,0:0,0:0","modp":"(DF)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(GF)","loc":"a,0:0,0:0","modp":"(FF)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_no_inline_mod.out
+++ b/test_regress/t/t_json_only_flat_no_inline_mod.out
@@ -1,51 +1,53 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"top","typeTablep":"(C)","constPoolp":"(D)","topScopep":"(E)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"top","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","topScopep":"(F)",
  "modulesp": [
-  {"type":"MODULE","name":"$root","addr":"(F)","loc":"d,11:8,11:11","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"$root","addr":"(G)","loc":"d,11:8,11:11","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"i_clk","addr":"(G)","loc":"d,11:24,11:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"top.i_clk","addr":"(I)","loc":"d,11:24,11:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"top.f.i_clk","addr":"(J)","loc":"d,7:24,7:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"TOPSCOPE","addr":"(E)","loc":"d,11:8,11:11",
+    {"type":"VAR","name":"i_clk","addr":"(H)","loc":"d,11:24,11:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"CELL","name":"$unit","addr":"(J)","loc":"a,0:0,0:0","modName":"__024unit","origName":"__024unit","verilogName":"\\$unit ","modp":"(E)"},
+    {"type":"VAR","name":"top.i_clk","addr":"(K)","loc":"d,11:24,11:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"top.f.i_clk","addr":"(L)","loc":"d,7:24,7:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"TOPSCOPE","addr":"(F)","loc":"d,11:8,11:11",
      "scopep": [
-      {"type":"SCOPE","name":"TOP","addr":"(K)","loc":"d,11:8,11:11","modp":"(F)",
+      {"type":"SCOPE","name":"TOP","addr":"(M)","loc":"d,11:8,11:11","modp":"(G)",
        "varsp": [
-        {"type":"VARSCOPE","name":"i_clk","addr":"(L)","loc":"d,11:24,11:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(G)"},
-        {"type":"VARSCOPE","name":"top.i_clk","addr":"(M)","loc":"d,11:24,11:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(I)"},
-        {"type":"ALWAYS","addr":"(N)","loc":"d,11:24,11:29","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"i_clk","addr":"(N)","loc":"d,11:24,11:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(H)"},
+        {"type":"VARSCOPE","name":"top.i_clk","addr":"(O)","loc":"d,11:24,11:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(K)"},
+        {"type":"ALWAYS","addr":"(P)","loc":"d,11:24,11:29","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(O)","loc":"d,11:24,11:29","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(Q)","loc":"d,11:24,11:29","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_clk","addr":"(P)","loc":"d,11:24,11:29","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(L)"}
+            {"type":"VARREF","name":"i_clk","addr":"(R)","loc":"d,11:24,11:29","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(N)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"top.i_clk","addr":"(Q)","loc":"d,11:24,11:29","dtypep":"(H)","access":"WR","varp":"(I)","varScopep":"(M)"}
+            {"type":"VARREF","name":"top.i_clk","addr":"(S)","loc":"d,11:24,11:29","dtypep":"(I)","access":"WR","varp":"(K)","varScopep":"(O)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"top.f.i_clk","addr":"(R)","loc":"d,7:24,7:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(J)"},
-        {"type":"ALWAYS","addr":"(S)","loc":"d,7:24,7:29","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"top.f.i_clk","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(L)"},
+        {"type":"ALWAYS","addr":"(U)","loc":"d,7:24,7:29","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(V)","loc":"d,7:24,7:29","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_clk","addr":"(U)","loc":"d,7:24,7:29","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(L)"}
+            {"type":"VARREF","name":"i_clk","addr":"(W)","loc":"d,7:24,7:29","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(N)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"top.f.i_clk","addr":"(V)","loc":"d,7:24,7:29","dtypep":"(H)","access":"WR","varp":"(J)","varScopep":"(R)"}
+            {"type":"VARREF","name":"top.f.i_clk","addr":"(X)","loc":"d,7:24,7:29","dtypep":"(I)","access":"WR","varp":"(L)","varScopep":"(T)"}
           ]}
         ]}
       ]}
     ]}
-  ]}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":3,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,11:18,11:23","dtypep":"(H)","keyword":"logic","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(I)","loc":"d,11:18,11:23","dtypep":"(I)","keyword":"logic","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(W)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(Y)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(X)","loc":"a,0:0,0:0","modp":"(W)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(Z)","loc":"a,0:0,0:0","modp":"(Y)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_pub_mod.out
+++ b/test_regress/t/t_json_only_flat_pub_mod.out
@@ -1,51 +1,53 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"top","typeTablep":"(C)","constPoolp":"(D)","topScopep":"(E)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"top","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","topScopep":"(F)",
  "modulesp": [
-  {"type":"MODULE","name":"$root","addr":"(F)","loc":"d,11:8,11:11","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"$root","addr":"(G)","loc":"d,11:8,11:11","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"i_clk","addr":"(G)","loc":"d,11:24,11:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"top.i_clk","addr":"(I)","loc":"d,11:24,11:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"top.f.i_clk","addr":"(J)","loc":"d,7:24,7:29","dtypep":"(H)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"TOPSCOPE","addr":"(E)","loc":"d,11:8,11:11",
+    {"type":"VAR","name":"i_clk","addr":"(H)","loc":"d,11:24,11:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"CELL","name":"$unit","addr":"(J)","loc":"a,0:0,0:0","modName":"__024unit","origName":"__024unit","verilogName":"\\$unit ","modp":"(E)"},
+    {"type":"VAR","name":"top.i_clk","addr":"(K)","loc":"d,11:24,11:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"top.f.i_clk","addr":"(L)","loc":"d,7:24,7:29","dtypep":"(I)","origName":"i_clk","verilogName":"i_clk","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"TOPSCOPE","addr":"(F)","loc":"d,11:8,11:11",
      "scopep": [
-      {"type":"SCOPE","name":"TOP","addr":"(K)","loc":"d,11:8,11:11","modp":"(F)",
+      {"type":"SCOPE","name":"TOP","addr":"(M)","loc":"d,11:8,11:11","modp":"(G)",
        "varsp": [
-        {"type":"VARSCOPE","name":"i_clk","addr":"(L)","loc":"d,11:24,11:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(G)"},
-        {"type":"VARSCOPE","name":"top.i_clk","addr":"(M)","loc":"d,11:24,11:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(I)"},
-        {"type":"ALWAYS","addr":"(N)","loc":"d,11:24,11:29","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"i_clk","addr":"(N)","loc":"d,11:24,11:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(H)"},
+        {"type":"VARSCOPE","name":"top.i_clk","addr":"(O)","loc":"d,11:24,11:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(K)"},
+        {"type":"ALWAYS","addr":"(P)","loc":"d,11:24,11:29","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(O)","loc":"d,11:24,11:29","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(Q)","loc":"d,11:24,11:29","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_clk","addr":"(P)","loc":"d,11:24,11:29","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(L)"}
+            {"type":"VARREF","name":"i_clk","addr":"(R)","loc":"d,11:24,11:29","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(N)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"top.i_clk","addr":"(Q)","loc":"d,11:24,11:29","dtypep":"(H)","access":"WR","varp":"(I)","varScopep":"(M)"}
+            {"type":"VARREF","name":"top.i_clk","addr":"(S)","loc":"d,11:24,11:29","dtypep":"(I)","access":"WR","varp":"(K)","varScopep":"(O)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"top.f.i_clk","addr":"(R)","loc":"d,7:24,7:29","dtypep":"(H)","isTrace":true,"scopep":"(K)","varp":"(J)"},
-        {"type":"ALWAYS","addr":"(S)","loc":"d,7:24,7:29","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"top.f.i_clk","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(I)","isTrace":true,"scopep":"(M)","varp":"(L)"},
+        {"type":"ALWAYS","addr":"(U)","loc":"d,7:24,7:29","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(T)","loc":"d,7:24,7:29","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(V)","loc":"d,7:24,7:29","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_clk","addr":"(U)","loc":"d,7:24,7:29","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(L)"}
+            {"type":"VARREF","name":"i_clk","addr":"(W)","loc":"d,7:24,7:29","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(N)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"top.f.i_clk","addr":"(V)","loc":"d,7:24,7:29","dtypep":"(H)","access":"WR","varp":"(J)","varScopep":"(R)"}
+            {"type":"VARREF","name":"top.f.i_clk","addr":"(X)","loc":"d,7:24,7:29","dtypep":"(I)","access":"WR","varp":"(L)","varScopep":"(T)"}
           ]}
         ]}
       ]}
     ]}
-  ]}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":3,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,11:18,11:23","dtypep":"(H)","keyword":"logic","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(I)","loc":"d,11:18,11:23","dtypep":"(I)","keyword":"logic","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(W)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(Y)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(X)","loc":"a,0:0,0:0","modp":"(W)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(Z)","loc":"a,0:0,0:0","modp":"(Y)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_flat_vlvbound.out
+++ b/test_regress/t/t_json_only_flat_vlvbound.out
@@ -1,355 +1,357 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"vlvbound_test","typeTablep":"(C)","constPoolp":"(D)","topScopep":"(E)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","resolvedTopModuleName":"vlvbound_test","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)","topScopep":"(F)",
  "modulesp": [
-  {"type":"MODULE","name":"$root","addr":"(F)","loc":"d,7:8,7:21","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"$root","addr":"(G)","loc":"d,7:8,7:21","origName":"$root","verilogName":"$root","level":1,"depth":1,"modPublic":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"i_a","addr":"(G)","loc":"d,8:24,8:27","dtypep":"(H)","origName":"i_a","verilogName":"i_a","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"i_b","addr":"(I)","loc":"d,9:24,9:27","dtypep":"(H)","origName":"i_b","verilogName":"i_b","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"o_a","addr":"(J)","loc":"d,10:24,10:27","dtypep":"(K)","origName":"o_a","verilogName":"o_a","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"o_b","addr":"(L)","loc":"d,11:24,11:27","dtypep":"(K)","origName":"o_b","verilogName":"o_b","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"vlvbound_test.i_a","addr":"(M)","loc":"d,8:24,8:27","dtypep":"(H)","origName":"i_a","verilogName":"i_a","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"vlvbound_test.i_b","addr":"(N)","loc":"d,9:24,9:27","dtypep":"(H)","origName":"i_b","verilogName":"i_b","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"vlvbound_test.o_a","addr":"(O)","loc":"d,10:24,10:27","dtypep":"(K)","origName":"o_a","verilogName":"o_a","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"vlvbound_test.o_b","addr":"(P)","loc":"d,11:24,11:27","dtypep":"(K)","origName":"o_b","verilogName":"o_b","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"TOPSCOPE","addr":"(E)","loc":"d,7:8,7:21",
+    {"type":"VAR","name":"i_a","addr":"(H)","loc":"d,8:24,8:27","dtypep":"(I)","origName":"i_a","verilogName":"i_a","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"i_b","addr":"(J)","loc":"d,9:24,9:27","dtypep":"(I)","origName":"i_b","verilogName":"i_b","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"o_a","addr":"(K)","loc":"d,10:24,10:27","dtypep":"(L)","origName":"o_a","verilogName":"o_a","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"o_b","addr":"(M)","loc":"d,11:24,11:27","dtypep":"(L)","origName":"o_b","verilogName":"o_b","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"CELL","name":"$unit","addr":"(N)","loc":"a,0:0,0:0","modName":"__024unit","origName":"__024unit","verilogName":"\\$unit ","modp":"(E)"},
+    {"type":"VAR","name":"vlvbound_test.i_a","addr":"(O)","loc":"d,8:24,8:27","dtypep":"(I)","origName":"i_a","verilogName":"i_a","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"vlvbound_test.i_b","addr":"(P)","loc":"d,9:24,9:27","dtypep":"(I)","origName":"i_b","verilogName":"i_b","direction":"NONE","declDirection":"INPUT","lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"vlvbound_test.o_a","addr":"(Q)","loc":"d,10:24,10:27","dtypep":"(L)","origName":"o_a","verilogName":"o_a","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"vlvbound_test.o_b","addr":"(R)","loc":"d,11:24,11:27","dtypep":"(L)","origName":"o_b","verilogName":"o_b","direction":"NONE","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"TOPSCOPE","addr":"(F)","loc":"d,7:8,7:21",
      "scopep": [
-      {"type":"SCOPE","name":"TOP","addr":"(Q)","loc":"d,7:8,7:21","modp":"(F)",
+      {"type":"SCOPE","name":"TOP","addr":"(S)","loc":"d,7:8,7:21","modp":"(G)",
        "varsp": [
-        {"type":"VARSCOPE","name":"i_a","addr":"(R)","loc":"d,8:24,8:27","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(G)"},
-        {"type":"VARSCOPE","name":"i_b","addr":"(S)","loc":"d,9:24,9:27","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(I)"},
-        {"type":"VARSCOPE","name":"o_a","addr":"(T)","loc":"d,10:24,10:27","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(J)"},
-        {"type":"VARSCOPE","name":"o_b","addr":"(U)","loc":"d,11:24,11:27","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(L)"},
-        {"type":"VARSCOPE","name":"vlvbound_test.i_a","addr":"(V)","loc":"d,8:24,8:27","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(M)"},
-        {"type":"ALWAYS","addr":"(W)","loc":"d,8:24,8:27","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"i_a","addr":"(T)","loc":"d,8:24,8:27","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(H)"},
+        {"type":"VARSCOPE","name":"i_b","addr":"(U)","loc":"d,9:24,9:27","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(J)"},
+        {"type":"VARSCOPE","name":"o_a","addr":"(V)","loc":"d,10:24,10:27","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(K)"},
+        {"type":"VARSCOPE","name":"o_b","addr":"(W)","loc":"d,11:24,11:27","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(M)"},
+        {"type":"VARSCOPE","name":"vlvbound_test.i_a","addr":"(X)","loc":"d,8:24,8:27","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(O)"},
+        {"type":"ALWAYS","addr":"(Y)","loc":"d,8:24,8:27","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(X)","loc":"d,8:24,8:27","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(Z)","loc":"d,8:24,8:27","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_a","addr":"(Y)","loc":"d,8:24,8:27","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(R)"}
+            {"type":"VARREF","name":"i_a","addr":"(AB)","loc":"d,8:24,8:27","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(T)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"vlvbound_test.i_a","addr":"(Z)","loc":"d,8:24,8:27","dtypep":"(H)","access":"WR","varp":"(M)","varScopep":"(V)"}
+            {"type":"VARREF","name":"vlvbound_test.i_a","addr":"(BB)","loc":"d,8:24,8:27","dtypep":"(I)","access":"WR","varp":"(O)","varScopep":"(X)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"vlvbound_test.i_b","addr":"(AB)","loc":"d,9:24,9:27","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(N)"},
-        {"type":"ALWAYS","addr":"(BB)","loc":"d,9:24,9:27","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"vlvbound_test.i_b","addr":"(CB)","loc":"d,9:24,9:27","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(P)"},
+        {"type":"ALWAYS","addr":"(DB)","loc":"d,9:24,9:27","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(CB)","loc":"d,9:24,9:27","dtypep":"(H)",
+          {"type":"ASSIGNW","addr":"(EB)","loc":"d,9:24,9:27","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_b","addr":"(DB)","loc":"d,9:24,9:27","dtypep":"(H)","access":"RD","varp":"(I)","varScopep":"(S)"}
+            {"type":"VARREF","name":"i_b","addr":"(FB)","loc":"d,9:24,9:27","dtypep":"(I)","access":"RD","varp":"(J)","varScopep":"(U)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"vlvbound_test.i_b","addr":"(EB)","loc":"d,9:24,9:27","dtypep":"(H)","access":"WR","varp":"(N)","varScopep":"(AB)"}
+            {"type":"VARREF","name":"vlvbound_test.i_b","addr":"(GB)","loc":"d,9:24,9:27","dtypep":"(I)","access":"WR","varp":"(P)","varScopep":"(CB)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"vlvbound_test.o_a","addr":"(FB)","loc":"d,10:24,10:27","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(O)"},
-        {"type":"ALWAYS","addr":"(GB)","loc":"d,10:24,10:27","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"vlvbound_test.o_a","addr":"(HB)","loc":"d,10:24,10:27","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(Q)"},
+        {"type":"ALWAYS","addr":"(IB)","loc":"d,10:24,10:27","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(HB)","loc":"d,10:24,10:27","dtypep":"(K)",
+          {"type":"ASSIGNW","addr":"(JB)","loc":"d,10:24,10:27","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"o_a","addr":"(IB)","loc":"d,10:24,10:27","dtypep":"(K)","access":"RD","varp":"(J)","varScopep":"(T)"}
+            {"type":"VARREF","name":"o_a","addr":"(KB)","loc":"d,10:24,10:27","dtypep":"(L)","access":"RD","varp":"(K)","varScopep":"(V)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"vlvbound_test.o_a","addr":"(JB)","loc":"d,10:24,10:27","dtypep":"(K)","access":"WR","varp":"(O)","varScopep":"(FB)"}
+            {"type":"VARREF","name":"vlvbound_test.o_a","addr":"(LB)","loc":"d,10:24,10:27","dtypep":"(L)","access":"WR","varp":"(Q)","varScopep":"(HB)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"vlvbound_test.o_b","addr":"(KB)","loc":"d,11:24,11:27","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(P)"},
-        {"type":"ALWAYS","addr":"(LB)","loc":"d,11:24,11:27","keyword":"cont_assign",
+        {"type":"VARSCOPE","name":"vlvbound_test.o_b","addr":"(MB)","loc":"d,11:24,11:27","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(R)"},
+        {"type":"ALWAYS","addr":"(NB)","loc":"d,11:24,11:27","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"ASSIGNW","addr":"(MB)","loc":"d,11:24,11:27","dtypep":"(K)",
+          {"type":"ASSIGNW","addr":"(OB)","loc":"d,11:24,11:27","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"o_b","addr":"(NB)","loc":"d,11:24,11:27","dtypep":"(K)","access":"RD","varp":"(L)","varScopep":"(U)"}
+            {"type":"VARREF","name":"o_b","addr":"(PB)","loc":"d,11:24,11:27","dtypep":"(L)","access":"RD","varp":"(M)","varScopep":"(W)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"vlvbound_test.o_b","addr":"(OB)","loc":"d,11:24,11:27","dtypep":"(K)","access":"WR","varp":"(P)","varScopep":"(KB)"}
+            {"type":"VARREF","name":"vlvbound_test.o_b","addr":"(QB)","loc":"d,11:24,11:27","dtypep":"(L)","access":"WR","varp":"(R)","varScopep":"(MB)"}
           ]}
         ]},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(PB)","loc":"d,14:34,14:37","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(QB)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(RB)","loc":"d,14:57,14:60","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(SB)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(TB)","loc":"d,15:17,15:20","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(UB)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(VB)","loc":"d,16:13,16:14","dtypep":"(WB)","isTrace":true,"scopep":"(Q)","varp":"(XB)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(YB)","loc":"d,14:34,14:37","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(ZB)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(AC)","loc":"d,14:57,14:60","dtypep":"(H)","isTrace":true,"scopep":"(Q)","varp":"(BC)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(CC)","loc":"d,15:17,15:20","dtypep":"(K)","isTrace":true,"scopep":"(Q)","varp":"(DC)"},
-        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(EC)","loc":"d,16:13,16:14","dtypep":"(WB)","isTrace":true,"scopep":"(Q)","varp":"(FC)"}
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(RB)","loc":"d,14:34,14:37","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(SB)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(TB)","loc":"d,14:57,14:60","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(UB)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(VB)","loc":"d,15:17,15:20","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(WB)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(XB)","loc":"d,16:13,16:14","dtypep":"(YB)","isTrace":true,"scopep":"(S)","varp":"(ZB)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(AC)","loc":"d,14:34,14:37","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(BC)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(CC)","loc":"d,14:57,14:60","dtypep":"(I)","isTrace":true,"scopep":"(S)","varp":"(DC)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(EC)","loc":"d,15:17,15:20","dtypep":"(L)","isTrace":true,"scopep":"(S)","varp":"(FC)"},
+        {"type":"VARSCOPE","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(GC)","loc":"d,16:13,16:14","dtypep":"(YB)","isTrace":true,"scopep":"(S)","varp":"(HC)"}
       ],
        "blocksp": [
-        {"type":"ALWAYS","addr":"(GC)","loc":"d,23:14,23:15","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(IC)","loc":"d,23:14,23:15","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"COMMENT","name":"Function: foo","addr":"(HC)","loc":"d,23:16,23:19","showAt":true},
-          {"type":"ASSIGN","addr":"(IC)","loc":"d,23:20,23:23","dtypep":"(H)",
+          {"type":"COMMENT","name":"Function: foo","addr":"(JC)","loc":"d,23:16,23:19","showAt":true},
+          {"type":"ASSIGN","addr":"(KC)","loc":"d,23:20,23:23","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_a","addr":"(JC)","loc":"d,23:20,23:23","dtypep":"(H)","access":"RD","varp":"(G)","varScopep":"(R)"}
+            {"type":"VARREF","name":"i_a","addr":"(LC)","loc":"d,23:20,23:23","dtypep":"(I)","access":"RD","varp":"(H)","varScopep":"(T)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(KC)","loc":"d,14:57,14:60","dtypep":"(H)","access":"WR","varp":"(SB)","varScopep":"(RB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(MC)","loc":"d,14:57,14:60","dtypep":"(I)","access":"WR","varp":"(UB)","varScopep":"(TB)"}
           ]},
-          {"type":"ASSIGN","addr":"(LC)","loc":"d,14:34,14:37","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(NC)","loc":"d,14:34,14:37","dtypep":"(L)",
            "rhsp": [
-            {"type":"CRESET","addr":"(MC)","loc":"d,14:34,14:37","dtypep":"(K)"}
+            {"type":"CRESET","addr":"(OC)","loc":"d,14:34,14:37","dtypep":"(L)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(NC)","loc":"d,14:34,14:37","dtypep":"(K)","access":"WR","varp":"(QB)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(PC)","loc":"d,14:34,14:37","dtypep":"(L)","access":"WR","varp":"(SB)","varScopep":"(RB)"}
           ]},
-          {"type":"ASSIGN","addr":"(OC)","loc":"d,15:17,15:20","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(QC)","loc":"d,15:17,15:20","dtypep":"(L)",
            "rhsp": [
-            {"type":"CRESET","addr":"(PC)","loc":"d,15:17,15:20","dtypep":"(K)"}
+            {"type":"CRESET","addr":"(RC)","loc":"d,15:17,15:20","dtypep":"(L)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(QC)","loc":"d,15:17,15:20","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(SC)","loc":"d,15:17,15:20","dtypep":"(L)","access":"WR","varp":"(WB)","varScopep":"(VB)"}
           ]},
-          {"type":"ASSIGN","addr":"(RC)","loc":"d,16:13,16:14","dtypep":"(WB)",
+          {"type":"ASSIGN","addr":"(TC)","loc":"d,16:13,16:14","dtypep":"(YB)",
            "rhsp": [
-            {"type":"CRESET","addr":"(SC)","loc":"d,16:13,16:14","dtypep":"(WB)"}
+            {"type":"CRESET","addr":"(UC)","loc":"d,16:13,16:14","dtypep":"(YB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(TC)","loc":"d,16:13,16:14","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(VC)","loc":"d,16:13,16:14","dtypep":"(YB)","access":"WR","varp":"(ZB)","varScopep":"(XB)"}
           ]},
-          {"type":"ASSIGN","addr":"(UC)","loc":"d,17:12,17:13","dtypep":"(WB)",
+          {"type":"ASSIGN","addr":"(WC)","loc":"d,17:12,17:13","dtypep":"(YB)",
            "rhsp": [
-            {"type":"CONST","name":"32'sh0","addr":"(VC)","loc":"d,17:14,17:15","dtypep":"(WC)"}
+            {"type":"CONST","name":"32'sh0","addr":"(XC)","loc":"d,17:14,17:15","dtypep":"(YC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(XC)","loc":"d,17:10,17:11","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(ZC)","loc":"d,17:10,17:11","dtypep":"(YB)","access":"WR","varp":"(ZB)","varScopep":"(XB)"}
           ]},
-          {"type":"LOOP","addr":"(YC)","loc":"d,17:5,17:8","unroll":"default",
+          {"type":"LOOP","addr":"(AD)","loc":"d,17:5,17:8","unroll":"default",
            "stmtsp": [
-            {"type":"LOOPTEST","addr":"(ZC)","loc":"d,17:17,17:18",
+            {"type":"LOOPTEST","addr":"(BD)","loc":"d,17:17,17:18",
              "condp": [
-              {"type":"GTS","addr":"(AD)","loc":"d,17:19,17:20","dtypep":"(BD)",
+              {"type":"GTS","addr":"(CD)","loc":"d,17:19,17:20","dtypep":"(DD)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh7","addr":"(CD)","loc":"d,17:21,17:22","dtypep":"(WC)"}
+                {"type":"CONST","name":"32'sh7","addr":"(ED)","loc":"d,17:21,17:22","dtypep":"(YC)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(DD)","loc":"d,17:17,17:18","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(FD)","loc":"d,17:17,17:18","dtypep":"(YB)","access":"RD","varp":"(ZB)","varScopep":"(XB)"}
               ]}
             ]},
-            {"type":"ASSIGN","addr":"(ED)","loc":"d,18:14,18:15","dtypep":"(FD)",
+            {"type":"ASSIGN","addr":"(GD)","loc":"d,18:14,18:15","dtypep":"(HD)",
              "rhsp": [
-              {"type":"EQ","addr":"(GD)","loc":"d,18:29,18:31","dtypep":"(BD)",
+              {"type":"EQ","addr":"(ID)","loc":"d,18:29,18:31","dtypep":"(DD)",
                "lhsp": [
-                {"type":"CONST","name":"2'h0","addr":"(HD)","loc":"d,18:32,18:37","dtypep":"(ID)"}
+                {"type":"CONST","name":"2'h0","addr":"(JD)","loc":"d,18:32,18:37","dtypep":"(KD)"}
               ],
                "rhsp": [
-                {"type":"SEL","addr":"(JD)","loc":"d,18:20,18:21","dtypep":"(KD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
+                {"type":"SEL","addr":"(LD)","loc":"d,18:20,18:21","dtypep":"(MD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(LD)","loc":"d,18:17,18:20","dtypep":"(H)","access":"RD","varp":"(SB)","varScopep":"(RB)"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(ND)","loc":"d,18:17,18:20","dtypep":"(I)","access":"RD","varp":"(UB)","varScopep":"(TB)"}
                 ],
                  "lsbp": [
-                  {"type":"SEL","addr":"(MD)","loc":"d,18:22,18:23","dtypep":"(ND)","widthConst":4,
+                  {"type":"SEL","addr":"(OD)","loc":"d,18:22,18:23","dtypep":"(PD)","widthConst":4,
                    "fromp": [
-                    {"type":"MULS","addr":"(OD)","loc":"d,18:22,18:23","dtypep":"(PD)",
+                    {"type":"MULS","addr":"(QD)","loc":"d,18:22,18:23","dtypep":"(RD)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'sh2","addr":"(QD)","loc":"d,18:23,18:24","dtypep":"(WC)"}
+                      {"type":"CONST","name":"32'sh2","addr":"(SD)","loc":"d,18:23,18:24","dtypep":"(YC)"}
                     ],
                      "rhsp": [
-                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(RD)","loc":"d,18:21,18:22","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)"}
+                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(TD)","loc":"d,18:21,18:22","dtypep":"(YB)","access":"RD","varp":"(ZB)","varScopep":"(XB)"}
                     ]}
                   ],
                    "lsbp": [
-                    {"type":"CONST","name":"32'h0","addr":"(SD)","loc":"d,18:22,18:23","dtypep":"(TD)"}
+                    {"type":"CONST","name":"32'h0","addr":"(UD)","loc":"d,18:22,18:23","dtypep":"(VD)"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"SEL","addr":"(UD)","loc":"d,18:10,18:11","dtypep":"(FD)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
+              {"type":"SEL","addr":"(WD)","loc":"d,18:10,18:11","dtypep":"(HD)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(VD)","loc":"d,18:7,18:10","dtypep":"(K)","access":"WR","varp":"(UB)","varScopep":"(TB)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(XD)","loc":"d,18:7,18:10","dtypep":"(L)","access":"WR","varp":"(WB)","varScopep":"(VB)"}
               ],
                "lsbp": [
-                {"type":"SEL","addr":"(WD)","loc":"d,18:11,18:12","dtypep":"(XD)","widthConst":3,
+                {"type":"SEL","addr":"(YD)","loc":"d,18:11,18:12","dtypep":"(ZD)","widthConst":3,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(YD)","loc":"d,18:11,18:12","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(AE)","loc":"d,18:11,18:12","dtypep":"(YB)","access":"RD","varp":"(ZB)","varScopep":"(XB)"}
                 ],
                  "lsbp": [
-                  {"type":"CONST","name":"32'h0","addr":"(ZD)","loc":"d,18:11,18:12","dtypep":"(TD)"}
+                  {"type":"CONST","name":"32'h0","addr":"(BE)","loc":"d,18:11,18:12","dtypep":"(VD)"}
                 ]}
               ]}
             ]},
-            {"type":"ASSIGN","addr":"(AE)","loc":"d,17:25,17:27","dtypep":"(WB)",
+            {"type":"ASSIGN","addr":"(CE)","loc":"d,17:25,17:27","dtypep":"(YB)",
              "rhsp": [
-              {"type":"ADD","addr":"(BE)","loc":"d,17:25,17:27","dtypep":"(CE)",
+              {"type":"ADD","addr":"(DE)","loc":"d,17:25,17:27","dtypep":"(EE)",
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(DE)","loc":"d,17:25,17:27","dtypep":"(TD)"}
+                {"type":"CONST","name":"32'h1","addr":"(FE)","loc":"d,17:25,17:27","dtypep":"(VD)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(EE)","loc":"d,17:24,17:25","dtypep":"(WB)","access":"RD","varp":"(XB)","varScopep":"(VB)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(GE)","loc":"d,17:24,17:25","dtypep":"(YB)","access":"RD","varp":"(ZB)","varScopep":"(XB)"}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(FE)","loc":"d,17:24,17:25","dtypep":"(WB)","access":"WR","varp":"(XB)","varScopep":"(VB)"}
+              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(HE)","loc":"d,17:24,17:25","dtypep":"(YB)","access":"WR","varp":"(ZB)","varScopep":"(XB)"}
             ]}
           ]},
-          {"type":"ASSIGN","addr":"(GE)","loc":"d,20:5,20:11","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(IE)","loc":"d,20:5,20:11","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(HE)","loc":"d,20:12,20:15","dtypep":"(K)","access":"RD","varp":"(UB)","varScopep":"(TB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(JE)","loc":"d,20:12,20:15","dtypep":"(L)","access":"RD","varp":"(WB)","varScopep":"(VB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(IE)","loc":"d,20:5,20:11","dtypep":"(K)","access":"WR","varp":"(QB)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(KE)","loc":"d,20:5,20:11","dtypep":"(L)","access":"WR","varp":"(SB)","varScopep":"(RB)"}
           ]},
-          {"type":"ASSIGNW","addr":"(JE)","loc":"d,23:14,23:15","dtypep":"(K)",
+          {"type":"ASSIGNW","addr":"(LE)","loc":"d,23:14,23:15","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(KE)","loc":"d,23:16,23:19","dtypep":"(K)","access":"RD","varp":"(QB)","varScopep":"(PB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(ME)","loc":"d,23:16,23:19","dtypep":"(L)","access":"RD","varp":"(SB)","varScopep":"(RB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"o_a","addr":"(LE)","loc":"d,23:10,23:13","dtypep":"(K)","access":"WR","varp":"(J)","varScopep":"(T)"}
+            {"type":"VARREF","name":"o_a","addr":"(NE)","loc":"d,23:10,23:13","dtypep":"(L)","access":"WR","varp":"(K)","varScopep":"(V)"}
           ]}
         ]},
-        {"type":"ALWAYS","addr":"(ME)","loc":"d,24:14,24:15","keyword":"cont_assign",
+        {"type":"ALWAYS","addr":"(OE)","loc":"d,24:14,24:15","keyword":"cont_assign",
          "stmtsp": [
-          {"type":"COMMENT","name":"Function: foo","addr":"(NE)","loc":"d,24:16,24:19","showAt":true},
-          {"type":"ASSIGN","addr":"(OE)","loc":"d,24:20,24:23","dtypep":"(H)",
+          {"type":"COMMENT","name":"Function: foo","addr":"(PE)","loc":"d,24:16,24:19","showAt":true},
+          {"type":"ASSIGN","addr":"(QE)","loc":"d,24:20,24:23","dtypep":"(I)",
            "rhsp": [
-            {"type":"VARREF","name":"i_b","addr":"(PE)","loc":"d,24:20,24:23","dtypep":"(H)","access":"RD","varp":"(I)","varScopep":"(S)"}
+            {"type":"VARREF","name":"i_b","addr":"(RE)","loc":"d,24:20,24:23","dtypep":"(I)","access":"RD","varp":"(J)","varScopep":"(U)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(QE)","loc":"d,14:57,14:60","dtypep":"(H)","access":"WR","varp":"(BC)","varScopep":"(AC)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(SE)","loc":"d,14:57,14:60","dtypep":"(I)","access":"WR","varp":"(DC)","varScopep":"(CC)"}
           ]},
-          {"type":"ASSIGN","addr":"(RE)","loc":"d,14:34,14:37","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(TE)","loc":"d,14:34,14:37","dtypep":"(L)",
            "rhsp": [
-            {"type":"CRESET","addr":"(SE)","loc":"d,14:34,14:37","dtypep":"(K)"}
+            {"type":"CRESET","addr":"(UE)","loc":"d,14:34,14:37","dtypep":"(L)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(TE)","loc":"d,14:34,14:37","dtypep":"(K)","access":"WR","varp":"(ZB)","varScopep":"(YB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(VE)","loc":"d,14:34,14:37","dtypep":"(L)","access":"WR","varp":"(BC)","varScopep":"(AC)"}
           ]},
-          {"type":"ASSIGN","addr":"(UE)","loc":"d,15:17,15:20","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(WE)","loc":"d,15:17,15:20","dtypep":"(L)",
            "rhsp": [
-            {"type":"CRESET","addr":"(VE)","loc":"d,15:17,15:20","dtypep":"(K)"}
+            {"type":"CRESET","addr":"(XE)","loc":"d,15:17,15:20","dtypep":"(L)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(WE)","loc":"d,15:17,15:20","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(YE)","loc":"d,15:17,15:20","dtypep":"(L)","access":"WR","varp":"(FC)","varScopep":"(EC)"}
           ]},
-          {"type":"ASSIGN","addr":"(XE)","loc":"d,16:13,16:14","dtypep":"(WB)",
+          {"type":"ASSIGN","addr":"(ZE)","loc":"d,16:13,16:14","dtypep":"(YB)",
            "rhsp": [
-            {"type":"CRESET","addr":"(YE)","loc":"d,16:13,16:14","dtypep":"(WB)"}
+            {"type":"CRESET","addr":"(AF)","loc":"d,16:13,16:14","dtypep":"(YB)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(ZE)","loc":"d,16:13,16:14","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(BF)","loc":"d,16:13,16:14","dtypep":"(YB)","access":"WR","varp":"(HC)","varScopep":"(GC)"}
           ]},
-          {"type":"ASSIGN","addr":"(AF)","loc":"d,17:12,17:13","dtypep":"(WB)",
+          {"type":"ASSIGN","addr":"(CF)","loc":"d,17:12,17:13","dtypep":"(YB)",
            "rhsp": [
-            {"type":"CONST","name":"32'sh0","addr":"(BF)","loc":"d,17:14,17:15","dtypep":"(WC)"}
+            {"type":"CONST","name":"32'sh0","addr":"(DF)","loc":"d,17:14,17:15","dtypep":"(YC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(CF)","loc":"d,17:10,17:11","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(EF)","loc":"d,17:10,17:11","dtypep":"(YB)","access":"WR","varp":"(HC)","varScopep":"(GC)"}
           ]},
-          {"type":"LOOP","addr":"(DF)","loc":"d,17:5,17:8","unroll":"default",
+          {"type":"LOOP","addr":"(FF)","loc":"d,17:5,17:8","unroll":"default",
            "stmtsp": [
-            {"type":"LOOPTEST","addr":"(EF)","loc":"d,17:17,17:18",
+            {"type":"LOOPTEST","addr":"(GF)","loc":"d,17:17,17:18",
              "condp": [
-              {"type":"GTS","addr":"(FF)","loc":"d,17:19,17:20","dtypep":"(BD)",
+              {"type":"GTS","addr":"(HF)","loc":"d,17:19,17:20","dtypep":"(DD)",
                "lhsp": [
-                {"type":"CONST","name":"32'sh7","addr":"(GF)","loc":"d,17:21,17:22","dtypep":"(WC)"}
+                {"type":"CONST","name":"32'sh7","addr":"(IF)","loc":"d,17:21,17:22","dtypep":"(YC)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(HF)","loc":"d,17:17,17:18","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(JF)","loc":"d,17:17,17:18","dtypep":"(YB)","access":"RD","varp":"(HC)","varScopep":"(GC)"}
               ]}
             ]},
-            {"type":"ASSIGN","addr":"(IF)","loc":"d,18:14,18:15","dtypep":"(FD)",
+            {"type":"ASSIGN","addr":"(KF)","loc":"d,18:14,18:15","dtypep":"(HD)",
              "rhsp": [
-              {"type":"EQ","addr":"(JF)","loc":"d,18:29,18:31","dtypep":"(BD)",
+              {"type":"EQ","addr":"(LF)","loc":"d,18:29,18:31","dtypep":"(DD)",
                "lhsp": [
-                {"type":"CONST","name":"2'h0","addr":"(KF)","loc":"d,18:32,18:37","dtypep":"(ID)"}
+                {"type":"CONST","name":"2'h0","addr":"(MF)","loc":"d,18:32,18:37","dtypep":"(KD)"}
               ],
                "rhsp": [
-                {"type":"SEL","addr":"(LF)","loc":"d,18:20,18:21","dtypep":"(KD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
+                {"type":"SEL","addr":"(NF)","loc":"d,18:20,18:21","dtypep":"(MD)","widthConst":2,"declRange":"[15:0]","declElWidth":1,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(MF)","loc":"d,18:17,18:20","dtypep":"(H)","access":"RD","varp":"(BC)","varScopep":"(AC)"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(OF)","loc":"d,18:17,18:20","dtypep":"(I)","access":"RD","varp":"(DC)","varScopep":"(CC)"}
                 ],
                  "lsbp": [
-                  {"type":"SEL","addr":"(NF)","loc":"d,18:22,18:23","dtypep":"(ND)","widthConst":4,
+                  {"type":"SEL","addr":"(PF)","loc":"d,18:22,18:23","dtypep":"(PD)","widthConst":4,
                    "fromp": [
-                    {"type":"MULS","addr":"(OF)","loc":"d,18:22,18:23","dtypep":"(PD)",
+                    {"type":"MULS","addr":"(QF)","loc":"d,18:22,18:23","dtypep":"(RD)",
                      "lhsp": [
-                      {"type":"CONST","name":"32'sh2","addr":"(PF)","loc":"d,18:23,18:24","dtypep":"(WC)"}
+                      {"type":"CONST","name":"32'sh2","addr":"(RF)","loc":"d,18:23,18:24","dtypep":"(YC)"}
                     ],
                      "rhsp": [
-                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(QF)","loc":"d,18:21,18:22","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)"}
+                      {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(SF)","loc":"d,18:21,18:22","dtypep":"(YB)","access":"RD","varp":"(HC)","varScopep":"(GC)"}
                     ]}
                   ],
                    "lsbp": [
-                    {"type":"CONST","name":"32'h0","addr":"(RF)","loc":"d,18:22,18:23","dtypep":"(TD)"}
+                    {"type":"CONST","name":"32'h0","addr":"(TF)","loc":"d,18:22,18:23","dtypep":"(VD)"}
                   ]}
                 ]}
               ]}
             ],
              "lhsp": [
-              {"type":"SEL","addr":"(SF)","loc":"d,18:10,18:11","dtypep":"(FD)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
+              {"type":"SEL","addr":"(UF)","loc":"d,18:10,18:11","dtypep":"(HD)","widthConst":1,"declRange":"[6:0]","declElWidth":1,
                "fromp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(TF)","loc":"d,18:7,18:10","dtypep":"(K)","access":"WR","varp":"(DC)","varScopep":"(CC)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(VF)","loc":"d,18:7,18:10","dtypep":"(L)","access":"WR","varp":"(FC)","varScopep":"(EC)"}
               ],
                "lsbp": [
-                {"type":"SEL","addr":"(UF)","loc":"d,18:11,18:12","dtypep":"(XD)","widthConst":3,
+                {"type":"SEL","addr":"(WF)","loc":"d,18:11,18:12","dtypep":"(ZD)","widthConst":3,
                  "fromp": [
-                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(VF)","loc":"d,18:11,18:12","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)"}
+                  {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(XF)","loc":"d,18:11,18:12","dtypep":"(YB)","access":"RD","varp":"(HC)","varScopep":"(GC)"}
                 ],
                  "lsbp": [
-                  {"type":"CONST","name":"32'h0","addr":"(WF)","loc":"d,18:11,18:12","dtypep":"(TD)"}
+                  {"type":"CONST","name":"32'h0","addr":"(YF)","loc":"d,18:11,18:12","dtypep":"(VD)"}
                 ]}
               ]}
             ]},
-            {"type":"ASSIGN","addr":"(XF)","loc":"d,17:25,17:27","dtypep":"(WB)",
+            {"type":"ASSIGN","addr":"(ZF)","loc":"d,17:25,17:27","dtypep":"(YB)",
              "rhsp": [
-              {"type":"ADD","addr":"(YF)","loc":"d,17:25,17:27","dtypep":"(CE)",
+              {"type":"ADD","addr":"(AG)","loc":"d,17:25,17:27","dtypep":"(EE)",
                "lhsp": [
-                {"type":"CONST","name":"32'h1","addr":"(ZF)","loc":"d,17:25,17:27","dtypep":"(TD)"}
+                {"type":"CONST","name":"32'h1","addr":"(BG)","loc":"d,17:25,17:27","dtypep":"(VD)"}
               ],
                "rhsp": [
-                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(AG)","loc":"d,17:24,17:25","dtypep":"(WB)","access":"RD","varp":"(FC)","varScopep":"(EC)"}
+                {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(CG)","loc":"d,17:24,17:25","dtypep":"(YB)","access":"RD","varp":"(HC)","varScopep":"(GC)"}
               ]}
             ],
              "lhsp": [
-              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(BG)","loc":"d,17:24,17:25","dtypep":"(WB)","access":"WR","varp":"(FC)","varScopep":"(EC)"}
+              {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(DG)","loc":"d,17:24,17:25","dtypep":"(YB)","access":"WR","varp":"(HC)","varScopep":"(GC)"}
             ]}
           ]},
-          {"type":"ASSIGN","addr":"(CG)","loc":"d,20:5,20:11","dtypep":"(K)",
+          {"type":"ASSIGN","addr":"(EG)","loc":"d,20:5,20:11","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(DG)","loc":"d,20:12,20:15","dtypep":"(K)","access":"RD","varp":"(DC)","varScopep":"(CC)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(FG)","loc":"d,20:12,20:15","dtypep":"(L)","access":"RD","varp":"(FC)","varScopep":"(EC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(EG)","loc":"d,20:5,20:11","dtypep":"(K)","access":"WR","varp":"(ZB)","varScopep":"(YB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(GG)","loc":"d,20:5,20:11","dtypep":"(L)","access":"WR","varp":"(BC)","varScopep":"(AC)"}
           ]},
-          {"type":"ASSIGNW","addr":"(FG)","loc":"d,24:14,24:15","dtypep":"(K)",
+          {"type":"ASSIGNW","addr":"(HG)","loc":"d,24:14,24:15","dtypep":"(L)",
            "rhsp": [
-            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(GG)","loc":"d,24:16,24:19","dtypep":"(K)","access":"RD","varp":"(ZB)","varScopep":"(YB)"}
+            {"type":"VARREF","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(IG)","loc":"d,24:16,24:19","dtypep":"(L)","access":"RD","varp":"(BC)","varScopep":"(AC)"}
           ],
            "lhsp": [
-            {"type":"VARREF","name":"o_b","addr":"(HG)","loc":"d,24:10,24:13","dtypep":"(K)","access":"WR","varp":"(L)","varScopep":"(U)"}
+            {"type":"VARREF","name":"o_b","addr":"(JG)","loc":"d,24:10,24:13","dtypep":"(L)","access":"WR","varp":"(M)","varScopep":"(W)"}
           ]}
         ]}
       ]}
     ]},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(QB)","loc":"d,14:34,14:37","dtypep":"(K)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout","verilogName":"__Vfunc_vlvbound_test.foo__0__Vfuncout","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(SB)","loc":"d,14:57,14:60","dtypep":"(H)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__val","verilogName":"__Vfunc_vlvbound_test.foo__0__val","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(UB)","loc":"d,15:17,15:20","dtypep":"(K)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__ret","verilogName":"__Vfunc_vlvbound_test.foo__0__ret","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(XB)","loc":"d,16:13,16:14","dtypep":"(WB)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__i","verilogName":"__Vfunc_vlvbound_test.foo__0__i","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(ZB)","loc":"d,14:34,14:37","dtypep":"(K)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__Vfuncout","verilogName":"__Vfunc_vlvbound_test.foo__1__Vfuncout","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(BC)","loc":"d,14:57,14:60","dtypep":"(H)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__val","verilogName":"__Vfunc_vlvbound_test.foo__1__val","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(DC)","loc":"d,15:17,15:20","dtypep":"(K)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__ret","verilogName":"__Vfunc_vlvbound_test.foo__1__ret","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
-    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(FC)","loc":"d,16:13,16:14","dtypep":"(WB)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__i","verilogName":"__Vfunc_vlvbound_test.foo__1__i","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer"}
-  ]}
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__Vfuncout","addr":"(SB)","loc":"d,14:34,14:37","dtypep":"(L)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__Vfuncout","verilogName":"__Vfunc_vlvbound_test.foo__0__Vfuncout","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__val","addr":"(UB)","loc":"d,14:57,14:60","dtypep":"(I)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__val","verilogName":"__Vfunc_vlvbound_test.foo__0__val","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__ret","addr":"(WB)","loc":"d,15:17,15:20","dtypep":"(L)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__ret","verilogName":"__Vfunc_vlvbound_test.foo__0__ret","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__0__i","addr":"(ZB)","loc":"d,16:13,16:14","dtypep":"(YB)","origName":"__Vfunc_vlvbound_test__DOT__foo__0__i","verilogName":"__Vfunc_vlvbound_test.foo__0__i","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__Vfuncout","addr":"(BC)","loc":"d,14:34,14:37","dtypep":"(L)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__Vfuncout","verilogName":"__Vfunc_vlvbound_test.foo__1__Vfuncout","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__val","addr":"(DC)","loc":"d,14:57,14:60","dtypep":"(I)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__val","verilogName":"__Vfunc_vlvbound_test.foo__1__val","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__ret","addr":"(FC)","loc":"d,15:17,15:20","dtypep":"(L)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__ret","verilogName":"__Vfunc_vlvbound_test.foo__1__ret","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"logic"},
+    {"type":"VAR","name":"__Vfunc_vlvbound_test.foo__1__i","addr":"(HC)","loc":"d,16:13,16:14","dtypep":"(YB)","origName":"__Vfunc_vlvbound_test__DOT__foo__1__i","verilogName":"__Vfunc_vlvbound_test.foo__1__i","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"BLOCKTEMP","dtypeName":"integer"}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":3,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"bit","addr":"(BD)","loc":"d,17:19,17:20","dtypep":"(BD)","keyword":"bit","generic":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(ID)","loc":"d,18:32,18:37","dtypep":"(ID)","keyword":"bit","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(FD)","loc":"d,18:29,18:31","dtypep":"(FD)","keyword":"logic","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,8:11,8:16","dtypep":"(H)","keyword":"logic","range":"15:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,10:12,10:17","dtypep":"(K)","keyword":"logic","range":"6:0","generic":true},
-    {"type":"BASICDTYPE","name":"integer","addr":"(WB)","loc":"d,16:5,16:12","dtypep":"(WB)","keyword":"integer","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(PD)","loc":"d,17:19,17:20","dtypep":"(PD)","keyword":"logic","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(XD)","loc":"d,18:10,18:11","dtypep":"(XD)","keyword":"logic","range":"2:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(TD)","loc":"d,18:11,18:12","dtypep":"(TD)","keyword":"bit","range":"31:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(KD)","loc":"d,18:20,18:21","dtypep":"(KD)","keyword":"logic","range":"1:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(ND)","loc":"d,18:20,18:21","dtypep":"(ND)","keyword":"logic","range":"3:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(CE)","loc":"d,17:25,17:27","dtypep":"(CE)","keyword":"logic","range":"31:0","generic":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(WC)","loc":"d,17:14,17:15","dtypep":"(WC)","keyword":"bit","range":"31:0","generic":true,"signed":true}
+    {"type":"BASICDTYPE","name":"bit","addr":"(DD)","loc":"d,17:19,17:20","dtypep":"(DD)","keyword":"bit","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(KD)","loc":"d,18:32,18:37","dtypep":"(KD)","keyword":"bit","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(HD)","loc":"d,18:29,18:31","dtypep":"(HD)","keyword":"logic","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(I)","loc":"d,8:11,8:16","dtypep":"(I)","keyword":"logic","range":"15:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(L)","loc":"d,10:12,10:17","dtypep":"(L)","keyword":"logic","range":"6:0","generic":true},
+    {"type":"BASICDTYPE","name":"integer","addr":"(YB)","loc":"d,16:5,16:12","dtypep":"(YB)","keyword":"integer","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(RD)","loc":"d,17:19,17:20","dtypep":"(RD)","keyword":"logic","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(ZD)","loc":"d,18:10,18:11","dtypep":"(ZD)","keyword":"logic","range":"2:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(VD)","loc":"d,18:11,18:12","dtypep":"(VD)","keyword":"bit","range":"31:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(MD)","loc":"d,18:20,18:21","dtypep":"(MD)","keyword":"logic","range":"1:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(PD)","loc":"d,18:20,18:21","dtypep":"(PD)","keyword":"logic","range":"3:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(EE)","loc":"d,17:25,17:27","dtypep":"(EE)","keyword":"logic","range":"31:0","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(YC)","loc":"d,17:14,17:15","dtypep":"(YC)","keyword":"bit","range":"31:0","generic":true,"signed":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(IG)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(KG)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(JG)","loc":"a,0:0,0:0","modp":"(IG)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(LG)","loc":"a,0:0,0:0","modp":"(KG)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_output.out
+++ b/test_regress/t/t_json_only_output.out
@@ -1,20 +1,21 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"m","addr":"(E)","loc":"d,7:8,7:9","origName":"m","verilogName":"m","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"m","addr":"(F)","loc":"d,7:8,7:9","origName":"m","verilogName":"m","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"clk","addr":"(F)","loc":"d,8:11,8:14","dtypep":"(G)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
-  ]}
+    {"type":"VAR","name":"clk","addr":"(G)","loc":"d,8:11,8:14","dtypep":"(H)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(G)","loc":"d,8:11,8:14","dtypep":"(G)","keyword":"logic","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,8:11,8:14","dtypep":"(H)","keyword":"logic","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(H)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(I)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(I)","loc":"a,0:0,0:0","modp":"(H)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(J)","loc":"a,0:0,0:0","modp":"(I)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_primary_io.out
+++ b/test_regress/t/t_json_only_primary_io.out
@@ -1,57 +1,58 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"top","addr":"(E)","loc":"d,7:8,7:11","origName":"top","verilogName":"top","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"top","addr":"(F)","loc":"d,7:8,7:11","origName":"top","verilogName":"top","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"clk","addr":"(F)","loc":"d,13:9,13:12","dtypep":"(G)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"a1","addr":"(H)","loc":"d,14:9,14:11","dtypep":"(G)","origName":"a1","verilogName":"a1","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"a2","addr":"(I)","loc":"d,15:9,15:11","dtypep":"(G)","origName":"a2","verilogName":"a2","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"ready","addr":"(J)","loc":"d,16:10,16:15","dtypep":"(G)","origName":"ready","verilogName":"ready","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"ready_reg","addr":"(K)","loc":"d,18:8,18:17","dtypep":"(G)","origName":"ready_reg","verilogName":"ready_reg","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"CELL","name":"and_cell","addr":"(L)","loc":"d,20:11,20:19","modName":"and2_x1","origName":"and_cell","verilogName":"and_cell","modp":"(M)",
+    {"type":"VAR","name":"clk","addr":"(G)","loc":"d,13:9,13:12","dtypep":"(H)","origName":"clk","verilogName":"clk","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"a1","addr":"(I)","loc":"d,14:9,14:11","dtypep":"(H)","origName":"a1","verilogName":"a1","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"a2","addr":"(J)","loc":"d,15:9,15:11","dtypep":"(H)","origName":"a2","verilogName":"a2","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"ready","addr":"(K)","loc":"d,16:10,16:15","dtypep":"(H)","origName":"ready","verilogName":"ready","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"ready_reg","addr":"(L)","loc":"d,18:8,18:17","dtypep":"(H)","origName":"ready_reg","verilogName":"ready_reg","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"CELL","name":"and_cell","addr":"(M)","loc":"d,20:11,20:19","modName":"and2_x1","origName":"and_cell","verilogName":"and_cell","modp":"(N)",
      "pinsp": [
-      {"type":"PIN","name":"a1","addr":"(N)","loc":"d,21:8,21:10","svDotName":true,"modVarp":"(O)",
+      {"type":"PIN","name":"a1","addr":"(O)","loc":"d,21:8,21:10","svDotName":true,"modVarp":"(P)",
        "exprp": [
-        {"type":"VARREF","name":"a1","addr":"(P)","loc":"d,21:11,21:13","dtypep":"(G)","access":"RD","varp":"(H)"}
+        {"type":"VARREF","name":"a1","addr":"(Q)","loc":"d,21:11,21:13","dtypep":"(H)","access":"RD","varp":"(I)"}
       ]},
-      {"type":"PIN","name":"a2","addr":"(Q)","loc":"d,22:8,22:10","svDotName":true,"modVarp":"(R)",
+      {"type":"PIN","name":"a2","addr":"(R)","loc":"d,22:8,22:10","svDotName":true,"modVarp":"(S)",
        "exprp": [
-        {"type":"VARREF","name":"a2","addr":"(S)","loc":"d,22:11,22:13","dtypep":"(G)","access":"RD","varp":"(I)"}
+        {"type":"VARREF","name":"a2","addr":"(T)","loc":"d,22:11,22:13","dtypep":"(H)","access":"RD","varp":"(J)"}
       ]},
-      {"type":"PIN","name":"zn","addr":"(T)","loc":"d,23:8,23:10","svDotName":true,"modVarp":"(U)",
+      {"type":"PIN","name":"zn","addr":"(U)","loc":"d,23:8,23:10","svDotName":true,"modVarp":"(V)",
        "exprp": [
-        {"type":"VARREF","name":"ready_reg","addr":"(V)","loc":"d,23:11,23:20","dtypep":"(G)","access":"WR","varp":"(K)"}
+        {"type":"VARREF","name":"ready_reg","addr":"(W)","loc":"d,23:11,23:20","dtypep":"(H)","access":"WR","varp":"(L)"}
       ]}
     ]},
-    {"type":"ALWAYS","addr":"(W)","loc":"d,26:16,26:17","keyword":"cont_assign",
+    {"type":"ALWAYS","addr":"(X)","loc":"d,26:16,26:17","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(X)","loc":"d,26:16,26:17","dtypep":"(G)",
+      {"type":"ASSIGNW","addr":"(Y)","loc":"d,26:16,26:17","dtypep":"(H)",
        "rhsp": [
-        {"type":"VARREF","name":"ready_reg","addr":"(Y)","loc":"d,26:18,26:27","dtypep":"(G)","access":"RD","varp":"(K)"}
+        {"type":"VARREF","name":"ready_reg","addr":"(Z)","loc":"d,26:18,26:27","dtypep":"(H)","access":"RD","varp":"(L)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"ready","addr":"(Z)","loc":"d,26:10,26:15","dtypep":"(G)","access":"WR","varp":"(J)"}
+        {"type":"VARREF","name":"ready","addr":"(AB)","loc":"d,26:10,26:15","dtypep":"(H)","access":"WR","varp":"(K)"}
       ]}
     ]}
   ]},
-  {"type":"MODULE","name":"and2_x1","addr":"(M)","loc":"d,29:8,29:15","origName":"and2_x1","verilogName":"and2_x1","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"},
+  {"type":"MODULE","name":"and2_x1","addr":"(N)","loc":"d,29:8,29:15","origName":"and2_x1","verilogName":"and2_x1","level":2,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"a1","addr":"(O)","loc":"d,30:16,30:18","dtypep":"(G)","origName":"a1","verilogName":"a1","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"a2","addr":"(R)","loc":"d,31:16,31:18","dtypep":"(G)","origName":"a2","verilogName":"a2","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"VAR","name":"zn","addr":"(U)","loc":"d,32:17,32:19","dtypep":"(G)","origName":"zn","verilogName":"zn","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"ALWAYS","addr":"(AB)","loc":"d,34:13,34:14","keyword":"cont_assign",
+    {"type":"VAR","name":"a1","addr":"(P)","loc":"d,30:16,30:18","dtypep":"(H)","origName":"a1","verilogName":"a1","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"a2","addr":"(S)","loc":"d,31:16,31:18","dtypep":"(H)","origName":"a2","verilogName":"a2","direction":"INPUT","declDirection":"INPUT","lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"VAR","name":"zn","addr":"(V)","loc":"d,32:17,32:19","dtypep":"(H)","origName":"zn","verilogName":"zn","direction":"OUTPUT","declDirection":"OUTPUT","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"ALWAYS","addr":"(BB)","loc":"d,34:13,34:14","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(BB)","loc":"d,34:13,34:14","dtypep":"(G)",
+      {"type":"ASSIGNW","addr":"(CB)","loc":"d,34:13,34:14","dtypep":"(H)",
        "rhsp": [
-        {"type":"AND","addr":"(CB)","loc":"d,34:19,34:20","dtypep":"(G)",
+        {"type":"AND","addr":"(DB)","loc":"d,34:19,34:20","dtypep":"(H)",
          "lhsp": [
-          {"type":"VARREF","name":"a1","addr":"(DB)","loc":"d,34:16,34:18","dtypep":"(G)","access":"RD","varp":"(O)"}
+          {"type":"VARREF","name":"a1","addr":"(EB)","loc":"d,34:16,34:18","dtypep":"(H)","access":"RD","varp":"(P)"}
         ],
          "rhsp": [
-          {"type":"VARREF","name":"a2","addr":"(EB)","loc":"d,34:21,34:23","dtypep":"(G)","access":"RD","varp":"(R)"}
+          {"type":"VARREF","name":"a2","addr":"(FB)","loc":"d,34:21,34:23","dtypep":"(H)","access":"RD","varp":"(S)"}
         ]}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"zn","addr":"(FB)","loc":"d,34:10,34:12","dtypep":"(G)","access":"WR","varp":"(U)"}
+        {"type":"VARREF","name":"zn","addr":"(GB)","loc":"d,34:10,34:12","dtypep":"(H)","access":"WR","varp":"(V)"}
       ]}
     ]}
   ]}
@@ -59,13 +60,13 @@
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"BASICDTYPE","name":"logic","addr":"(G)","loc":"d,30:16,30:18","dtypep":"(G)","keyword":"logic","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,30:16,30:18","dtypep":"(H)","keyword":"logic","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(GB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(HB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(HB)","loc":"a,0:0,0:0","modp":"(GB)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(IB)","loc":"a,0:0,0:0","modp":"(HB)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_json_only_tag.out
+++ b/test_regress/t/t_json_only_tag.out
@@ -1,103 +1,104 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"m","addr":"(E)","loc":"d,12:8,12:9","origName":"m","verilogName":"m","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"m","addr":"(F)","loc":"d,12:8,12:9","origName":"m","verilogName":"m","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"clk_ip","addr":"(F)","loc":"d,13:11,13:17","dtypep":"(G)","origName":"clk_ip","verilogName":"clk_ip","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"rst_ip","addr":"(H)","loc":"d,14:11,14:17","dtypep":"(G)","origName":"rst_ip","verilogName":"rst_ip","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"foo_op","addr":"(I)","loc":"d,15:12,15:18","dtypep":"(G)","origName":"foo_op","verilogName":"foo_op","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"TYPEDEF","name":"my_struct","addr":"(J)","loc":"d,25:5,25:14","dtypep":"(K)"},
-    {"type":"CELL","name":"itop","addr":"(L)","loc":"d,29:7,29:11","modName":"ifc","origName":"itop","verilogName":"itop","modp":"(M)"},
-    {"type":"VAR","name":"itop","addr":"(N)","loc":"d,29:7,29:11","dtypep":"(O)","origName":"itop__Viftop","verilogName":"itop__Viftop","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"IFACEREF"},
-    {"type":"VAR","name":"this_struct","addr":"(P)","loc":"d,31:13,31:24","dtypep":"(Q)","origName":"this_struct","verilogName":"this_struct","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"VAR"},
-    {"type":"VAR","name":"dotted","addr":"(R)","loc":"d,33:15,33:21","dtypep":"(S)","origName":"dotted","verilogName":"dotted","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
-    {"type":"ALWAYS","addr":"(T)","loc":"d,33:22,33:23","keyword":"cont_assign",
+    {"type":"VAR","name":"clk_ip","addr":"(G)","loc":"d,13:11,13:17","dtypep":"(H)","origName":"clk_ip","verilogName":"clk_ip","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"rst_ip","addr":"(I)","loc":"d,14:11,14:17","dtypep":"(H)","origName":"rst_ip","verilogName":"rst_ip","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"foo_op","addr":"(J)","loc":"d,15:12,15:18","dtypep":"(H)","origName":"foo_op","verilogName":"foo_op","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"TYPEDEF","name":"my_struct","addr":"(K)","loc":"d,25:5,25:14","dtypep":"(L)"},
+    {"type":"CELL","name":"itop","addr":"(M)","loc":"d,29:7,29:11","modName":"ifc","origName":"itop","verilogName":"itop","modp":"(N)"},
+    {"type":"VAR","name":"itop","addr":"(O)","loc":"d,29:7,29:11","dtypep":"(P)","origName":"itop__Viftop","verilogName":"itop__Viftop","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"IFACEREF"},
+    {"type":"VAR","name":"this_struct","addr":"(Q)","loc":"d,31:13,31:24","dtypep":"(R)","origName":"this_struct","verilogName":"this_struct","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"VAR"},
+    {"type":"VAR","name":"dotted","addr":"(S)","loc":"d,33:15,33:21","dtypep":"(T)","origName":"dotted","verilogName":"dotted","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"},
+    {"type":"ALWAYS","addr":"(U)","loc":"d,33:22,33:23","keyword":"cont_assign",
      "stmtsp": [
-      {"type":"ASSIGNW","addr":"(U)","loc":"d,33:22,33:23","dtypep":"(S)",
+      {"type":"ASSIGNW","addr":"(V)","loc":"d,33:22,33:23","dtypep":"(T)",
        "rhsp": [
-        {"type":"VARXREF","name":"value","addr":"(V)","loc":"d,33:29,33:34","dtypep":"(W)","dotted":"itop","access":"RD","varp":"(X)"}
+        {"type":"VARXREF","name":"value","addr":"(W)","loc":"d,33:29,33:34","dtypep":"(X)","dotted":"itop","access":"RD","varp":"(Y)"}
       ],
        "lhsp": [
-        {"type":"VARREF","name":"dotted","addr":"(Y)","loc":"d,33:15,33:21","dtypep":"(S)","access":"WR","varp":"(R)"}
+        {"type":"VARREF","name":"dotted","addr":"(Z)","loc":"d,33:15,33:21","dtypep":"(T)","access":"WR","varp":"(S)"}
       ]}
     ]},
-    {"type":"TASK","name":"f","addr":"(Z)","loc":"d,35:17,35:18","lifetime":"VSTATICI","cname":"f",
+    {"type":"TASK","name":"f","addr":"(AB)","loc":"d,35:17,35:18","lifetime":"VSTATICI","cname":"f",
      "stmtsp": [
-      {"type":"VAR","name":"m","addr":"(AB)","loc":"d,35:32,35:33","dtypep":"(BB)","origName":"m","verilogName":"m","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
-      {"type":"DISPLAY","addr":"(CB)","loc":"d,36:5,36:13","displayType":"display",
+      {"type":"VAR","name":"m","addr":"(BB)","loc":"d,35:32,35:33","dtypep":"(CB)","origName":"m","verilogName":"m","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
+      {"type":"DISPLAY","addr":"(DB)","loc":"d,36:5,36:13","displayType":"display",
        "fmtp": [
-        {"type":"SFORMATF","name":"%s","addr":"(DB)","loc":"d,36:5,36:13","dtypep":"(BB)","hidden":true,
+        {"type":"SFORMATF","name":"%s","addr":"(EB)","loc":"d,36:5,36:13","dtypep":"(CB)","hidden":true,
          "exprsp": [
-          {"type":"SFORMATARG","addr":"(EB)","loc":"d,36:20,36:21","dtypep":"(BB)","formatAttr":"S",
+          {"type":"SFORMATARG","addr":"(FB)","loc":"d,36:20,36:21","dtypep":"(CB)","formatAttr":"S",
            "exprp": [
-            {"type":"VARREF","name":"m","addr":"(FB)","loc":"d,36:20,36:21","dtypep":"(BB)","access":"RD","varp":"(AB)"}
+            {"type":"VARREF","name":"m","addr":"(GB)","loc":"d,36:20,36:21","dtypep":"(CB)","access":"RD","varp":"(BB)"}
           ]}
         ]}
       ]}
     ]},
-    {"type":"INITIAL","addr":"(GB)","loc":"d,39:3,39:10",
+    {"type":"INITIAL","addr":"(HB)","loc":"d,39:3,39:10",
      "stmtsp": [
-      {"type":"BEGIN","addr":"(HB)","loc":"d,39:11,39:16","unnamed":true,
+      {"type":"BEGIN","addr":"(IB)","loc":"d,39:11,39:16","unnamed":true,
        "stmtsp": [
-        {"type":"STMTEXPR","addr":"(IB)","loc":"d,41:5,41:6",
+        {"type":"STMTEXPR","addr":"(JB)","loc":"d,41:5,41:6",
          "exprp": [
-          {"type":"TASKREF","name":"f","addr":"(JB)","loc":"d,41:5,41:6","dtypep":"(KB)","taskp":"(Z)",
+          {"type":"TASKREF","name":"f","addr":"(KB)","loc":"d,41:5,41:6","dtypep":"(LB)","taskp":"(AB)",
            "argsp": [
-            {"type":"ARG","addr":"(LB)","loc":"d,42:9,42:736",
+            {"type":"ARG","addr":"(MB)","loc":"d,42:9,42:736",
              "exprp": [
-              {"type":"CONST","name":"\\\"\\001\\002\\003\\004\\005\\006\\007\\010\\t\\n\\013\\014\\r\\016\\017\\020\\021\\022\\023\\024\\025\\026\\027\\030\\031\\032\\033\\034\\035\\036\\037 !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\177\\200\\201\\202\\203\\204\\205\\206\\207\\210\\211\\212\\213\\214\\215\\216\\217\\220\\221\\222\\223\\224\\225\\226\\227\\230\\231\\232\\233\\234\\235\\236\\237\\240\\241\\242\\243\\244\\245\\246\\247\\250\\251\\252\\253\\254\\255\\256\\257\\260\\261\\262\\263\\264\\265\\266\\267\\270\\271\\272\\273\\274\\275\\276\\277\\300\\301\\302\\303\\304\\305\\306\\307\\310\\311\\312\\313\\314\\315\\316\\317\\320\\321\\322\\323\\324\\325\\326\\327\\330\\331\\332\\333\\334\\335\\336\\337\\340\\341\\342\\343\\344\\345\\346\\347\\350\\351\\352\\353\\354\\355\\356\\357\\360\\361\\362\\363\\364\\365\\366\\367\\370\\371\\372\\373\\374\\375\\376\\377\\\"","addr":"(MB)","loc":"d,42:9,42:736","dtypep":"(BB)"}
+              {"type":"CONST","name":"\\\"\\001\\002\\003\\004\\005\\006\\007\\010\\t\\n\\013\\014\\r\\016\\017\\020\\021\\022\\023\\024\\025\\026\\027\\030\\031\\032\\033\\034\\035\\036\\037 !\\\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\\177\\200\\201\\202\\203\\204\\205\\206\\207\\210\\211\\212\\213\\214\\215\\216\\217\\220\\221\\222\\223\\224\\225\\226\\227\\230\\231\\232\\233\\234\\235\\236\\237\\240\\241\\242\\243\\244\\245\\246\\247\\250\\251\\252\\253\\254\\255\\256\\257\\260\\261\\262\\263\\264\\265\\266\\267\\270\\271\\272\\273\\274\\275\\276\\277\\300\\301\\302\\303\\304\\305\\306\\307\\310\\311\\312\\313\\314\\315\\316\\317\\320\\321\\322\\323\\324\\325\\326\\327\\330\\331\\332\\333\\334\\335\\336\\337\\340\\341\\342\\343\\344\\345\\346\\347\\350\\351\\352\\353\\354\\355\\356\\357\\360\\361\\362\\363\\364\\365\\366\\367\\370\\371\\372\\373\\374\\375\\376\\377\\\"","addr":"(NB)","loc":"d,42:9,42:736","dtypep":"(CB)"}
             ]}
           ]}
         ]}
       ]}
     ]}
   ]},
-  {"type":"IFACE","name":"ifc","addr":"(M)","loc":"d,7:11,7:14","origName":"ifc","verilogName":"ifc","level":2,"depth":2,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"},
+  {"type":"IFACE","name":"ifc","addr":"(N)","loc":"d,7:11,7:14","origName":"ifc","verilogName":"ifc","level":2,"depth":2,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"value","addr":"(X)","loc":"d,8:11,8:16","dtypep":"(W)","origName":"value","verilogName":"value","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"},
-    {"type":"MODPORT","name":"out_modport","addr":"(NB)","loc":"d,9:11,9:22",
+    {"type":"VAR","name":"value","addr":"(Y)","loc":"d,8:11,8:16","dtypep":"(X)","origName":"value","verilogName":"value","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"},
+    {"type":"MODPORT","name":"out_modport","addr":"(OB)","loc":"d,9:11,9:22",
      "varsp": [
-      {"type":"MODPORTVARREF","name":"value","addr":"(OB)","loc":"d,9:30,9:35","direction":"OUTPUT","varp":"(X)"}
+      {"type":"MODPORTVARREF","name":"value","addr":"(PB)","loc":"d,9:30,9:35","direction":"OUTPUT","varp":"(Y)"}
     ]}
   ]}
 ],
  "miscsp": [
-  {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0","voidp":"(KB)",
+  {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0","voidp":"(LB)",
    "typesp": [
-    {"type":"VOIDDTYPE","addr":"(KB)","loc":"d,41:5,41:6","dtypep":"(KB)"},
-    {"type":"BASICDTYPE","name":"integer","addr":"(W)","loc":"d,8:3,8:10","dtypep":"(W)","keyword":"integer","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(G)","loc":"d,13:11,13:17","dtypep":"(G)","keyword":"logic","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(PB)","loc":"d,21:5,21:10","dtypep":"(PB)","keyword":"logic"},
-    {"type":"BASICDTYPE","name":"logic","addr":"(QB)","loc":"d,22:5,22:10","dtypep":"(QB)","keyword":"logic"},
-    {"type":"BASICDTYPE","name":"logic","addr":"(RB)","loc":"d,23:5,23:10","dtypep":"(RB)","keyword":"logic"},
-    {"type":"BASICDTYPE","name":"logic","addr":"(SB)","loc":"d,24:5,24:10","dtypep":"(SB)","keyword":"logic"},
-    {"type":"STRUCTDTYPE","name":"m.my_struct","addr":"(K)","loc":"d,20:11,20:17","dtypep":"(K)","packed":true,"isFourstate":true,
+    {"type":"VOIDDTYPE","addr":"(LB)","loc":"d,41:5,41:6","dtypep":"(LB)"},
+    {"type":"BASICDTYPE","name":"integer","addr":"(X)","loc":"d,8:3,8:10","dtypep":"(X)","keyword":"integer","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(H)","loc":"d,13:11,13:17","dtypep":"(H)","keyword":"logic","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(QB)","loc":"d,21:5,21:10","dtypep":"(QB)","keyword":"logic"},
+    {"type":"BASICDTYPE","name":"logic","addr":"(RB)","loc":"d,22:5,22:10","dtypep":"(RB)","keyword":"logic"},
+    {"type":"BASICDTYPE","name":"logic","addr":"(SB)","loc":"d,23:5,23:10","dtypep":"(SB)","keyword":"logic"},
+    {"type":"BASICDTYPE","name":"logic","addr":"(TB)","loc":"d,24:5,24:10","dtypep":"(TB)","keyword":"logic"},
+    {"type":"STRUCTDTYPE","name":"m.my_struct","addr":"(L)","loc":"d,20:11,20:17","dtypep":"(L)","packed":true,"isFourstate":true,
      "membersp": [
-      {"type":"MEMBERDTYPE","name":"clk","addr":"(TB)","loc":"d,21:11,21:14","dtypep":"(PB)","lsb":"3","name":"clk","tag":"this is clk","refDTypep":"(PB)"},
-      {"type":"MEMBERDTYPE","name":"k","addr":"(UB)","loc":"d,22:11,22:12","dtypep":"(QB)","lsb":"2","name":"k","refDTypep":"(QB)"},
-      {"type":"MEMBERDTYPE","name":"enable","addr":"(VB)","loc":"d,23:11,23:17","dtypep":"(RB)","lsb":"1","name":"enable","tag":"enable","refDTypep":"(RB)"},
-      {"type":"MEMBERDTYPE","name":"data","addr":"(WB)","loc":"d,24:11,24:15","dtypep":"(SB)","name":"data","tag":"data","refDTypep":"(SB)"}
+      {"type":"MEMBERDTYPE","name":"clk","addr":"(UB)","loc":"d,21:11,21:14","dtypep":"(QB)","lsb":"3","name":"clk","tag":"this is clk","refDTypep":"(QB)"},
+      {"type":"MEMBERDTYPE","name":"k","addr":"(VB)","loc":"d,22:11,22:12","dtypep":"(RB)","lsb":"2","name":"k","refDTypep":"(RB)"},
+      {"type":"MEMBERDTYPE","name":"enable","addr":"(WB)","loc":"d,23:11,23:17","dtypep":"(SB)","lsb":"1","name":"enable","tag":"enable","refDTypep":"(SB)"},
+      {"type":"MEMBERDTYPE","name":"data","addr":"(XB)","loc":"d,24:11,24:15","dtypep":"(TB)","name":"data","tag":"data","refDTypep":"(TB)"}
     ]},
-    {"type":"IFACEREFDTYPE","addr":"(O)","loc":"d,29:7,29:11","dtypep":"(O)","cellName":"itop","ifaceName":"ifc","cellp":"(L)"},
-    {"type":"BASICDTYPE","name":"bit","addr":"(XB)","loc":"d,31:25,31:26","dtypep":"(XB)","keyword":"bit","range":"31:0","generic":true},
-    {"type":"REFDTYPE","name":"my_struct","addr":"(YB)","loc":"d,31:3,31:12","dtypep":"(K)","refDTypep":"(K)"},
-    {"type":"UNPACKARRAYDTYPE","addr":"(Q)","loc":"d,31:24,31:25","dtypep":"(Q)","declRange":"[0:1]","refDTypep":"(YB)",
+    {"type":"IFACEREFDTYPE","addr":"(P)","loc":"d,29:7,29:11","dtypep":"(P)","cellName":"itop","ifaceName":"ifc","cellp":"(M)"},
+    {"type":"BASICDTYPE","name":"bit","addr":"(YB)","loc":"d,31:25,31:26","dtypep":"(YB)","keyword":"bit","range":"31:0","generic":true},
+    {"type":"REFDTYPE","name":"my_struct","addr":"(ZB)","loc":"d,31:3,31:12","dtypep":"(L)","refDTypep":"(L)"},
+    {"type":"UNPACKARRAYDTYPE","addr":"(R)","loc":"d,31:24,31:25","dtypep":"(R)","declRange":"[0:1]","refDTypep":"(ZB)",
      "rangep": [
-      {"type":"RANGE","addr":"(ZB)","loc":"d,31:24,31:25","ascending":true,"fromBracket":true,
+      {"type":"RANGE","addr":"(AC)","loc":"d,31:24,31:25","ascending":true,"fromBracket":true,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(AC)","loc":"d,31:25,31:26","dtypep":"(XB)"}
+        {"type":"CONST","name":"32'h0","addr":"(BC)","loc":"d,31:25,31:26","dtypep":"(YB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h1","addr":"(BC)","loc":"d,31:25,31:26","dtypep":"(XB)"}
+        {"type":"CONST","name":"32'h1","addr":"(CC)","loc":"d,31:25,31:26","dtypep":"(YB)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"logic","addr":"(S)","loc":"d,33:8,33:9","dtypep":"(S)","keyword":"logic","range":"31:0","generic":true},
-    {"type":"BASICDTYPE","name":"string","addr":"(BB)","loc":"d,35:25,35:31","dtypep":"(BB)","keyword":"string","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(T)","loc":"d,33:8,33:9","dtypep":"(T)","keyword":"logic","range":"31:0","generic":true},
+    {"type":"BASICDTYPE","name":"string","addr":"(CB)","loc":"d,35:25,35:31","dtypep":"(CB)","keyword":"string","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(CC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(DC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(DC)","loc":"a,0:0,0:0","modp":"(CC)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(EC)","loc":"a,0:0,0:0","modp":"(DC)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_var_port_json_only.out
+++ b/test_regress/t/t_var_port_json_only.out
@@ -1,105 +1,106 @@
-{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)",
+{"type":"NETLIST","name":"$root","addr":"(B)","loc":"a,0:0,0:0","timeunit":"1ps","timeprecision":"1ps","typeTablep":"(C)","constPoolp":"(D)","dollarUnitPkgp":"(E)",
  "modulesp": [
-  {"type":"MODULE","name":"mh2","addr":"(E)","loc":"d,18:8,18:11","origName":"mh2","verilogName":"mh2","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh2","addr":"(F)","loc":"d,18:8,18:11","origName":"mh2","verilogName":"mh2","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_inout_wire_integer","addr":"(F)","loc":"d,18:27,18:47","dtypep":"(G)","origName":"x_inout_wire_integer","verilogName":"x_inout_wire_integer","isPrimaryIO":true,"direction":"INOUT","declDirection":"INOUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
+    {"type":"VAR","name":"x_inout_wire_integer","addr":"(G)","loc":"d,18:27,18:47","dtypep":"(H)","origName":"x_inout_wire_integer","verilogName":"x_inout_wire_integer","isPrimaryIO":true,"direction":"INOUT","declDirection":"INOUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
   ]},
-  {"type":"MODULE","name":"mh5","addr":"(H)","loc":"d,24:8,24:11","origName":"mh5","verilogName":"mh5","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh5","addr":"(I)","loc":"d,24:8,24:11","origName":"mh5","verilogName":"mh5","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_input_wire_logic","addr":"(I)","loc":"d,24:19,24:37","dtypep":"(J)","origName":"x_input_wire_logic","verilogName":"x_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_input_wire_logic","addr":"(J)","loc":"d,24:19,24:37","dtypep":"(K)","origName":"x_input_wire_logic","verilogName":"x_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh6","addr":"(K)","loc":"d,26:8,26:11","origName":"mh6","verilogName":"mh6","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh6","addr":"(L)","loc":"d,26:8,26:11","origName":"mh6","verilogName":"mh6","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_input_var_logic","addr":"(L)","loc":"d,26:23,26:40","dtypep":"(J)","origName":"x_input_var_logic","verilogName":"x_input_var_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"}
+    {"type":"VAR","name":"x_input_var_logic","addr":"(M)","loc":"d,26:23,26:40","dtypep":"(K)","origName":"x_input_var_logic","verilogName":"x_input_var_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh7","addr":"(M)","loc":"d,28:8,28:11","origName":"mh7","verilogName":"mh7","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh7","addr":"(N)","loc":"d,28:8,28:11","origName":"mh7","verilogName":"mh7","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_input_var_integer","addr":"(N)","loc":"d,28:31,28:50","dtypep":"(G)","origName":"x_input_var_integer","verilogName":"x_input_var_integer","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"}
+    {"type":"VAR","name":"x_input_var_integer","addr":"(O)","loc":"d,28:31,28:50","dtypep":"(H)","origName":"x_input_var_integer","verilogName":"x_input_var_integer","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"}
   ]},
-  {"type":"MODULE","name":"mh8","addr":"(O)","loc":"d,30:8,30:11","origName":"mh8","verilogName":"mh8","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh8","addr":"(P)","loc":"d,30:8,30:11","origName":"mh8","verilogName":"mh8","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_wire_logic","addr":"(P)","loc":"d,30:20,30:39","dtypep":"(J)","origName":"x_output_wire_logic","verilogName":"x_output_wire_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_output_wire_logic","addr":"(Q)","loc":"d,30:20,30:39","dtypep":"(K)","origName":"x_output_wire_logic","verilogName":"x_output_wire_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh9","addr":"(Q)","loc":"d,32:8,32:11","origName":"mh9","verilogName":"mh9","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh9","addr":"(R)","loc":"d,32:8,32:11","origName":"mh9","verilogName":"mh9","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_var_logic","addr":"(R)","loc":"d,32:24,32:42","dtypep":"(J)","origName":"x_output_var_logic","verilogName":"x_output_var_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"}
+    {"type":"VAR","name":"x_output_var_logic","addr":"(S)","loc":"d,32:24,32:42","dtypep":"(K)","origName":"x_output_var_logic","verilogName":"x_output_var_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh10","addr":"(S)","loc":"d,34:8,34:12","origName":"mh10","verilogName":"mh10","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh10","addr":"(T)","loc":"d,34:8,34:12","origName":"mh10","verilogName":"mh10","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_wire_logic_signed_p6","addr":"(T)","loc":"d,34:33,34:62","dtypep":"(U)","origName":"x_output_wire_logic_signed_p6","verilogName":"x_output_wire_logic_signed_p6","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_output_wire_logic_signed_p6","addr":"(U)","loc":"d,34:33,34:62","dtypep":"(V)","origName":"x_output_wire_logic_signed_p6","verilogName":"x_output_wire_logic_signed_p6","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh11","addr":"(V)","loc":"d,36:8,36:12","origName":"mh11","verilogName":"mh11","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh11","addr":"(W)","loc":"d,36:8,36:12","origName":"mh11","verilogName":"mh11","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_var_integer","addr":"(W)","loc":"d,36:28,36:48","dtypep":"(G)","origName":"x_output_var_integer","verilogName":"x_output_var_integer","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
+    {"type":"VAR","name":"x_output_var_integer","addr":"(X)","loc":"d,36:28,36:48","dtypep":"(H)","origName":"x_output_var_integer","verilogName":"x_output_var_integer","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
   ]},
-  {"type":"MODULE","name":"mh12","addr":"(X)","loc":"d,38:8,38:12","origName":"mh12","verilogName":"mh12","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh12","addr":"(Y)","loc":"d,38:8,38:12","origName":"mh12","verilogName":"mh12","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_ref_logic_p6","addr":"(Y)","loc":"d,38:23,38:37","dtypep":"(Z)","origName":"x_ref_logic_p6","verilogName":"x_ref_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_ref_logic_p6","addr":"(Z)","loc":"d,38:23,38:37","dtypep":"(AB)","origName":"x_ref_logic_p6","verilogName":"x_ref_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh13","addr":"(AB)","loc":"d,40:8,40:12","origName":"mh13","verilogName":"mh13","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh13","addr":"(BB)","loc":"d,40:8,40:12","origName":"mh13","verilogName":"mh13","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_ref_var_logic_u6","addr":"(BB)","loc":"d,40:17,40:35","dtypep":"(CB)","origName":"x_ref_var_logic_u6","verilogName":"x_ref_var_logic_u6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT"}
+    {"type":"VAR","name":"x_ref_var_logic_u6","addr":"(CB)","loc":"d,40:17,40:35","dtypep":"(DB)","origName":"x_ref_var_logic_u6","verilogName":"x_ref_var_logic_u6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT"}
   ]},
-  {"type":"MODULE","name":"mh17","addr":"(DB)","loc":"d,50:8,50:12","origName":"mh17","verilogName":"mh17","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh17","addr":"(EB)","loc":"d,50:8,50:12","origName":"mh17","verilogName":"mh17","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_input_var_integer","addr":"(EB)","loc":"d,50:31,50:50","dtypep":"(G)","origName":"x_input_var_integer","verilogName":"x_input_var_integer","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"},
-    {"type":"VAR","name":"y_input_wire_logic","addr":"(FB)","loc":"d,50:57,50:75","dtypep":"(J)","origName":"y_input_wire_logic","verilogName":"y_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"}
+    {"type":"VAR","name":"x_input_var_integer","addr":"(FB)","loc":"d,50:31,50:50","dtypep":"(H)","origName":"x_input_var_integer","verilogName":"x_input_var_integer","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"integer"},
+    {"type":"VAR","name":"y_input_wire_logic","addr":"(GB)","loc":"d,50:57,50:75","dtypep":"(K)","origName":"y_input_wire_logic","verilogName":"y_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"WIRE","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh18","addr":"(GB)","loc":"d,52:8,52:12","origName":"mh18","verilogName":"mh18","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh18","addr":"(HB)","loc":"d,52:8,52:12","origName":"mh18","verilogName":"mh18","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_var_logic","addr":"(HB)","loc":"d,52:24,52:42","dtypep":"(J)","origName":"x_output_var_logic","verilogName":"x_output_var_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
-    {"type":"VAR","name":"y_input_wire_logic","addr":"(IB)","loc":"d,52:50,52:68","dtypep":"(J)","origName":"y_input_wire_logic","verilogName":"y_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_output_var_logic","addr":"(IB)","loc":"d,52:24,52:42","dtypep":"(K)","origName":"x_output_var_logic","verilogName":"x_output_var_logic","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"logic"},
+    {"type":"VAR","name":"y_input_wire_logic","addr":"(JB)","loc":"d,52:50,52:68","dtypep":"(K)","origName":"y_input_wire_logic","verilogName":"y_input_wire_logic","isPrimaryIO":true,"direction":"INPUT","declDirection":"INPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh19","addr":"(JB)","loc":"d,54:8,54:12","origName":"mh19","verilogName":"mh19","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh19","addr":"(KB)","loc":"d,54:8,54:12","origName":"mh19","verilogName":"mh19","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_output_wire_logic_signed_p6","addr":"(KB)","loc":"d,54:33,54:62","dtypep":"(U)","origName":"x_output_wire_logic_signed_p6","verilogName":"x_output_wire_logic_signed_p6","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"y_output_var_integer","addr":"(LB)","loc":"d,54:72,54:92","dtypep":"(G)","origName":"y_output_var_integer","verilogName":"y_output_var_integer","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
+    {"type":"VAR","name":"x_output_wire_logic_signed_p6","addr":"(LB)","loc":"d,54:33,54:62","dtypep":"(V)","origName":"x_output_wire_logic_signed_p6","verilogName":"x_output_wire_logic_signed_p6","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"y_output_var_integer","addr":"(MB)","loc":"d,54:72,54:92","dtypep":"(H)","origName":"y_output_var_integer","verilogName":"y_output_var_integer","isPrimaryIO":true,"direction":"OUTPUT","declDirection":"OUTPUT","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"integer"}
   ]},
-  {"type":"MODULE","name":"mh20","addr":"(MB)","loc":"d,56:8,56:12","origName":"mh20","verilogName":"mh20","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh20","addr":"(NB)","loc":"d,56:8,56:12","origName":"mh20","verilogName":"mh20","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"x_ref_var_logic_p6","addr":"(NB)","loc":"d,56:23,56:41","dtypep":"(Z)","origName":"x_ref_var_logic_p6","verilogName":"x_ref_var_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
-    {"type":"VAR","name":"y_ref_var_logic_p6","addr":"(OB)","loc":"d,56:43,56:61","dtypep":"(Z)","origName":"y_ref_var_logic_p6","verilogName":"y_ref_var_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+    {"type":"VAR","name":"x_ref_var_logic_p6","addr":"(OB)","loc":"d,56:23,56:41","dtypep":"(AB)","origName":"x_ref_var_logic_p6","verilogName":"x_ref_var_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"},
+    {"type":"VAR","name":"y_ref_var_logic_p6","addr":"(PB)","loc":"d,56:43,56:61","dtypep":"(AB)","origName":"y_ref_var_logic_p6","verilogName":"y_ref_var_logic_p6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
   ]},
-  {"type":"MODULE","name":"mh21","addr":"(PB)","loc":"d,58:8,58:12","origName":"mh21","verilogName":"mh21","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+  {"type":"MODULE","name":"mh21","addr":"(QB)","loc":"d,58:8,58:12","origName":"mh21","verilogName":"mh21","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"ref_var_logic_u6","addr":"(QB)","loc":"d,58:17,58:33","dtypep":"(RB)","origName":"ref_var_logic_u6","verilogName":"ref_var_logic_u6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT"},
-    {"type":"VAR","name":"y_ref_var_logic","addr":"(SB)","loc":"d,58:41,58:56","dtypep":"(J)","origName":"y_ref_var_logic","verilogName":"y_ref_var_logic","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
-  ]}
+    {"type":"VAR","name":"ref_var_logic_u6","addr":"(RB)","loc":"d,58:17,58:33","dtypep":"(SB)","origName":"ref_var_logic_u6","verilogName":"ref_var_logic_u6","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT"},
+    {"type":"VAR","name":"y_ref_var_logic","addr":"(TB)","loc":"d,58:41,58:56","dtypep":"(K)","origName":"y_ref_var_logic","verilogName":"y_ref_var_logic","isPrimaryIO":true,"direction":"REF","declDirection":"REF","isSigPublic":true,"lifetime":"VSTATICI","varType":"PORT","dtypeName":"logic"}
+  ]},
+  {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps"}
 ],
  "miscsp": [
   {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0",
    "typesp": [
-    {"type":"UNPACKARRAYDTYPE","addr":"(RB)","loc":"d,58:34,58:35","dtypep":"(RB)","declRange":"[5:0]","refDTypep":"(J)",
+    {"type":"UNPACKARRAYDTYPE","addr":"(SB)","loc":"d,58:34,58:35","dtypep":"(SB)","declRange":"[5:0]","refDTypep":"(K)",
      "rangep": [
-      {"type":"RANGE","addr":"(TB)","loc":"d,58:34,58:35",
+      {"type":"RANGE","addr":"(UB)","loc":"d,58:34,58:35",
        "leftp": [
-        {"type":"CONST","name":"32'sh5","addr":"(UB)","loc":"d,58:35,58:36","dtypep":"(VB)"}
+        {"type":"CONST","name":"32'sh5","addr":"(VB)","loc":"d,58:35,58:36","dtypep":"(WB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'sh0","addr":"(WB)","loc":"d,58:37,58:38","dtypep":"(VB)"}
+        {"type":"CONST","name":"32'sh0","addr":"(XB)","loc":"d,58:37,58:38","dtypep":"(WB)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"logic","addr":"(J)","loc":"d,58:41,58:56","dtypep":"(J)","keyword":"logic","generic":true},
-    {"type":"UNPACKARRAYDTYPE","addr":"(CB)","loc":"d,40:36,40:37","dtypep":"(CB)","declRange":"[5:0]","refDTypep":"(J)",
+    {"type":"BASICDTYPE","name":"logic","addr":"(K)","loc":"d,58:41,58:56","dtypep":"(K)","keyword":"logic","generic":true},
+    {"type":"UNPACKARRAYDTYPE","addr":"(DB)","loc":"d,40:36,40:37","dtypep":"(DB)","declRange":"[5:0]","refDTypep":"(K)",
      "rangep": [
-      {"type":"RANGE","addr":"(XB)","loc":"d,40:36,40:37",
+      {"type":"RANGE","addr":"(YB)","loc":"d,40:36,40:37",
        "leftp": [
-        {"type":"CONST","name":"32'sh5","addr":"(YB)","loc":"d,40:37,40:38","dtypep":"(VB)"}
+        {"type":"CONST","name":"32'sh5","addr":"(ZB)","loc":"d,40:37,40:38","dtypep":"(WB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'sh0","addr":"(ZB)","loc":"d,40:39,40:40","dtypep":"(VB)"}
+        {"type":"CONST","name":"32'sh0","addr":"(AC)","loc":"d,40:39,40:40","dtypep":"(WB)"}
       ]}
     ]},
-    {"type":"BASICDTYPE","name":"logic","addr":"(Z)","loc":"d,38:17,38:18","dtypep":"(Z)","keyword":"logic","range":"5:0","generic":true},
-    {"type":"BASICDTYPE","name":"logic","addr":"(U)","loc":"d,34:27,34:28","dtypep":"(U)","keyword":"logic","range":"5:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"integer","addr":"(G)","loc":"d,18:19,18:26","dtypep":"(G)","keyword":"integer","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(VB)","loc":"d,40:37,40:38","dtypep":"(VB)","keyword":"bit","range":"31:0","generic":true,"signed":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(AB)","loc":"d,38:17,38:18","dtypep":"(AB)","keyword":"logic","range":"5:0","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(V)","loc":"d,34:27,34:28","dtypep":"(V)","keyword":"logic","range":"5:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"integer","addr":"(H)","loc":"d,18:19,18:26","dtypep":"(H)","keyword":"integer","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(WB)","loc":"d,40:37,40:38","dtypep":"(WB)","keyword":"bit","range":"31:0","generic":true,"signed":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(AC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(BC)","loc":"a,0:0,0:0","modp":"(AC)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(CC)","loc":"a,0:0,0:0","modp":"(BC)"}
     ]}
   ]}
 ]}


### PR DESCRIPTION
V3LinkLevel::wrapTop/nonWrapTop now runs immediately after elaboration (W3Width), and before V3Coverage::coverage.

To keep things simple, V3Coverage::coverage is now not run for --json-only (coverageJoin was already gated on the same). Also the $unit package is unconditionally created when the netlist is constructed, V3Dead can then eliminate it in later stages if empty, preserving minimal output as before.

Prep for #7001
