### PR TITLE
Fix property and sequence line coverage

### DIFF
--- a/src/V3Coverage.cpp
+++ b/src/V3Coverage.cpp
@@ -1114,6 +1114,16 @@ class CoverageVisitor final : public VNVisitor {
     }
 
     // VISITORS - BOTH
+    void visit(AstProperty* nodep) override {
+        VL_RESTORER(m_state);
+        m_state.m_on = false;
+        iterateChildren(nodep);
+    }
+    void visit(AstSequence* nodep) override {
+        VL_RESTORER(m_state);
+        m_state.m_on = false;
+        iterateChildren(nodep);
+    }
     void visit(AstNode* nodep) override {
         iterateChildren(nodep);
         lineTrack(nodep);

--- a/test_regress/t/t_coverage_prop_seq.out
+++ b/test_regress/t/t_coverage_prop_seq.out
@@ -1,0 +1,13 @@
+TN:verilator_coverage
+SF:t/t_coverage_prop_seq.v
+DA:8,1
+DA:48,5
+DA:50,1
+DA:51,3
+BRDA:51,0,block,1
+BRDA:51,0,block,3
+DA:52,1
+DA:53,1
+BRF:2
+BRH:0
+end_of_record

--- a/test_regress/t/t_coverage_prop_seq.py
+++ b/test_regress/t/t_coverage_prop_seq.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2026 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--binary --coverage'])
+
+test.execute(all_run_flags=[" +verilator+coverage+file+" + test.obj_dir + "/coverage.dat"])
+
+test.run(cmd=[
+    os.environ["VERILATOR_ROOT"] + "/bin/verilator_coverage", "--filter-type line", "--write-info",
+    test.obj_dir + "/line.info", test.obj_dir + "/coverage.dat"
+],
+         verilator_run=True)
+
+test.files_identical(test.obj_dir + "/line.info", test.golden_filename)
+
+test.passes()

--- a/test_regress/t/t_coverage_prop_seq.v
+++ b/test_regress/t/t_coverage_prop_seq.v
@@ -1,0 +1,55 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Antmicro
+// SPDX-License-Identifier: CC0-1.0
+
+module t;
+  logic clk = 1'b0;
+
+  property c_prop;
+    @(negedge clk)
+    1'b1;
+  endproperty : c_prop
+
+  property asrt_prop;
+    @(negedge clk)
+    1'b1;
+  endproperty : asrt_prop
+
+  property assm_prop;
+    @(negedge clk)
+    1'b1;
+  endproperty : assm_prop
+
+  sequence seq;
+    1'b1;
+  endsequence : seq
+
+  property prop_seq;
+    @(negedge clk) seq;
+  endproperty : prop_seq
+
+  property inner_prop;
+    @(negedge clk)
+    1'b1;
+  endproperty : inner_prop
+
+  property outer_prop;
+    inner_prop;
+  endproperty : outer_prop
+
+  cover property (c_prop);
+  assert property (asrt_prop);
+  assume property (assm_prop);
+  cover property (prop_seq);
+  cover property (outer_prop);
+
+  always #1 clk = ~clk;
+
+  initial begin
+    repeat (3) @(posedge clk);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule


### PR DESCRIPTION
Currently the declaration bodies of `property` and `sequence` are instrumented in line coverage as it was a procedural block.

An example causing this issue (**master**):
~~~systemverilog
module t;
  logic clk = 1'b0;

  property prop;
    @(negedge clk)
    (1'b1);
  endproperty : prop

  cover_prop: cover property (prop);

  always #1 clk = ~clk;

  initial begin
    repeat (3) @(posedge clk);
    $finish;
  end
endmodule
~~~
run:
~~~sh
verilator test.v --binary --coverage
obj_dir/Vtest
verilator_coverage --filter-type line --write-info line.info coverage.dat
~~~
`line.info`:
~~~log
TN:verilator_coverage
SF:test.v
DA:2,1
DA:4,0
DA:5,0
DA:6,0
DA:11,5
DA:13,1
DA:14,3
BRDA:14,0,block,1
BRDA:14,0,block,3
DA:15,1
BRF:2
BRH:0
end_of_record
~~~

Lines 4, 5 and 6 are:
~~~systemverilog
property prop;
  @(negedge clk)
  (1'b1);
~~~

The problem occurs because `coverage` stage does not ignore lines inside that declaration and creates `COVERINC` and `COVEROTHERDECL` for them. Then `assertpre` stage removes the declaration body entirely, losing its `COVERINC`, and now only `COVEROTHERDECL` remains, without ever changing.

The solution is to do not cover the declaration bodies of `property` and `sequence`, because they are just templates for future logic, not running code.