### PR TITLE
Preserve typed pattern formatting primitives

### DIFF
--- a/src/V3Clean.cpp
+++ b/src/V3Clean.cpp
@@ -18,7 +18,8 @@
 // Each module:
 //      For each expression, if it requires a clean operand,
 //      and the operand is dirty, insert a CLEAN node.
-//      Resize operands (but not variables or variable selects) to C++ 32/64/wide types.
+//      Resize operands (but not variables, variable selects, or formatting metadata)
+//      to C++ 32/64/wide types.
 //      Copy all width() values to widthMin() so RANGE, etc can still see orig widths
 //
 //*************************************************************************
@@ -84,6 +85,7 @@ class CleanVisitor final : public VNVisitor {
                 || VN_IS(nodep, ConsPackMember)  //
                 || VN_IS(nodep, NodeDType)  // Don't want to change variable widths!
                 || VN_IS(nodep, NodeSel)  // Array selects should reflect variable widths
+                || VN_IS(nodep, SFormatArg)  // Retain the logical argument type, not storage width
                 || VN_IS(nodep->dtypep()->skipRefp(), AssocArrayDType)  // Or arrays
                 || VN_IS(nodep->dtypep()->skipRefp(), WildcardArrayDType)
                 || VN_IS(nodep->dtypep()->skipRefp(), DynArrayDType)

--- a/src/V3Simulate.h
+++ b/src/V3Simulate.h
@@ -427,7 +427,7 @@ private:
         if (const AstInitArray* const avaluep = VN_CAST(valuep, InitArray)) {
             string result = "'{";
             string comma;
-            if (VN_IS(nodep->dtypep(), AssocArrayDType)) {
+            if (VN_IS(nodep->dtypep()->skipRefp(), AssocArrayDType)) {
                 if (avaluep->defaultp()) {
                     result += comma + "default:" + toStringRecurse(avaluep->defaultp());
                     comma = ", ";
@@ -439,7 +439,7 @@ private:
                     comma = ", ";
                 }
             } else if (const AstUnpackArrayDType* const dtypep
-                       = VN_CAST(nodep->dtypep(), UnpackArrayDType)) {
+                       = VN_CAST(nodep->dtypep()->skipRefp(), UnpackArrayDType)) {
                 for (int n = 0; n < dtypep->elementsConst(); ++n) {
                     result += comma + toStringRecurse(avaluep->getIndexDefaultedValuep(n));
                     comma = ", ";

--- a/test_regress/t/t_display_pattern_format.v
+++ b/test_regress/t/t_display_pattern_format.v
@@ -14,9 +14,26 @@ module t;
   always #5 clk = ~clk;
   int cyc = 0;
   typedef string text_t;
+  typedef bit [6:0] narrow_array_t[2];
+  typedef bit [64:0] wide_array_t[2];
+  typedef enum logic [6:0] {
+    FIRST = 7'd3,
+    SECOND = 7'd65
+  } enum_t;
+  typedef enum_t enum_alias_t;
 
   localparam text_t TEXT_PARAM = "quote=\" slash=\\ bell=\a form=\f vert=\v ctrl=\001";
   localparam string ESCAPED_PARAM_STRING = $sformatf("%p", TEXT_PARAM);
+  localparam narrow_array_t NARROW_FIRST = '{7'd3, 7'd127};
+  localparam narrow_array_t NARROW_SECOND = '{7'd65, 7'd9};
+  localparam wide_array_t WIDE_FIRST = '{65'h10000000000000001, 65'h100000000};
+  localparam wide_array_t WIDE_SECOND = '{65'h1ffffffffffffffff, 65'h200000003};
+  localparam string NARROW_FIRST_TEXT = $sformatf("%p", NARROW_FIRST);
+  localparam string NARROW_SECOND_TEXT = $sformatf("%p", NARROW_SECOND);
+  localparam string WIDE_FIRST_TEXT = $sformatf("%p", WIDE_FIRST);
+  localparam string WIDE_SECOND_TEXT = $sformatf("%p", WIDE_SECOND);
+  localparam string REAL_FIRST_TEXT = $sformatf("%p", 1.25);
+  localparam string REAL_SECOND_TEXT = $sformatf("%p", 0.5);
 
   initial begin
 `ifdef QUESTA
@@ -33,6 +50,14 @@ module t;
     string escaped;
     string escaped_expected;
     string fmt;
+    enum_alias_t enum_value;
+    narrow_array_t narrow;
+    wide_array_t wide;
+    real real_value;
+    string array_expected;
+    string real_expected;
+    string formatted;
+    string enum_text;
 
     plain = $sformatf("round %0d", cyc);
     escaped = {"quote=\" slash=\\ line=\n cr=\r tab=\t bell=\a form=\f vert=\v ctrl=\001 ", plain};
@@ -42,13 +67,50 @@ module t;
     escaped_expected = {"\"quote=\\\" slash=\\\\ line=\\n cr=\\r tab=\\t bell=\\007 ",
                         "form=\\014 vert=\\013 ctrl=\\001 ", plain, "\""};
 `endif
-    `checks($sformatf("%p", plain), {"\"", plain, "\""});
-    `checks($sformatf("%p", escaped), escaped_expected);
-    `checks($sformatf("%s", escaped), escaped);
+    formatted = $sformatf("%p", plain);
+    `checks(formatted, {"\"", plain, "\""});
+    formatted = $sformatf("%p", escaped);
+    `checks(formatted, escaped_expected);
+    formatted = $sformatf("%s", escaped);
+    `checks(formatted, escaped);
     fmt = cyc[0] ? "%p" : "%P";
-    `checks($sformatf(fmt, escaped), escaped_expected);
+    formatted = $sformatf(fmt, escaped);
+    `checks(formatted, escaped_expected);
     plain = "";
-    `checks($sformatf("%p", plain), "\"\"");
+    formatted = $sformatf("%p", plain);
+    `checks(formatted, "\"\"");
+
+    narrow = cyc[0] ? NARROW_SECOND : NARROW_FIRST;
+    wide = cyc[0] ? WIDE_SECOND : WIDE_FIRST;
+
+    // Pattern layout may vary by simulator; constant and runtime forms must agree.
+    array_expected = cyc[0] ? NARROW_SECOND_TEXT : NARROW_FIRST_TEXT;
+    formatted = $sformatf("%p", narrow);
+    `checks(formatted, array_expected);
+    formatted = $sformatf(fmt, narrow);
+    `checks(formatted, array_expected);
+    array_expected = cyc[0] ? WIDE_SECOND_TEXT : WIDE_FIRST_TEXT;
+    formatted = $sformatf("%p", wide);
+    `checks(formatted, array_expected);
+    formatted = $sformatf(fmt, wide);
+    `checks(formatted, array_expected);
+
+    enum_value = cyc[0] ? SECOND : FIRST;
+
+    // Identical enum conversions must compare correctly when merging the branches.
+    if (cyc[0]) enum_text = $sformatf(fmt, enum_value);
+    else enum_text = $sformatf(fmt, enum_value);
+
+    `checks(enum_text, cyc[0] ? "SECOND" : "FIRST");
+    formatted = $sformatf("%p", enum_value);
+    `checks(formatted, enum_text);
+    formatted = $sformatf("%s", enum_value);
+    `checks(formatted, enum_text);
+
+    real_value = cyc[0] ? 0.5 : 1.25;
+    real_expected = cyc[0] ? REAL_SECOND_TEXT : REAL_FIRST_TEXT;
+    formatted = $sformatf(fmt, real_value);
+    `checks(formatted, real_expected);
 
     cyc <= cyc + 1;
     if (cyc == 3) begin


### PR DESCRIPTION
Preserve original type metadata for %p formatting across optimization.
Fix constant formatting of typedef-based arrays to match runtime output

Tested on Questa

Part 2 of #8296.