### PR TITLE
Optimize away netlist teardown when about to exit

### DIFF
--- a/src/V3Error.cpp
+++ b/src/V3Error.cpp
@@ -266,7 +266,7 @@ void V3ErrorGuarded::v3errorEndGuts(const std::ostringstream& sstr, const string
                     }
                     if (debug()) {
                         execErrorExitCb();
-                        V3Stats::statsFinalAll(v3Global.rootp());
+                        V3Stats::statsStageAll(v3Global.rootp(), "Final");
                         V3Stats::statsReport();
                     }
                     vlAbortOrExit();

--- a/src/V3Stats.cpp
+++ b/src/V3Stats.cpp
@@ -193,5 +193,3 @@ public:
 void V3Stats::statsStageAll(AstNetlist* nodep, const std::string& stage, bool fastOnly) {
     StatsVisitor{nodep, stage, fastOnly};
 }
-
-void V3Stats::statsFinalAll(AstNetlist* nodep) { statsStageAll(nodep, "Final"); }

--- a/src/V3Stats.h
+++ b/src/V3Stats.h
@@ -147,9 +147,8 @@ public:
     }
     /// Called each stage
     static void statsStage(const string& name);
-    /// Called by the top level to collect statistics
+    /// Called by the top level, and error path, to collect statistics
     static void statsStageAll(AstNetlist* nodep, const string& stage, bool fastOnly = false);
-    static void statsFinalAll(AstNetlist* nodep);
     /// Called by the top level to dump the statistics
     static void statsReport();
     /// Called by debug dumps

--- a/src/Verilator.cpp
+++ b/src/Verilator.cpp
@@ -127,7 +127,6 @@ V3Global v3Global;
 static void reportStatsIfEnabled() {
     if (v3Global.opt.stats()) {
         FileLine::stats();
-        V3Stats::statsFinalAll(v3Global.rootp());
         V3Stats::statsReport();
     }
 }
@@ -207,10 +206,7 @@ static void process() {
             V3Hierarchical::createGraph(v3Global.rootp());
             // If a plan is created, further analysis is not necessary.
             // The actual Verilation will be done based on this plan.
-            if (v3Global.hierGraphp()) {
-                reportStatsIfEnabled();
-                return;
-            }
+            if (v3Global.hierGraphp()) return;
         }
 
         // Calculate and check widths, edit tree to TRUNC/EXTRACT any width mismatches
@@ -815,12 +811,6 @@ static bool verilate(const string& argString) {
     // Final writing shouldn't throw warnings, but...
     V3Error::abortIfWarnings();
 
-    // Free memory so compiler has more for --build
-    // No need to do this if skipped (above) as didn't alloc much
-    UINFO(1, "Releasing netlist memory");
-    v3Global.rootp()->deleteContents();
-    V3Os::releaseMemory();
-    if (v3Global.opt.stats()) V3Stats::statsStage("released");
     return true;
 }
 
@@ -844,10 +834,18 @@ static string buildMakeCmd(const string& makefile, const string& target) {
     return cmd.str();
 }
 
+static void releaseNetlistMemory() {
+    UINFO(1, "Releasing netlist memory");
+    v3Global.rootp()->deleteContents();
+    V3Os::releaseMemory();
+    if (v3Global.opt.stats()) V3Stats::statsStage("released");
+}
+
 static void execBuildJob() {
     UASSERT(v3Global.opt.build(), "--build is not specified.");
     UASSERT(v3Global.opt.gmake(), "--build requires GNU Make.");
     UASSERT(!v3Global.opt.makeJson(), "--build cannot use json build.");
+    releaseNetlistMemory();
     const VlOs::DeltaWallTime buildWallTime{true};
     UINFO(1, "Start Build");
 
@@ -864,6 +862,7 @@ static void execBuildJob() {
 
 static void execHierVerilation() {
     UASSERT(v3Global.hierGraphp(), "must be called only when plan exists");
+    releaseNetlistMemory();
     const string makefile = v3Global.opt.prefix() + "_hier.mk ";
     const string target = v3Global.opt.build() ? " hier_build" : " hier_verilation";
     const string cmdStr = buildMakeCmd(makefile, target);

--- a/test_regress/t/t_benchmark_mux4k.py
+++ b/test_regress/t/t_benchmark_mux4k.py
@@ -15,4 +15,7 @@ test.compile(v_flags2=["--stats", test.wno_unopthreads_for_few_cores])
 
 test.execute()
 
+# Check netlist was NOT released on shutdown
+test.file_grep_not(test.stats, r"Stage, Elapsed time \(sec\), \d+_released")
+
 test.passes()

--- a/test_regress/t/t_flag_build.py
+++ b/test_regress/t/t_flag_build.py
@@ -14,7 +14,8 @@ test.top_filename = "t/t_flag_make_cmake.v"
 
 test.compile(  # Don't call cmake nor gmake from driver.py
     verilator_flags2=[
-        '--exe --cc --build -j 2', '../' + test.main_filename, '-MAKEFLAGS -p --trace-vcd', '--stats'
+        '--exe --cc --build -j 2', '../' + test.main_filename, '-MAKEFLAGS -p --trace-vcd',
+        '--stats'
     ])
 
 test.execute()

--- a/test_regress/t/t_flag_build.py
+++ b/test_regress/t/t_flag_build.py
@@ -14,9 +14,12 @@ test.top_filename = "t/t_flag_make_cmake.v"
 
 test.compile(  # Don't call cmake nor gmake from driver.py
     verilator_flags2=[
-        '--exe --cc --build -j 2', '../' + test.main_filename, '-MAKEFLAGS -p --trace-vcd'
+        '--exe --cc --build -j 2', '../' + test.main_filename, '-MAKEFLAGS -p --trace-vcd', '--stats'
     ])
 
 test.execute()
+
+# Check netlist was released before forking the build
+test.file_grep(test.stats, r"Stage, Elapsed time \(sec\), \d+_released")
 
 test.passes()

--- a/test_regress/t/t_hier_block.py
+++ b/test_regress/t/t_hier_block.py
@@ -41,5 +41,7 @@ test.file_grep(test.obj_dir + "/Vsub1/sub1.sv", r'^module\s+(\S+)\s+', "sub1")
 test.file_grep(test.obj_dir + "/Vsub2/sub2.sv", r'^module\s+(\S+)\s+', "sub2")
 test.file_grep(test.stats, r'HierBlock,\s+Hierarchical blocks\s+(\d+)', 14)
 test.file_grep(test.run_log_filename, r'MACRO:(\S+) is defined', "cplusplus")
+# Check netlist was released before forking the sub verilation
+test.file_grep(test.stats, r"Stage, Elapsed time \(sec\), \d+_released")
 
 test.passes()


### PR DESCRIPTION
Freeing the netlist at the end of Verilation takes significant time on
big designs. Only do it if we are going to fork for build/hierarchical
verilation. Otherwise the OS will tear down the process. Leak checks are
fine, V3Global::shutdown() will delete the whole netlist.

Note this also intentionally removes the top level "Final" statistics
stage. It used to run after the teardown, so it only ever measured the
emptied netlist (i.e.: no information). Without the teardown it would
just inflate the runtime for numbers the "WroteAll"/"WroteFast" stages
already report. That leaves V3Stats::statsFinalAll with a single caller
on the error path, so it is folded into that call site and removed.

Similarly, the hierarchical plan path no longer reports statistics on
early return, as main() reports them again once the plan is written.

---

FWIW I went through 5 rounds of "/clear; Review" on this, and it keeps flip-flopping around it's own recommendations, if you implement them, next time it tells you to revert it 🙃 