### PR TITLE
Fix CMake to call Verilator perl wrapper (#8269) (#8270 redo)

### DIFF
--- a/docs/guide/install.rst
+++ b/docs/guide/install.rst
@@ -174,7 +174,7 @@ once, after ``configure``:
    # Install dependencies
    sudo apt install python3-pip
 
-   # Create Python virutal environment in .venv:
+   # Create Python virtual environment in .venv:
    make venv
 
    # Or alternatively, to put it somewhere else:

--- a/verilator-config.cmake.in
+++ b/verilator-config.cmake.in
@@ -21,6 +21,8 @@
 
 cmake_minimum_required(VERSION 3.19)
 
+find_package(Perl REQUIRED)
+
 # Prefer VERILATOR_ROOT from environment
 if(DEFINED ENV{VERILATOR_ROOT})
     set(VERILATOR_ROOT "$ENV{VERILATOR_ROOT}" CACHE PATH "VERILATOR_ROOT")
@@ -30,13 +32,18 @@ set(VERILATOR_ROOT "${CMAKE_CURRENT_LIST_DIR}" CACHE PATH "VERILATOR_ROOT")
 
 find_program(
     VERILATOR_BIN
-    NAMES verilator_bin verilator_bin.exe
+    NAMES verilator
     HINTS ${VERILATOR_ROOT}/bin
     ENV VERILATOR_ROOT
     NO_CMAKE_PATH
     NO_CMAKE_ENVIRONMENT_PATH
     NO_CMAKE_SYSTEM_PATH
 )
+
+# The installed wrapper under bin/verilator is a Perl script. Execute it via
+# Perl explicitly so CMake can launch it reliably on Windows and other hosts
+# where direct execution of the wrapper is not supported.
+set(VERILATOR_BIN_COMMAND "${PERL_EXECUTABLE}" "${VERILATOR_BIN}")
 
 if(NOT VERILATOR_ROOT)
     message(
@@ -46,7 +53,7 @@ if(NOT VERILATOR_ROOT)
 endif()
 
 if(NOT VERILATOR_BIN)
-    message(FATAL_ERROR "Cannot find verilator_bin excecutable.")
+    message(FATAL_ERROR "Cannot find verilator executable.")
 endif()
 
 set(verilator_FOUND 1)
@@ -398,7 +405,7 @@ function(verilate TARGET)
         -E
         env
         "VERILATOR_ROOT=${VERILATOR_ROOT}"
-        "${VERILATOR_BIN}"
+        ${VERILATOR_BIN_COMMAND}
         --compiler
         ${COMPILER}
         --prefix
@@ -860,7 +867,7 @@ endfunction()
 
 function(verilator_generate_key OUTPUT_VARIABLE)
     execute_process(
-        COMMAND ${VERILATOR_BIN} --generate-key
+        COMMAND ${VERILATOR_BIN_COMMAND} --generate-key
         OUTPUT_VARIABLE KEY_VAL
         RESULT_VARIABLE KEY_RET
     )


### PR DESCRIPTION
Fixes #8269 

# Overview
Re-implement the changes in #8270.
That PR was reverted because of a misconfiguration issue by a maintainer. The issue was traced in https://github.com/verilator/verilator/pull/8270#issuecomment-5590172394 to an old ``CMakeCache.txt``, which needed removal to function properly (it mixed an old value for ``VERILATOR_BIN`` with the new perl wrapper call)

This reverts commit c1c19494c4e006e4a4b1e38c687ee5238ae3362d.