### PR TITLE
Fix/dfg break cycles stackoverflow

### DIFF
--- a/src/V3DfgBreakCycles.cpp
+++ b/src/V3DfgBreakCycles.cpp
@@ -180,6 +180,13 @@ class TraceDriver final : public DfgVisitor {
     };
 
     // STATE
+    // Maximum recursive trace depth before we short-circuit and create a
+    // temporary slice. The trace logic already accepts creating a Sel to break
+    // the recursion safely when independence is guaranteed.
+    static constexpr size_t MAX_TRACE_DEPTH = 2048;
+    // If a single vertex is extremely wide, slicing it early prevents deep
+    // recursion across its internal structure (packed arrays / concatenations).
+    static constexpr uint32_t LARGE_WIDTH_LIMIT = 4096;
     DfgGraph& m_dfg;  // The graph being processed
     SccInfo& m_sccInfo;  // The SccInfo instance
     // The strongly connected component we are currently trying to escape
@@ -187,6 +194,7 @@ class TraceDriver final : public DfgVisitor {
     uint32_t m_lsb = 0;  // LSB to extract from the currently visited Vertex
     uint32_t m_msb = 0;  // MSB to extract from the currently visited Vertex
     std::vector<uint32_t> m_idxs;  // Indices to extract from the currently visited Vertex
+    size_t m_traceDepth = 0;       // Guard against pathological recursion depth
     // Result of tracing the currently visited Vertex. Use SET_RESULT below!
     DfgVertex* m_resp = nullptr;
     DfgVertex* m_defaultp = nullptr;  // When tracing a variable, this is its 'defaultp', if any
@@ -247,6 +255,55 @@ class TraceDriver final : public DfgVisitor {
         UASSERT_OBJ(vtxp->isPacked(), vtxp, "Can only trace packed type vertices");
         UASSERT_OBJ(vtxp->size() > msb, vtxp, "Traced Vertex too narrow");
 
+        // Some deeply nested packed-array/shift chains can run several thousand
+        // recursive trace steps at a single stack size. Short-circuit the worst
+        // cases by creating a new slice of the original vertex; this preserves the
+        // requested bit selection while keeping the new driver outside the current
+        // SCC and avoids stack exhaustion.
+        // First, short-circuit extremely wide vertices to avoid deep internal
+        // traversal even when trace depth is small. This prevents pathological
+        // cases where a huge packed/concat structure would recurse a lot.
+        if (VL_UNLIKELY(vtxp->width() > LARGE_WIDTH_LIMIT)) {
+            DfgVertex* const basep = vtxp;
+            DfgVertex* respr = basep;
+            if (msb != respr->width() - 1 || lsb != 0) {
+                DfgSel* const selp = make<DfgSel>(basep, msb - lsb + 1);
+                selp->fromp(basep);
+                selp->lsb(lsb);
+                // Wrap the Sel in a temporary variable so the returned driver is
+                // outside the original SCC. This prevents returning a node that
+                // references back into the original component and avoids SCC
+                // inconsistency during replacement.
+                DfgVertexVar* const tmpp = createTmp("TraceDriver", selp);
+                tmpp->srcp(selp);
+                respr = tmpp;
+            }
+            UASSERT_OBJ(respr->width() == (msb - lsb + 1), vtxp, "Wrong result width");
+            return respr;
+        }
+
+        if (VL_UNLIKELY(++m_traceDepth > MAX_TRACE_DEPTH)) {
+            std::cerr << "TRACEDEPTH " << m_traceDepth << " vertex " << vtxp->typeName()
+                      << " width " << vtxp->width() << " range " << msb << ":" << lsb << std::endl;
+            DfgVertex* const basep = vtxp;
+            DfgVertex* respr = basep;
+            if (msb != respr->width() - 1 || lsb != 0) {
+                DfgSel* const selp = make<DfgSel>(basep, msb - lsb + 1);
+                selp->fromp(basep);
+                selp->lsb(lsb);
+                // Wrap the Sel in a temporary variable to ensure the returned
+                // driver is outside the original SCC when we cut recursion by
+                // depth. This mirrors the handling elsewhere when a splice is
+                // returned and prevents SCC inconsistency.
+                DfgVertexVar* const tmpp = createTmp("TraceDriver", selp);
+                tmpp->srcp(selp);
+                respr = tmpp;
+            }
+            --m_traceDepth;
+            UASSERT_OBJ(respr->width() == (msb - lsb + 1), vtxp, "Wrong result width");
+            return respr;
+        }
+
         // Get the cache entry, which is the resulting driver that is not part of
         // the same component as vtxp
         DfgVertex*& respr = m_cache
@@ -292,6 +349,7 @@ class TraceDriver final : public DfgVisitor {
             iterate(vtxp);
             respr = m_resp;
         }
+        --m_traceDepth;
         // We only ever trace drivers of bits that are known to be independent
         // of the cycles, so we should always be able to find an acyclic driver.
         UASSERT_OBJ(respr, vtxp, "Tracing driver failed for " << vtxp->typeName());

--- a/src/V3DfgBreakCycles.cpp
+++ b/src/V3DfgBreakCycles.cpp
@@ -180,13 +180,10 @@ class TraceDriver final : public DfgVisitor {
     };
 
     // STATE
-    // Maximum recursive trace depth before we short-circuit and create a
-    // temporary slice. The trace logic already accepts creating a Sel to break
-    // the recursion safely when independence is guaranteed.
+    // Maximum recursive trace depth. If we exceed this, something is wrong with
+    // the SCC breakdown and the pass should fail loudly instead of creating a
+    // fake acyclic driver that keeps the graph inconsistent.
     static constexpr size_t MAX_TRACE_DEPTH = 2048;
-    // If a single vertex is extremely wide, slicing it early prevents deep
-    // recursion across its internal structure (packed arrays / concatenations).
-    static constexpr uint32_t LARGE_WIDTH_LIMIT = 4096;
     DfgGraph& m_dfg;  // The graph being processed
     SccInfo& m_sccInfo;  // The SccInfo instance
     // The strongly connected component we are currently trying to escape
@@ -255,53 +252,10 @@ class TraceDriver final : public DfgVisitor {
         UASSERT_OBJ(vtxp->isPacked(), vtxp, "Can only trace packed type vertices");
         UASSERT_OBJ(vtxp->size() > msb, vtxp, "Traced Vertex too narrow");
 
-        // Some deeply nested packed-array/shift chains can run several thousand
-        // recursive trace steps at a single stack size. Short-circuit the worst
-        // cases by creating a new slice of the original vertex; this preserves the
-        // requested bit selection while keeping the new driver outside the current
-        // SCC and avoids stack exhaustion.
-        // First, short-circuit extremely wide vertices to avoid deep internal
-        // traversal even when trace depth is small. This prevents pathological
-        // cases where a huge packed/concat structure would recurse a lot.
-        if (VL_UNLIKELY(vtxp->width() > LARGE_WIDTH_LIMIT)) {
-            DfgVertex* const basep = vtxp;
-            DfgVertex* respr = basep;
-            if (msb != respr->width() - 1 || lsb != 0) {
-                DfgSel* const selp = make<DfgSel>(basep, msb - lsb + 1);
-                selp->fromp(basep);
-                selp->lsb(lsb);
-                // Wrap the Sel in a temporary variable so the returned driver is
-                // outside the original SCC. This prevents returning a node that
-                // references back into the original component and avoids SCC
-                // inconsistency during replacement.
-                DfgVertexVar* const tmpp = createTmp("TraceDriver", selp);
-                tmpp->srcp(selp);
-                respr = tmpp;
-            }
-            UASSERT_OBJ(respr->width() == (msb - lsb + 1), vtxp, "Wrong result width");
-            return respr;
-        }
-
         if (VL_UNLIKELY(++m_traceDepth > MAX_TRACE_DEPTH)) {
-            std::cerr << "TRACEDEPTH " << m_traceDepth << " vertex " << vtxp->typeName()
-                      << " width " << vtxp->width() << " range " << msb << ":" << lsb << std::endl;
-            DfgVertex* const basep = vtxp;
-            DfgVertex* respr = basep;
-            if (msb != respr->width() - 1 || lsb != 0) {
-                DfgSel* const selp = make<DfgSel>(basep, msb - lsb + 1);
-                selp->fromp(basep);
-                selp->lsb(lsb);
-                // Wrap the Sel in a temporary variable to ensure the returned
-                // driver is outside the original SCC when we cut recursion by
-                // depth. This mirrors the handling elsewhere when a splice is
-                // returned and prevents SCC inconsistency.
-                DfgVertexVar* const tmpp = createTmp("TraceDriver", selp);
-                tmpp->srcp(selp);
-                respr = tmpp;
-            }
-            --m_traceDepth;
-            UASSERT_OBJ(respr->width() == (msb - lsb + 1), vtxp, "Wrong result width");
-            return respr;
+            vtxp->v3fatalSrc("TraceDriver recursion depth exceeded while tracing "
+                             << vtxp->typeName() << " width " << vtxp->width()
+                             << " range " << msb << ":" << lsb);
         }
 
         // Get the cache entry, which is the resulting driver that is not part of

--- a/test_regress/t/t_dfg_break_cycles_deep.v
+++ b/test_regress/t/t_dfg_break_cycles_deep.v
@@ -1,0 +1,60 @@
+module prim (
+  input logic i,
+  output logic o
+  );
+  assign o = !(!i);
+endmodule
+
+module t (/*AUTOARG*/
+  // Inputs
+  clk
+  );
+  input clk;
+
+  localparam WIDTH = 2;
+  localparam DEPTH = 512;
+
+  logic [WIDTH-1:0] din = '0;
+  logic [WIDTH-1:0][$clog2(DEPTH+1)-1:0] sel = '0;
+  logic [WIDTH-1:0] dout;
+
+  // verilator lint_off UNOPTFLAT
+  logic [WIDTH-1:0][DEPTH:0] arr;
+  // verilator lint_on UNOPTFLAT
+
+  generate
+    for (genvar i = 0; i < WIDTH; ++i) begin : gen_width
+      assign arr[i][0] = din[i];
+      for (genvar j = 0; j < DEPTH; ++j) begin : gen_depth
+        prim u_prim (.i(arr[i][j]), .o(arr[i][j+1]));
+      end
+    end
+  endgenerate
+
+  always_comb begin
+    dout = '0;
+    for (int i = 0; i < WIDTH; ++i) begin
+      if (sel[i] <= DEPTH) dout[i] = arr[i][sel[i]];
+    end
+  end
+
+  int cyc = 0;
+
+  always @(posedge clk) begin
+    cyc <= cyc + 1;
+    din <= WIDTH'(cyc);
+    for (int i = 0; i < WIDTH; ++i) sel[i] <= $clog2(DEPTH+1)'((cyc * 7 + i) % (DEPTH + 1));
+    // The chain is a buffer, so every element equals the driving input bit
+    if (cyc > 1) begin
+      if (dout !== din) begin
+        $write("%%Error: dout=%0x din=%0x\n", dout, din);
+        $stop;
+      end
+    end
+    if (cyc == 20) begin
+      $write("*-* All Finished *-*\n");
+      $finish;
+    end
+  end
+
+endmodule


### PR DESCRIPTION
Thanks for the careful review. I agree with the correctness concerns. The early-return workaround did not actually break the SCC and could hide the cycle at the call site instead of fixing the underlying pass invariant. I also agree that the debug output should not remain in the final patch, and I should have validated the reproducer before requesting review.

I have removed the fake short-circuit logic and the debug print. The remaining guard is now a strict sanity check rather than a semantic workaround. I will validate the reproducer with the project build before any further push or PR.