### PR TITLE
Inline VerilatedContext::assertCtlGet

### DIFF
--- a/include/verilated.cpp
+++ b/include/verilated.cpp
@@ -3126,15 +3126,6 @@ bool VerilatedContext::assertOnGet(VerilatedAssertType_t type,
                                    VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE {
     return assertCtlGet(VerilatedAssertCtlQuery::ASSERT_CTL_ON, type, directive);
 }
-uint32_t VerilatedContext::assertOnMask(VerilatedAssertType_t types,
-                                        VerilatedAssertDirectiveType_t directives) VL_PURE {
-    // Place the directive bits at each selected assertion type's 3-bit group.
-    uint32_t mask = 0;
-    for (int i = 0; i < std::numeric_limits<VerilatedAssertType_t>::digits; ++i) {
-        if (VL_BITISSET_I(types, i)) mask |= directives << (i * ASSERT_DIRECTIVE_TYPE_MASK_WIDTH);
-    }
-    return mask;
-}
 void VerilatedContext::assertOnSet(VerilatedAssertType_t types,
                                    VerilatedAssertDirectiveType_t directives) VL_MT_SAFE {
     if (assertCtlsLocked()) return;
@@ -3201,26 +3192,6 @@ void VerilatedContext::assertCtl(uint32_t controlType, VerilatedAssertType_t typ
                     + "' (IEEE 1800-2023 Table 20-5)")
                        .c_str());
     }
-}
-uint32_t
-VerilatedContext::assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertType_t type,
-                               VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE {
-    const uint32_t mask = assertOnMask(type, directive);
-    if (!mask) return 0;
-    switch (query) {  // LCOV_EXCL_BR_LINE
-    case VerilatedAssertCtlQuery::ASSERT_CTL_ON: return (m_s.m_assertOn & mask) != 0;
-    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL:
-        assert(mask && (mask & (mask - 1)) == 0);
-        return m_s.m_assertKill[VL_CLOG2_I(mask)];
-    case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_VACUOUS:
-        return (m_s.m_assertPassOnVacuous & mask) != 0;
-    case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_NONVACUOUS:
-        return (m_s.m_assertPassOnNonvacuous & mask) != 0;
-    case VerilatedAssertCtlQuery::ASSERT_CTL_FAIL_ON: return (m_s.m_assertFailOn & mask) != 0;
-    default:  // LCOV_EXCL_START
-        VL_FATAL_MT("", 0, "", "Internal: Bad assertCtlGet query");
-        VL_UNREACHABLE;
-    }  // LCOV_EXCL_STOP
 }
 void VerilatedContext::calcUnusedSigs(bool flag) VL_MT_SAFE {
     const VerilatedLockGuard lock{m_mutex};

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -480,8 +480,8 @@ private:
         = ASSERT_DIRECTIVE_TYPE_MASK_WIDTH * std::numeric_limits<VerilatedAssertType_t>::digits
           + 1;
     // Build the assertion-control bit mask for the given assertion x directive types.
-    static uint32_t assertOnMask(VerilatedAssertType_t types,
-                                 VerilatedAssertDirectiveType_t directives) VL_PURE;
+    static inline uint32_t assertOnMask(VerilatedAssertType_t types,
+                                        VerilatedAssertDirectiveType_t directives) VL_PURE;
     static constexpr size_t ASSERT_CONTROL_SLOT_COUNT = ASSERT_ON_WIDTH - 1;
     // No termination request has stamped m_finishPendingTime yet
     static constexpr uint64_t TIME_UNSET = ~0ULL;
@@ -643,8 +643,8 @@ public:
                    VerilatedAssertDirectiveType_t directives) VL_MT_SAFE;
     /// Get assertion-control runtime state. Boolean queries return 0/1, Kill returns
     /// the generation count.
-    uint32_t assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertType_t type,
-                          VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE;
+    inline uint32_t assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertType_t type,
+                                 VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE;
     /// Return if calculating of unused signals (for traces)
     bool calcUnusedSigs() const VL_MT_SAFE { return m_s.m_calcUnusedSigs; }
     /// Enable calculation of unused signals (for traces)
@@ -1283,22 +1283,25 @@ void VerilatedContext::timeprecision(int value) VL_MT_SAFE {
 }
 
 // Defined here, not in-class: VL_CLOG2_I / VL_FATAL_MT (verilated_funcs.h) are not yet in scope
-inline uint32_t VerilatedContext::assertOnMask(VerilatedAssertType_t types,
-                                               VerilatedAssertDirectiveType_t directives) VL_PURE {
+uint32_t VerilatedContext::assertOnMask(VerilatedAssertType_t types,
+                                        VerilatedAssertDirectiveType_t directives) VL_PURE {
+    // Place the directive bits at each selected assertion type's 3-bit group.
     uint32_t mask = 0;
     for (int i = 0; i < std::numeric_limits<VerilatedAssertType_t>::digits; ++i) {
         if (VL_BITISSET_I(types, i)) mask |= directives << (i * ASSERT_DIRECTIVE_TYPE_MASK_WIDTH);
     }
     return mask;
 }
-inline uint32_t
+uint32_t
 VerilatedContext::assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertType_t type,
                                VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE {
     const uint32_t mask = assertOnMask(type, directive);
     if (!mask) return 0;
     switch (query) {  // LCOV_EXCL_BR_LINE
     case VerilatedAssertCtlQuery::ASSERT_CTL_ON: return (m_s.m_assertOn & mask) != 0;
-    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL: return m_s.m_assertKill[VL_CLOG2_I(mask)];
+    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL:
+        assert(mask && (mask & (mask - 1)) == 0);
+        return m_s.m_assertKill[VL_CLOG2_I(mask)];
     case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_VACUOUS:
         return (m_s.m_assertPassOnVacuous & mask) != 0;
     case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_NONVACUOUS:

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -1282,5 +1282,35 @@ void VerilatedContext::timeprecision(int value) VL_MT_SAFE {
 #endif
 }
 
+// Defined here, not in-class: VL_CLOG2_I / VL_FATAL_MT (verilated_funcs.h) are not yet in scope
+inline uint32_t
+VerilatedContext::assertOnMask(VerilatedAssertType_t types,
+                               VerilatedAssertDirectiveType_t directives) VL_PURE {
+    uint32_t mask = 0;
+    for (int i = 0; i < std::numeric_limits<VerilatedAssertType_t>::digits; ++i) {
+        if (VL_BITISSET_I(types, i)) mask |= directives << (i * ASSERT_DIRECTIVE_TYPE_MASK_WIDTH);
+    }
+    return mask;
+}
+inline uint32_t
+VerilatedContext::assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertType_t type,
+                               VerilatedAssertDirectiveType_t directive) const VL_MT_SAFE {
+    const uint32_t mask = assertOnMask(type, directive);
+    if (!mask) return 0;
+    switch (query) {  // LCOV_EXCL_BR_LINE
+    case VerilatedAssertCtlQuery::ASSERT_CTL_ON: return (m_s.m_assertOn & mask) != 0;
+    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL:
+        return m_s.m_assertKill[VL_CLOG2_I(mask)];
+    case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_VACUOUS:
+        return (m_s.m_assertPassOnVacuous & mask) != 0;
+    case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_NONVACUOUS:
+        return (m_s.m_assertPassOnNonvacuous & mask) != 0;
+    case VerilatedAssertCtlQuery::ASSERT_CTL_FAIL_ON: return (m_s.m_assertFailOn & mask) != 0;
+    default:  // LCOV_EXCL_START
+        VL_FATAL_MT("", 0, "", "Internal: Bad assertCtlGet query");
+        VL_UNREACHABLE;
+    }  // LCOV_EXCL_STOP
+}
+
 #undef VERILATOR_VERILATED_H_INTERNAL_
 #endif  // Guard

--- a/include/verilated.h
+++ b/include/verilated.h
@@ -1283,9 +1283,8 @@ void VerilatedContext::timeprecision(int value) VL_MT_SAFE {
 }
 
 // Defined here, not in-class: VL_CLOG2_I / VL_FATAL_MT (verilated_funcs.h) are not yet in scope
-inline uint32_t
-VerilatedContext::assertOnMask(VerilatedAssertType_t types,
-                               VerilatedAssertDirectiveType_t directives) VL_PURE {
+inline uint32_t VerilatedContext::assertOnMask(VerilatedAssertType_t types,
+                                               VerilatedAssertDirectiveType_t directives) VL_PURE {
     uint32_t mask = 0;
     for (int i = 0; i < std::numeric_limits<VerilatedAssertType_t>::digits; ++i) {
         if (VL_BITISSET_I(types, i)) mask |= directives << (i * ASSERT_DIRECTIVE_TYPE_MASK_WIDTH);
@@ -1299,8 +1298,7 @@ VerilatedContext::assertCtlGet(VerilatedAssertCtlQuery query, VerilatedAssertTyp
     if (!mask) return 0;
     switch (query) {  // LCOV_EXCL_BR_LINE
     case VerilatedAssertCtlQuery::ASSERT_CTL_ON: return (m_s.m_assertOn & mask) != 0;
-    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL:
-        return m_s.m_assertKill[VL_CLOG2_I(mask)];
+    case VerilatedAssertCtlQuery::ASSERT_CTL_KILL: return m_s.m_assertKill[VL_CLOG2_I(mask)];
     case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_VACUOUS:
         return (m_s.m_assertPassOnVacuous & mask) != 0;
     case VerilatedAssertCtlQuery::ASSERT_CTL_PASS_ON_NONVACUOUS:


### PR DESCRIPTION
**Description:**

`assertCtlGet` and `assertOnMask` are defined out-of-line in `verilated.cpp`. Generated models call them with compile-time constant `type`/`directive` arguments, but across a translation-unit boundary nothing can fold: `assertOnMask` runs a 32-iteration loop over
`numeric_limits<VerilatedAssertType_t>::digits` on every query, the `switch` on `query` survives, and the `seq_cst` loads of `m_assertOn` and friends block CSE in the surrounding code. Moving both bodies into `verilated.h` as `inline` lets the mask fold to a constant, the switch collapse to a single masked compare, and the enable check hoist out of the assertion body.

The bodies go at the **end** of the header rather than in the class body: `VL_CLOG2_I` and `VL_FATAL_MT` come from verilated_funcs.h`, which is included after the class definition.

#### Measurement

Measured on a cocotb-driven design (`pcie_top_xilinx`): 241 source files of hand-written SystemVerilog plus SpinalHDL and Vitis HLS output, 887 module instances, ~73.5k variables, ~1.47M lines of generated C++ — and only **494 concurrent assertions**, roughly one per 150 variables. Those 494 assertions produce **4,859 `assertCtlGet` call sites** (nb running with #7707 too).

Single-threaded, `--timing --assert -CFLAGS -O2`:

| | ns/s | wall |
|---|---|---|
| master | 2377 | 631 s |
| + patch | 2691 | 557 s |

About 10% faster. In `perf record`, `assertCtlGet` goes from **7.41%** of samples to absent from the profile. The call-site count is unchanged (4,859 in both arms) — the fix makes the calls inlinable, not fewer.

For scale, `--no-assert` on the same test gives 4158 ns/s, so assertions cost ~35% of runtime here; this recovers roughly a third of that.
