### PR TITLE
Add `-fno-dead-members` and optimize dead class member functions.

### DIFF
--- a/Changes
+++ b/Changes
@@ -17,6 +17,7 @@ Verilator 5.053 devel
 
 * Add covergroup runtime registry (#8134). [Matthew Ballance]
 * Add initial support for solo `binsof` (#8298). [Marco Bartoli]
+* Add `-fno-dead-members` and optimize dead class member functions.
 * Change JSON dumps to suppress empty strings, etc.
 * Support VPI interface references (#8081). [Todd Strader]
 * Support nested array and associative array element member access in constraint 1/4 - pre-cleanup (#8237). [Kamil Danecki, Antmicro Ltd.]

--- a/Changes
+++ b/Changes
@@ -17,7 +17,7 @@ Verilator 5.053 devel
 
 * Add covergroup runtime registry (#8134). [Matthew Ballance]
 * Add initial support for solo `binsof` (#8298). [Marco Bartoli]
-* Add `-fno-dead-members` and optimize dead class member functions.
+* Add `-fno-dead-members` and optimize dead class member functions (#8830).
 * Change JSON dumps to suppress empty strings, etc.
 * Support VPI interface references (#8081). [Todd Strader]
 * Support nested array and associative array element member access in constraint 1/4 - pre-cleanup (#8237). [Kamil Danecki, Antmicro Ltd.]

--- a/docs/guide/exe_verilator.rst
+++ b/docs/guide/exe_verilator.rst
@@ -706,6 +706,8 @@ Summary:
 
 .. option:: -fno-dead-cells
 
+.. option:: -fno-dead-methods
+
 .. option:: -fno-dedup
 
 .. option:: -fno-dfg

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -113,6 +113,7 @@ class AstNodeFTask VL_NOT_FINAL : public AstNode {
     bool m_isHideLocal : 1;  // Verilog local
     bool m_isHideProtected : 1;  // Verilog protected
     bool m_dpiPure : 1;  // DPI import pure (vs. virtual pure)
+    bool m_keepAlive : 1;  // Disable dead function elimination
     bool m_pureVirtual : 1;  // Pure virtual
     bool m_recursive : 1;  // Recursive or part of recursion
     bool m_static : 1;  // Static method in class
@@ -145,6 +146,7 @@ protected:
         , m_isHideLocal{false}
         , m_isHideProtected{false}
         , m_dpiPure{false}
+        , m_keepAlive{false}
         , m_pureVirtual{false}
         , m_recursive{false}
         , m_static{false}
@@ -212,6 +214,8 @@ public:
     void isHideProtected(bool flag) { m_isHideProtected = flag; }
     bool dpiPure() const { return m_dpiPure; }
     void dpiPure(bool flag) { m_dpiPure = flag; }
+    bool keepAlive() const { return m_keepAlive; }
+    void keepAlive(bool flag) { m_keepAlive = flag; }
     bool pureVirtual() const { return m_pureVirtual; }
     void pureVirtual(bool flag) { m_pureVirtual = flag; }
     bool recursive() const { return m_recursive; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2601,6 +2601,7 @@ void AstNodeFTask::dump(std::ostream& str) const {
     if (isExternDef()) str << " [EXTDEF]";
     if (isExternProto()) str << " [EXTPROTO]";
     if (isVirtual()) str << " [VIRT]";
+    if (keepAlive()) str << " [KALIVE]";
     if (prototype()) str << " [PROTOTYPE]";
     if (pureVirtual()) str << " [PUREVIRTUAL]";
     if (recursive()) str << " [RECURSIVE]";
@@ -2623,6 +2624,7 @@ void AstNodeFTask::dumpJson(std::ostream& str) const {
     dumpJsonBoolFuncIf(str, isExternDef);
     dumpJsonBoolFuncIf(str, isExternProto);
     dumpJsonBoolFuncIf(str, isVirtual);
+    dumpJsonBoolFuncIf(str, keepAlive);
     dumpJsonBoolFuncIf(str, needProcess);
     dumpJsonBoolFuncIf(str, prototype);
     dumpJsonBoolFuncIf(str, recursive);

--- a/src/V3Dead.cpp
+++ b/src/V3Dead.cpp
@@ -52,22 +52,28 @@ class DeadVertex final : public V3GraphVertex {
     VL_RTTI_IMPL(DeadVertex, V3GraphVertex)
     AstNode* const m_nodep;  // Node that created vertex
     uint64_t m_workPos = 0;  // Position on DeadWorkList, 0 = not on list
-    bool m_removable;  // Subject to dead removal
+    bool m_removable = false;  // Subject to dead removal
+    bool m_isVirtual = false;  // Virtual node, indirection
 
 public:
-    DeadVertex(V3Graph* graphp, AstNode* nodep, bool removable)
+    DeadVertex(V3Graph* graphp, AstNode* nodep)
         : V3GraphVertex{graphp}
-        , m_nodep{nodep}
-        , m_removable{removable} {}
+        , m_nodep{nodep} {}
     ~DeadVertex() override = default;
-    string dotShape() const override { return removable() ? "rectangle" : "ellipse"; }
+    string dotShape() const override {
+        return isVirtual() ? "diamond" : removable() ? "rectangle" : "ellipse";
+    }
     AstNode* nodep() const VL_MT_STABLE { return m_nodep; }
     string name() const override VL_MT_STABLE {
-        return (removable() ? "[R] "s : "") + nodep()->typeName() + ' ' + cvtToHex(nodep()) + ' '
-               + nodep()->name();
+        return (isVirtual()   ? "[VIRT] "
+                : removable() ? "[R] "s
+                              : "[NR] ")
+               + nodep()->typeName() + ' ' + cvtToHex(nodep()) + ' ' + nodep()->name();
     }
     bool removable() const { return m_removable; }
     void removable(bool flag) { m_removable = flag; }
+    bool isVirtual() const { return m_isVirtual; }
+    void isVirtual(bool flag) { m_isVirtual = flag; }
     uint64_t workPos() const { return m_workPos; }
     void workPos(uint64_t value) { m_workPos = value; }
 };
@@ -117,7 +123,13 @@ class DeadGraph final : public V3Graph {
     //  See const VNUser2InUse m_inuser2; inside DeadVisitor
     // MEMBERS
     DeadWorkList m_funcs;  // Functions eligble for deletion
+    // Each virtual vertex by the ftask name()
+    std::unordered_map<std::string, DeadVertex*> m_virtualVtxsp;
 
+    void newEdge(DeadVertex* fromp, DeadVertex* top) {
+        new V3GraphEdge{this, fromp, top, 1, false};
+        if (top->removable()) m_funcs.erase(top);  // Now has an input edge
+    }
     void pushWorkMaybe(DeadVertex* vtxp, bool allowSize1) {
         if (vtxp->removable()) {
             if (VN_IS(vtxp->nodep(), NodeFTask)
@@ -130,18 +142,32 @@ public:
     // METHODS
     DeadGraph() = default;
     ~DeadGraph() override = default;
-    DeadVertex* findNewVertex(AstNode* nodep, bool removable) {
+    DeadVertex* findNewVertex(AstNode* nodep) {
         DeadVertex* vtxp = nodep->user2u().to<DeadVertex*>();
         if (!vtxp) {
-            vtxp = new DeadVertex{this, nodep, removable};
+            vtxp = new DeadVertex{this, nodep};
             nodep->user2p(vtxp);
             pushWorkMaybe(vtxp, false);
         }
         UASSERT_OBJ(vtxp->nodep() == nodep, nodep, "Vertex points at different node");
         return vtxp;
     }
+    DeadVertex* findVirtualVertex(AstNode* nodep) {
+        const auto it = m_virtualVtxsp.find(nodep->name());
+        DeadVertex* vtxp;
+        if (it != m_virtualVtxsp.end()) {
+            vtxp = it->second;
+        } else {
+            vtxp = new DeadVertex{this, nodep};
+            vtxp->removable(true);
+            vtxp->isVirtual(true);
+            pushWorkMaybe(vtxp, false);
+            m_virtualVtxsp.emplace(nodep->name(), vtxp);
+        }
+        return vtxp;
+    }
     void findNewRemovableVertex(AstNode* nodep, bool removable) {
-        DeadVertex* const vtxp = findNewVertex(nodep, removable);
+        DeadVertex* const vtxp = findNewVertex(nodep);
         // Wasn't removable before (due to earlier insert), make removable now
         if (removable && !vtxp->removable()) {
             vtxp->removable(true);
@@ -149,35 +175,65 @@ public:
         }
     }
     void deleteNodeVertex(AstNode* nodep) {
-        if (DeadVertex* const vtxp = nodep->user2u().to<DeadVertex*>()) {
-            UINFO(9, "Delete vertex due to node deletion " << vtxp->name());
-            // Mark all about-to-empty downstream vertices onto worklist
-            for (const V3GraphEdge& oedge : vtxp->outEdges()) {
-                DeadVertex* const toVtxp = static_cast<DeadVertex*>(oedge.top());
-                pushWorkMaybe(toVtxp, true);
-            }
-            nodep->user2p(nullptr);  // Shouldn't be checked later as deleting, but in case
-            if (vtxp->removable()) m_funcs.erase(vtxp);
-            VL_DO_DANGLING(vtxp->unlinkDelete(this), vtxp);
+        if (DeadVertex* const vtxp = nodep->user2u().to<DeadVertex*>()) deleteVertex(vtxp);
+    }
+    void deleteVertex(DeadVertex* vtxp) {
+        UINFO(9, "Delete vertex " << vtxp->name());
+        // Mark all about-to-empty downstream vertices onto worklist
+        for (const V3GraphEdge& oedge : vtxp->outEdges()) {
+            DeadVertex* const toVtxp = static_cast<DeadVertex*>(oedge.top());
+            pushWorkMaybe(toVtxp, true);  // size1 ok as about to delete below
         }
+        // Node shouldn't be looking at user2p later as node being deleting, but in case
+        if (!vtxp->isVirtual()) vtxp->nodep()->user2p(nullptr);
+        if (vtxp->removable()) m_funcs.erase(vtxp);
+        VL_DO_DANGLING(vtxp->unlinkDelete(this), vtxp);
     }
     // This only tracks usage dependancy, not "containership",
     // When all needs disappear the related node is eligble for deletion
     void needs(AstNode* nodep, AstNode* parentp) {
         if (parentp == nodep) return;  // No need for tracking needs itself (recursion)
         UINFO(9, "Edge node " << nodep << " -> " << parentp);
-        DeadVertex* const parentVtxp = findNewVertex(parentp, false);
-        DeadVertex* const nodeVtxp = findNewVertex(nodep, false);
+        DeadVertex* const parentVtxp = findNewVertex(parentp);
+        DeadVertex* const nodeVtxp = findNewVertex(nodep);
         UINFO(9, "Edge need " << parentVtxp << " -> " << nodeVtxp);
-        new V3GraphEdge{this, parentVtxp, nodeVtxp, 1, false};
-        if (nodeVtxp->removable()) m_funcs.erase(nodeVtxp);  // Now has an input edge
+        newEdge(parentVtxp, nodeVtxp);
+    }
+    void needsVirtual(AstNodeFTask* nodep, AstNode* parentp) {
+        // Virtual call can be to any function in the call hierarchy.
+        // For simplicity rather than tracking possible multiple base
+        // classes (due to 'implements' classes there can be more than
+        // one), we simply assume all virtual functions of the same name
+        // can call any other virtual function of the same name
+        // Track via an intermediate node.
+        //  All calling parents' verticies -> Virtual Vertex -> all ftasks verticies
+        if (parentp == nodep) return;  // No need for tracking needs itself (recursion)
+        DeadVertex* const parentVtxp = findNewVertex(parentp);
+        DeadVertex* const virtualVtxp = findVirtualVertex(nodep);
+        UINFO(9, "Edge needVirtual " << parentVtxp << " -> " << virtualVtxp);
+        newEdge(parentVtxp, virtualVtxp);
+    }
+    void funcVirtual(AstNodeFTask* nodep) {
+        //  Virtual Vertex -> all ftasks verticies
+        DeadVertex* const virtualVtxp = findVirtualVertex(nodep);
+        DeadVertex* const nodeVtxp = findNewVertex(nodep);
+        UINFO(9, "Edge funcvirtual " << virtualVtxp << " -> " << nodeVtxp);
+        newEdge(virtualVtxp, nodeVtxp);
     }
     bool funcsEmpty() const { return m_funcs.empty(); }
     AstNode* funcsGetPopFront() {
-        DeadVertex* const nodeVtxp = m_funcs.getPopFront();
-        AstNode* const nodep = nodeVtxp->nodep();
-        UASSERT_OBJ(nodeVtxp->inEmpty(), nodep, "Non-empty node on work list");
-        UASSERT_OBJ(nodeVtxp->removable(), nodep, "Non-removable node on work list");
+        DeadVertex* const vtxp = m_funcs.getPopFront();
+        UASSERT_OBJ(vtxp->inEmpty(), vtxp->nodep(), "Non-empty node on work list");
+        UASSERT_OBJ(vtxp->removable(), vtxp->nodep(), "Non-removable node on work list");
+        if (vtxp->isVirtual()) {
+            // Emptied (no inbound edge) virtual wrapper; all
+            // destinations verticies are now unused too (e.g. all virtual
+            // functions of this name may be deleted)
+            UINFO(9, "Removing virtual " << vtxp);
+            deleteVertex(vtxp);
+            return nullptr;  // Caller will search again
+        }
+        AstNode* const nodep = vtxp->nodep();
         return nodep;
     }
 };
@@ -225,7 +281,10 @@ class DeadVisitor final : public VNVisitor {
     AstNode* m_containingFTaskRefp = nullptr;  // Parent of ftaskref (e.g. task/module)
 
     // STATE - Statistic tracking
-    VDouble0 m_statFTasksDeadified;
+    VDouble0 m_statFTasksDemoted;
+    VDouble0 m_statFTasksMDeadified;
+    VDouble0 m_statFTasksNMDeadified;
+    VDouble0 m_statFTasksVirtDeadified;
 
     // METHODS
 
@@ -259,6 +318,14 @@ class DeadVisitor final : public VNVisitor {
         if (VN_IS(m_modp, Package) || VN_IS(m_modp, Class)) m_dtypePkgsp.emplace(nodep, m_modp);
         if (AstNode* const subnodep = nodep->virtRefDTypep()) subnodep->user1Inc();
         if (AstNode* const subnodep = nodep->virtRefDType2p()) subnodep->user1Inc();
+    }
+    void needsTask(AstNodeFTask* taskp, AstNode* containerp) {
+        if (!taskp) return;  // Unlinked
+        if (taskp->isVirtual()) {
+            m_graph.needsVirtual(taskp, containerp);
+        } else {
+            m_graph.needs(taskp, containerp);
+        }
     }
 
     // VISITORS
@@ -319,7 +386,7 @@ class DeadVisitor final : public VNVisitor {
         iterateChildren(nodep);
         if (!m_sideEffect && !nodep->isPure()) m_sideEffect = true;
         checkAll(nodep);
-        if (nodep->taskp()) m_graph.needs(nodep->taskp(), m_containingFTaskRefp);
+        needsTask(nodep->taskp(), m_containingFTaskRefp);
         if (nodep->classOrPackagep()) {
             if (m_elimCells) {
                 nodep->classOrPackagep(nullptr);
@@ -331,7 +398,7 @@ class DeadVisitor final : public VNVisitor {
     void visit(AstModportFTaskRef* nodep) override {
         iterateChildren(nodep);
         checkAll(nodep);
-        if (nodep->ftaskp()) m_graph.needs(nodep->ftaskp(), m_containingFTaskRefp);
+        needsTask(nodep->ftaskp(), m_containingFTaskRefp);
     }
     void visit(AstRefDType* nodep) override {
         iterateChildren(nodep);
@@ -472,13 +539,15 @@ class DeadVisitor final : public VNVisitor {
     }
     void visit(AstNodeFTask* nodep) override {
         const bool removable = !(nodep->taskPublic() || nodep->dpiExport() || nodep->dpiImport()
-                                 || nodep->classMethod());
+                                 || nodep->keepAlive() || nodep->isConstructor()
+                                 || (!v3Global.opt.fDeadMethods() && nodep->classMethod()));
         m_graph.findNewRemovableVertex(nodep, removable);
         //
         VL_RESTORER(m_containingFTaskRefp);
         m_containingFTaskRefp = nodep;
         iterateChildren(nodep);
         checkAll(nodep);
+        if (nodep->isVirtual()) m_graph.funcVirtual(nodep);
         if (!removable) {
             if (m_modp && !m_modp->dead() && !m_modp->verilatorLib())
                 m_modp->user1Inc();  // Keep container
@@ -523,10 +592,41 @@ class DeadVisitor final : public VNVisitor {
 
     void deadCheckTasks() {
         while (!m_graph.funcsEmpty()) {
-            AstNode* const taskp = m_graph.funcsGetPopFront();
-            UINFO(9, "Dead task " << taskp);
-            deleting(taskp);
-            ++m_statFTasksDeadified;
+            AstNode* const nodep = m_graph.funcsGetPopFront();
+            if (!nodep) continue;
+            UINFO(9, "Dead " << nodep);
+            if (AstNodeFTask* const taskp = VN_CAST(nodep, NodeFTask)) {
+                if (taskp->isVirtual()) {
+                    ++m_statFTasksVirtDeadified;
+                } else if (taskp->classMethod()) {
+                    ++m_statFTasksMDeadified;
+                } else {
+                    ++m_statFTasksNMDeadified;
+                }
+            }
+            deleting(nodep);
+        }
+    }
+
+    void deadCheckDemote() {
+        for (V3GraphVertex& gvtx : m_graph.vertices()) {
+            DeadVertex* const vtxp = gvtx.cast<DeadVertex>();
+            // A isVirtual vertex with single out means there's only one target virtual function
+            // that can be virtually called, so can make it non-virtual for faster execution
+            // (UVM benefits from this)
+            if (!vtxp->outSize1()) continue;
+            if (!vtxp->isVirtual()) continue;
+            for (V3GraphEdge& edge : vtxp->outEdges()) {  // Always a single one
+                AstNode* const nodep = edge.top()->as<DeadVertex>()->nodep();
+                AstNodeFTask* const funcp = VN_AS(nodep, NodeFTask);
+                UASSERT_OBJ(funcp->isVirtual(), funcp,
+                            "Only virtual ftasks should be under DeadVirtualVertex");
+                if (v3Global.opt.fDeadMethods()) {
+                    funcp->isVirtual(false);
+                    UINFO(9, "Demote to non-virtual " << funcp);
+                    ++m_statFTasksDemoted;
+                }
+            }
         }
     }
 
@@ -746,13 +846,22 @@ public:
         if (!elimTopIfaces) preserveTopIfaces(nodep);
         deadCheckMod();
 
+        // After deleting as much as can, demote some virtual functions
+        if (elimTasks) deadCheckDemote();
+
         // We may have removed some datatypes, cleanup
         nodep->typeTablep()->repairCache();
         VIsCached::clearCacheTree();  // Removing assignments may affect isPure
         nodep->constPoolp()->rebuildVarScopesAndCache();
     }
     ~DeadVisitor() override {
-        V3Stats::addStatSum("Optimizations, deadified FTasks", m_statFTasksDeadified);
+        V3Stats::addStatSum("Optimizations, FTasks, virtual-to-nonvirtual demotion",
+                            m_statFTasksDemoted);
+        V3Stats::addStatSum("Optimizations, FTasks, deadified, methods", m_statFTasksMDeadified);
+        V3Stats::addStatSum("Optimizations, FTasks, deadified, non-methods",
+                            m_statFTasksNMDeadified);
+        V3Stats::addStatSum("Optimizations, FTasks, deadified, virtual",
+                            m_statFTasksVirtDeadified);
     };
 };
 

--- a/src/V3LinkParse.cpp
+++ b/src/V3LinkParse.cpp
@@ -1228,6 +1228,7 @@ class LinkParseVisitor final : public VNVisitor {
             addArgMemberCopies(funcp, sampleArgsp, false);
             funcp->classMethod(true);
             funcp->dtypep(funcp->findVoidDType());
+            funcp->keepAlive(true);  // TODO create AstFuncRef and hold until findMethod("sample")
             nodep->addMembersp(funcp);
         }
 

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -1476,6 +1476,7 @@ void V3Options::parseOptsList(FileLine* fl, const string& optdir, int argc,
     DECL_OPTION("-fconst-eager", FOnOff, &m_fConstEager);
     DECL_OPTION("-fdead-assigns", FOnOff, &m_fDeadAssigns);
     DECL_OPTION("-fdead-cells", FOnOff, &m_fDeadCells);
+    DECL_OPTION("-fdead-methods", FOnOff, &m_fDeadMethods);
     DECL_OPTION("-fdedup", FOnOff, &m_fDedupe);
     DECL_OPTION("-fdfg", CbFOnOff, [this](bool flag) { m_fDfg = flag; });
     DECL_OPTION("-fdfg-break-cycles", CbFOnOff, [fl](bool) {
@@ -2386,6 +2387,7 @@ void V3Options::optimize(int level) {
     m_fDfg = flag;
     m_fDeadAssigns = flag;
     m_fDeadCells = flag;
+    m_fDeadMethods = flag;
     m_fExpand = flag;
     m_fGate = flag;
     m_fInline = flag;

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -412,6 +412,7 @@ private:
     bool m_fDfgSynthesizeAll = false;  // main switch: -fdfg-synthesize-all
     bool m_fDeadAssigns;     // main switch: -fno-dead-assigns: remove dead assigns
     bool m_fDeadCells;   // main switch: -fno-dead-cells: remove dead cells
+    bool m_fDeadMethods;   // main switch: -fno-dead-methods: remove dead methods
     bool m_fExpand;      // main switch: -fno-expand: expansion of C macros
     bool m_fFuncBalanceCat = true;  // main switch: -fno-func-balance-cat: expansion of C macros
     bool m_fFuncSplitCat = true;  // main switch: -fno-func-split-cat: expansion of C macros
@@ -753,6 +754,7 @@ public:
     }
     bool fDeadAssigns() const { return m_fDeadAssigns; }
     bool fDeadCells() const { return m_fDeadCells; }
+    bool fDeadMethods() const { return m_fDeadMethods; }
     bool fExpand() const { return m_fExpand; }
     bool fFuncBalanceCat() const { return m_fFuncBalanceCat; }
     bool fFuncSplitCat() const { return m_fFuncSplitCat; }

--- a/test_regress/t/t_constraint_json_only.out
+++ b/test_regress/t/t_constraint_json_only.out
@@ -2,90 +2,815 @@
  "modulesp": [
   {"type":"MODULE","name":"t","addr":"(F)","loc":"d,67:8,67:9","origName":"t","verilogName":"t","level":1,"depth":2,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"VAR","name":"p","addr":"(G)","loc":"d,69:10,69:11","dtypep":"(H)","origName":"p","verilogName":"p","direction":"NONE","declDirection":"NONE","lifetime":"VSTATICI","varType":"VAR","dtypeName":"Packet"},
+    {"type":"VAR","name":"p","addr":"(G)","loc":"d,69:10,69:11","dtypep":"(H)","origName":"p","verilogName":"p","direction":"NONE","declDirection":"NONE","icoMaybeWritten":true,"lifetime":"VSTATICI","varType":"VAR","dtypeName":"Packet"},
     {"type":"INITIAL","addr":"(I)","loc":"d,71:3,71:10",
      "stmtsp": [
       {"type":"BEGIN","addr":"(J)","loc":"d,71:11,71:16","unnamed":true,
        "stmtsp": [
-        {"type":"DISPLAY","addr":"(K)","loc":"d,73:5,73:11","displayType":"write",
-         "fmtp": [
-          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(L)","loc":"d,73:5,73:11","dtypep":"(M)","hidden":true}
+        {"type":"ASSIGN","addr":"(K)","loc":"d,72:7,72:8","dtypep":"(H)",
+         "rhsp": [
+          {"type":"NEW","name":"new","addr":"(L)","loc":"d,72:9,72:12","dtypep":"(H)","taskp":"(M)","classOrPackagep":"(N)"}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"p","addr":"(O)","loc":"d,72:5,72:6","dtypep":"(H)","access":"WR","varp":"(G)"}
         ]},
-        {"type":"FINISH","addr":"(N)","loc":"d,74:5,74:12"}
+        {"type":"IF","addr":"(P)","loc":"d,74:5,74:7",
+         "condp": [
+          {"type":"CEXPRUSER","addr":"(Q)","loc":"d,74:9,74:11","dtypep":"(R)",
+           "nodesp": [
+            {"type":"CONST","name":"32'sh0","addr":"(S)","loc":"d,74:12,74:13","dtypep":"(T)"}
+          ]}
+        ],
+         "thensp": [
+          {"type":"STMTEXPR","addr":"(U)","loc":"d,74:17,74:18",
+           "exprp": [
+            {"type":"COND","addr":"(V)","loc":"d,74:18,74:27","dtypep":"(T)",
+             "condp": [
+              {"type":"NEQ","addr":"(W)","loc":"d,74:18,74:27","dtypep":"(X)",
+               "lhsp": [
+                {"type":"CONST","name":"null","addr":"(Y)","loc":"d,74:18,74:27","dtypep":"(X)"}
+              ],
+               "rhsp": [
+                {"type":"VARREF","name":"p","addr":"(Z)","loc":"d,74:16,74:17","dtypep":"(H)","access":"RD","varp":"(G)"}
+              ]}
+            ],
+             "thenp": [
+              {"type":"METHODCALL","name":"randomize","addr":"(AB)","loc":"d,74:18,74:27","dtypep":"(T)","taskp":"(BB)","classOrPackagep":"(N)",
+               "fromp": [
+                {"type":"VARREF","name":"p","addr":"(CB)","loc":"d,74:16,74:17","dtypep":"(H)","access":"RD","varp":"(G)"}
+              ]}
+            ],
+             "elsep": [
+              {"type":"CONST","name":"32'h0","addr":"(DB)","loc":"d,74:18,74:27","dtypep":"(EB)"}
+            ]}
+          ]}
+        ]},
+        {"type":"DISPLAY","addr":"(FB)","loc":"d,75:5,75:11","displayType":"write",
+         "fmtp": [
+          {"type":"SFORMATF","name":"*-* All Finished *-*\\n","addr":"(GB)","loc":"d,75:5,75:11","dtypep":"(HB)","hidden":true}
+        ]},
+        {"type":"FINISH","addr":"(IB)","loc":"d,76:5,76:12"}
       ]}
     ]}
   ]},
   {"type":"PACKAGE","name":"$unit","addr":"(E)","loc":"a,0:0,0:0","origName":"__024unit","verilogName":"\\$unit ","level":2,"depth":3,"inLibrary":true,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
    "stmtsp": [
-    {"type":"CLASS","name":"Packet","addr":"(O)","loc":"d,7:1,7:6","cgAutoBinMax":-1,"origName":"Packet","verilogName":"Packet","level":3,"depth":4,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
+    {"type":"CLASS","name":"Packet","addr":"(N)","loc":"d,7:1,7:6","needRNG":true,"cgAutoBinMax":-1,"origName":"Packet","verilogName":"Packet","level":3,"depth":4,"unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"1ps",
      "stmtsp": [
-      {"type":"VAR","name":"header","addr":"(P)","loc":"d,8:12,8:18","dtypep":"(Q)","origName":"header","verilogName":"header","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
-      {"type":"VAR","name":"length","addr":"(R)","loc":"d,9:12,9:18","dtypep":"(Q)","origName":"length","verilogName":"length","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
-      {"type":"VAR","name":"sublength","addr":"(S)","loc":"d,10:12,10:21","dtypep":"(Q)","origName":"sublength","verilogName":"sublength","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
-      {"type":"VAR","name":"if_4","addr":"(T)","loc":"d,11:12,11:16","dtypep":"(U)","origName":"if_4","verilogName":"if_4","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
-      {"type":"VAR","name":"iff_5_6","addr":"(V)","loc":"d,12:12,12:19","dtypep":"(U)","origName":"iff_5_6","verilogName":"iff_5_6","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
-      {"type":"VAR","name":"if_state_ok","addr":"(W)","loc":"d,13:12,13:23","dtypep":"(U)","origName":"if_state_ok","verilogName":"if_state_ok","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
-      {"type":"VAR","name":"array","addr":"(X)","loc":"d,15:12,15:17","dtypep":"(Y)","origName":"array","verilogName":"array","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","rand":"RAND"},
-      {"type":"VAR","name":"state","addr":"(Z)","loc":"d,17:10,17:15","dtypep":"(M)","origName":"state","verilogName":"state","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"string"},
-      {"type":"FUNC","name":"strings_equal","addr":"(AB)","loc":"d,61:16,61:29","dtypep":"(U)","method":true,"lifetime":"VAUTOMI","cname":"strings_equal",
+      {"type":"VAR","name":"header","addr":"(JB)","loc":"d,8:12,8:18","dtypep":"(KB)","origName":"header","verilogName":"header","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
+      {"type":"VAR","name":"length","addr":"(LB)","loc":"d,9:12,9:18","dtypep":"(KB)","origName":"length","verilogName":"length","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
+      {"type":"VAR","name":"sublength","addr":"(MB)","loc":"d,10:12,10:21","dtypep":"(KB)","origName":"sublength","verilogName":"sublength","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"int","rand":"RAND"},
+      {"type":"VAR","name":"if_4","addr":"(NB)","loc":"d,11:12,11:16","dtypep":"(X)","origName":"if_4","verilogName":"if_4","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
+      {"type":"VAR","name":"iff_5_6","addr":"(OB)","loc":"d,12:12,12:19","dtypep":"(X)","origName":"iff_5_6","verilogName":"iff_5_6","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
+      {"type":"VAR","name":"if_state_ok","addr":"(PB)","loc":"d,13:12,13:23","dtypep":"(X)","origName":"if_state_ok","verilogName":"if_state_ok","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"bit","rand":"RAND"},
+      {"type":"VAR","name":"array","addr":"(QB)","loc":"d,15:12,15:17","dtypep":"(RB)","origName":"array","verilogName":"array","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","rand":"RAND"},
+      {"type":"VAR","name":"state","addr":"(SB)","loc":"d,17:10,17:15","dtypep":"(HB)","origName":"state","verilogName":"state","direction":"NONE","declDirection":"NONE","lifetime":"VAUTOMI","varType":"MEMBER","dtypeName":"string"},
+      {"type":"FUNC","name":"strings_equal","addr":"(TB)","loc":"d,61:16,61:29","dtypep":"(X)","method":true,"lifetime":"VAUTOMI","cname":"strings_equal",
        "fvarp": [
-        {"type":"VAR","name":"strings_equal","addr":"(BB)","loc":"d,61:16,61:29","dtypep":"(U)","origName":"strings_equal","verilogName":"strings_equal","direction":"OUTPUT","declDirection":"NONE","noCReset":true,"icoMaybeWritten":true,"isFuncReturn":true,"isFuncLocal":true,"lifetime":"VAUTOM","varType":"VAR","dtypeName":"bit"}
+        {"type":"VAR","name":"strings_equal","addr":"(UB)","loc":"d,61:16,61:29","dtypep":"(X)","origName":"strings_equal","verilogName":"strings_equal","direction":"OUTPUT","declDirection":"NONE","noCReset":true,"icoMaybeWritten":true,"isFuncReturn":true,"isFuncLocal":true,"lifetime":"VAUTOM","varType":"VAR","dtypeName":"bit"}
       ],
        "stmtsp": [
-        {"type":"VAR","name":"a","addr":"(CB)","loc":"d,61:37,61:38","dtypep":"(M)","origName":"a","verilogName":"a","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
-        {"type":"VAR","name":"b","addr":"(DB)","loc":"d,61:47,61:48","dtypep":"(M)","origName":"b","verilogName":"b","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
-        {"type":"ASSIGN","addr":"(EB)","loc":"d,61:16,61:29","dtypep":"(U)",
+        {"type":"VAR","name":"a","addr":"(VB)","loc":"d,61:37,61:38","dtypep":"(HB)","origName":"a","verilogName":"a","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
+        {"type":"VAR","name":"b","addr":"(WB)","loc":"d,61:47,61:48","dtypep":"(HB)","origName":"b","verilogName":"b","direction":"INPUT","declDirection":"INPUT","isFuncLocal":true,"lifetime":"VAUTOMI","varType":"PORT","dtypeName":"string"},
+        {"type":"ASSIGN","addr":"(XB)","loc":"d,61:16,61:29","dtypep":"(X)",
          "rhsp": [
-          {"type":"CONST","name":"1'h0","addr":"(FB)","loc":"d,61:16,61:29","dtypep":"(U)"}
+          {"type":"CONST","name":"1'h0","addr":"(YB)","loc":"d,61:16,61:29","dtypep":"(X)"}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"strings_equal","addr":"(GB)","loc":"d,61:16,61:29","dtypep":"(U)","access":"WR","varp":"(BB)"}
+          {"type":"VARREF","name":"strings_equal","addr":"(ZB)","loc":"d,61:16,61:29","dtypep":"(X)","access":"WR","varp":"(UB)"}
         ]},
-        {"type":"ASSIGN","addr":"(HB)","loc":"d,62:5,62:11","dtypep":"(U)",
+        {"type":"ASSIGN","addr":"(AC)","loc":"d,62:5,62:11","dtypep":"(X)",
          "rhsp": [
-          {"type":"EQN","addr":"(IB)","loc":"d,62:14,62:16","dtypep":"(U)",
+          {"type":"EQN","addr":"(BC)","loc":"d,62:14,62:16","dtypep":"(X)",
            "lhsp": [
-            {"type":"VARREF","name":"a","addr":"(JB)","loc":"d,62:12,62:13","dtypep":"(M)","access":"RD","varp":"(CB)","classOrPackagep":"(O)"}
+            {"type":"VARREF","name":"a","addr":"(CC)","loc":"d,62:12,62:13","dtypep":"(HB)","access":"RD","varp":"(VB)","classOrPackagep":"(N)"}
           ],
            "rhsp": [
-            {"type":"VARREF","name":"b","addr":"(KB)","loc":"d,62:17,62:18","dtypep":"(M)","access":"RD","varp":"(DB)","classOrPackagep":"(O)"}
+            {"type":"VARREF","name":"b","addr":"(DC)","loc":"d,62:17,62:18","dtypep":"(HB)","access":"RD","varp":"(WB)","classOrPackagep":"(N)"}
           ]}
         ],
          "lhsp": [
-          {"type":"VARREF","name":"strings_equal","addr":"(LB)","loc":"d,62:5,62:11","dtypep":"(U)","access":"WR","varp":"(BB)"}
+          {"type":"VARREF","name":"strings_equal","addr":"(EC)","loc":"d,62:5,62:11","dtypep":"(X)","access":"WR","varp":"(UB)"}
         ]}
       ]},
-      {"type":"FUNC","name":"new","addr":"(MB)","loc":"d,7:1,7:6","dtypep":"(NB)","method":true,"lifetime":"NONE","cname":"new"},
-      {"type":"VAR","name":"constraint","addr":"(OB)","loc":"d,7:1,7:6","dtypep":"(PB)","origName":"constraint","verilogName":"constraint","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"MEMBER","dtypeName":"VlRandomizer"}
+      {"type":"FUNC","name":"new","addr":"(M)","loc":"d,7:1,7:6","dtypep":"(FC)","method":true,"lifetime":"NONE","cname":"new",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(GC)","loc":"d,8:12,8:18",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(HC)","loc":"d,8:12,8:18","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(IC)","loc":"d,8:12,8:18","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"header","addr":"(LC)","loc":"d,8:12,8:18","dtypep":"(KB)","access":"WR","varp":"(JB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h20","addr":"(MC)","loc":"d,8:12,8:18","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(OC)","loc":"d,8:12,8:18","dtypep":"(KB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(PC)","loc":"d,8:12,8:18","text":"\"header\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(QC)","loc":"d,8:8,8:11","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(RC)","loc":"d,9:12,9:18",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(SC)","loc":"d,9:12,9:18","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(TC)","loc":"d,9:12,9:18","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"length","addr":"(UC)","loc":"d,9:12,9:18","dtypep":"(KB)","access":"WR","varp":"(LB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h20","addr":"(VC)","loc":"d,9:12,9:18","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(WC)","loc":"d,9:12,9:18","dtypep":"(KB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(XC)","loc":"d,9:12,9:18","text":"\"length\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(YC)","loc":"d,8:8,8:11","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(ZC)","loc":"d,11:12,11:16",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(AD)","loc":"d,11:12,11:16","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(BD)","loc":"d,11:12,11:16","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"if_4","addr":"(CD)","loc":"d,11:12,11:16","dtypep":"(X)","access":"WR","varp":"(NB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h1","addr":"(DD)","loc":"d,11:12,11:16","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(ED)","loc":"d,11:12,11:16","dtypep":"(X)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(FD)","loc":"d,11:12,11:16","text":"\"if_4\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(GD)","loc":"d,11:8,11:11","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(HD)","loc":"d,12:12,12:19",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(ID)","loc":"d,12:12,12:19","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(JD)","loc":"d,12:12,12:19","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"iff_5_6","addr":"(KD)","loc":"d,12:12,12:19","dtypep":"(X)","access":"WR","varp":"(OB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h1","addr":"(LD)","loc":"d,12:12,12:19","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(MD)","loc":"d,12:12,12:19","dtypep":"(X)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(ND)","loc":"d,12:12,12:19","text":"\"iff_5_6\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(OD)","loc":"d,11:8,11:11","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(PD)","loc":"d,15:12,15:17",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(QD)","loc":"d,15:12,15:17","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(RD)","loc":"d,15:12,15:17","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"array","addr":"(SD)","loc":"d,15:12,15:17","dtypep":"(RB)","access":"WR","varp":"(QB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h20","addr":"(TD)","loc":"d,15:12,15:17","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(UD)","loc":"d,15:12,15:17","dtypep":"(RB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(VD)","loc":"d,15:12,15:17","text":"\"array\""}
+            ]},
+            {"type":"CONST","name":"64'h1","addr":"(WD)","loc":"d,15:17,15:18","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(XD)","loc":"d,10:12,10:21",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(YD)","loc":"d,10:12,10:21","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(ZD)","loc":"d,10:12,10:21","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"sublength","addr":"(AE)","loc":"d,10:12,10:21","dtypep":"(KB)","access":"WR","varp":"(MB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h20","addr":"(BE)","loc":"d,10:12,10:21","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(CE)","loc":"d,10:12,10:21","dtypep":"(KB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(DE)","loc":"d,10:12,10:21","text":"\"sublength\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(EE)","loc":"d,8:8,8:11","dtypep":"(NC)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(FE)","loc":"d,13:12,13:23",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"write_var","addr":"(GE)","loc":"d,13:12,13:23","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(HE)","loc":"d,13:12,13:23","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"VARREF","name":"if_state_ok","addr":"(IE)","loc":"d,13:12,13:23","dtypep":"(X)","access":"WR","varp":"(PB)","classOrPackagep":"(N)"},
+            {"type":"CONST","name":"64'h1","addr":"(JE)","loc":"d,13:12,13:23","dtypep":"(NC)"},
+            {"type":"CEXPR","addr":"(KE)","loc":"d,13:12,13:23","dtypep":"(X)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(LE)","loc":"d,13:12,13:23","text":"\"if_state_ok\""}
+            ]},
+            {"type":"CONST","name":"64'h0","addr":"(ME)","loc":"d,11:8,11:11","dtypep":"(NC)"}
+          ]}
+        ]}
+      ]},
+      {"type":"FUNC","name":"randomize","addr":"(BB)","loc":"d,7:1,7:6","dtypep":"(T)","method":true,"lifetime":"NONE","cname":"randomize",
+       "fvarp": [
+        {"type":"VAR","name":"randomize","addr":"(NE)","loc":"d,7:1,7:6","dtypep":"(T)","origName":"randomize","verilogName":"randomize","direction":"OUTPUT","declDirection":"NONE","isFuncReturn":true,"isFuncLocal":true,"lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit"}
+      ],
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(OE)","loc":"d,7:1,7:6",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"clearConstraints","addr":"(PE)","loc":"d,7:1,7:6","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(QE)","loc":"d,7:1,7:6","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(RE)","loc":"d,7:1,7:6",
+         "exprp": [
+          {"type":"TASKREF","name":"__Vsetup_constraints","addr":"(SE)","loc":"d,7:1,7:6","dtypep":"(FC)","taskp":"(TE)"}
+        ]},
+        {"type":"ASSIGN","addr":"(UE)","loc":"d,7:1,7:6","dtypep":"(T)",
+         "rhsp": [
+          {"type":"CEXPR","addr":"(VE)","loc":"d,7:1,7:6","dtypep":"(X)",
+           "nodesp": [
+            {"type":"VARREF","name":"constraint","addr":"(WE)","loc":"d,7:1,7:6","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"},
+            {"type":"TEXT","addr":"(XE)","loc":"d,7:1,7:6","text":".next(__Vm_rng)"}
+          ]}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"randomize","addr":"(YE)","loc":"d,7:1,7:6","dtypep":"(T)","access":"WR","varp":"(NE)"}
+        ]},
+        {"type":"ASSIGN","addr":"(ZE)","loc":"d,7:1,7:6","dtypep":"(T)",
+         "rhsp": [
+          {"type":"AND","addr":"(AF)","loc":"d,7:1,7:6","dtypep":"(T)",
+           "lhsp": [
+            {"type":"VARREF","name":"randomize","addr":"(BF)","loc":"d,7:1,7:6","dtypep":"(T)","access":"RD","varp":"(NE)"}
+          ],
+           "rhsp": [
+            {"type":"FUNCREF","name":"__VBasicRand","addr":"(CF)","loc":"d,7:1,7:6","dtypep":"(T)","taskp":"(DF)"}
+          ]}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"randomize","addr":"(EF)","loc":"d,7:1,7:6","dtypep":"(T)","access":"WR","varp":"(NE)"}
+        ]}
+      ]},
+      {"type":"VAR","name":"constraint","addr":"(KC)","loc":"d,7:1,7:6","dtypep":"(JC)","origName":"constraint","verilogName":"constraint","direction":"NONE","declDirection":"NONE","lifetime":"NONE","varType":"MEMBER","dtypeName":"VlRandomizer"},
+      {"type":"TASK","name":"empty_setup_constraint","addr":"(FF)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"empty_setup_constraint"},
+      {"type":"TASK","name":"size_setup_constraint","addr":"(GF)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"size_setup_constraint",
+       "stmtsp": [
+        {"type":"VAR","name":"__Vdist_total0","addr":"(HF)","loc":"d,25:12,25:16","dtypep":"(IF)","origName":"__Vdist_total0","verilogName":"__Vdist_total0","direction":"NONE","declDirection":"NONE","isFuncLocal":true,"lifetime":"VAUTOM","varType":"BLOCKTEMP","dtypeName":"QData"},
+        {"type":"ASSIGN","addr":"(JF)","loc":"d,25:12,25:16","dtypep":"(IF)",
+         "rhsp": [
+          {"type":"CONST","name":"64'h15","addr":"(KF)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"__Vdist_total0","addr":"(LF)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"WR","varp":"(HF)"}
+        ]},
+        {"type":"VAR","name":"__Vdist_bucket0","addr":"(MF)","loc":"d,25:12,25:16","dtypep":"(IF)","origName":"__Vdist_bucket0","verilogName":"__Vdist_bucket0","direction":"NONE","declDirection":"NONE","isFuncLocal":true,"lifetime":"VAUTOM","varType":"BLOCKTEMP","dtypeName":"QData"},
+        {"type":"ASSIGN","addr":"(NF)","loc":"d,25:12,25:16","dtypep":"(IF)",
+         "rhsp": [
+          {"type":"ADD","addr":"(OF)","loc":"d,25:12,25:16","dtypep":"(NC)",
+           "lhsp": [
+            {"type":"CONST","name":"64'h1","addr":"(PF)","loc":"d,25:12,25:16","dtypep":"(NC)"}
+          ],
+           "rhsp": [
+            {"type":"MODDIV","addr":"(QF)","loc":"d,25:12,25:16","dtypep":"(IF)",
+             "lhsp": [
+              {"type":"RAND","addr":"(RF)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+            ],
+             "rhsp": [
+              {"type":"VARREF","name":"__Vdist_total0","addr":"(SF)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"RD","varp":"(HF)"}
+            ]}
+          ]}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"__Vdist_bucket0","addr":"(TF)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"WR","varp":"(MF)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(UF)","loc":"d,22:16,22:18",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(VF)","loc":"d,22:16,22:18","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(WF)","loc":"d,22:16,22:18","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(bvand (__Vbv (bvsgt header #x00000000)) (__Vbv (bvsle header #x00000007)))\\\"","addr":"(XF)","loc":"d,22:16,22:18","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(YF)","loc":"d,22:16,22:18","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(ZF)","loc":"d,22:16,22:18","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h16","addr":"(AG)","loc":"d,22:16,22:18","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(BG)","loc":"d,22:16,22:18","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(CG)","loc":"d,22:16,22:18","text":"\"    header > 0 && header <= 7;\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(DG)","loc":"d,23:12,23:14",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(EG)","loc":"d,23:12,23:14","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(FG)","loc":"d,23:12,23:14","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (bvsle length #x0000000f))\\\"","addr":"(GG)","loc":"d,23:12,23:14","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(HG)","loc":"d,23:12,23:14","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(IG)","loc":"d,23:12,23:14","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h17","addr":"(JG)","loc":"d,23:12,23:14","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(KG)","loc":"d,23:12,23:14","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(LG)","loc":"d,23:12,23:14","text":"\"    length <= 15;\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(MG)","loc":"d,24:12,24:14",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(NG)","loc":"d,24:12,24:14","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(OG)","loc":"d,24:12,24:14","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (bvsge length header))\\\"","addr":"(PG)","loc":"d,24:12,24:14","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(QG)","loc":"d,24:12,24:14","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(RG)","loc":"d,24:12,24:14","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h18","addr":"(SG)","loc":"d,24:12,24:14","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(TG)","loc":"d,24:12,24:14","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(UG)","loc":"d,24:12,24:14","text":"\"    length >= header;\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(VG)","loc":"d,25:12,25:16",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(WG)","loc":"d,25:12,25:16","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(XG)","loc":"d,25:12,25:16","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(bvor (__Vbv (= length #x00000001)) (bvor (__Vbv (= length #x00000007)) (bvor (__Vbv (= length #x00000006)) (bvor (bvand (__Vbv (bvsge length #x00000002)) (__Vbv (bvsle length #x00000005))) (bvand (__Vbv (bvsge length #x00000000)) (__Vbv (bvsle length #x00000001)))))))\\\"","addr":"(YG)","loc":"d,25:12,25:16","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(ZG)","loc":"d,25:12,25:16","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(AH)","loc":"d,25:12,25:16","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h19","addr":"(BH)","loc":"d,25:12,25:16","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(CH)","loc":"d,25:12,25:16","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(DH)","loc":"d,25:12,25:16","text":"\"    length dist { [0:1], [2:5] :/ 2, 6 := 6, 7 := 10, 1};\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(EH)","loc":"d,25:12,25:16",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(FH)","loc":"d,25:12,25:16","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(GH)","loc":"d,25:12,25:16","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"COND","addr":"(HH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+             "condp": [
+              {"type":"GTE","addr":"(IH)","loc":"d,25:12,25:16","dtypep":"(X)",
+               "lhsp": [
+                {"type":"CONST","name":"64'h2","addr":"(JH)","loc":"d,25:12,25:16","dtypep":"(KH)"}
+              ],
+               "rhsp": [
+                {"type":"VARREF","name":"__Vdist_bucket0","addr":"(LH)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"RD","varp":"(MF)"}
+              ]}
+            ],
+             "thenp": [
+              {"type":"SFORMATF","name":"(__Vbv (= length %s))","addr":"(MH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+               "exprsp": [
+                {"type":"SFORMATF","name":"#x%x","addr":"(NH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+                 "exprsp": [
+                  {"type":"CCAST","addr":"(OH)","loc":"d,25:12,25:16","dtypep":"(T)","size":32,
+                   "lhsp": [
+                    {"type":"AND","addr":"(PH)","loc":"d,25:12,25:16","dtypep":"(IF)",
+                     "lhsp": [
+                      {"type":"CONST","name":"64'h1","addr":"(QH)","loc":"d,25:12,25:16","dtypep":"(NC)"}
+                    ],
+                     "rhsp": [
+                      {"type":"RAND","addr":"(RH)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+                    ]}
+                  ]}
+                ]}
+              ]}
+            ],
+             "elsep": [
+              {"type":"COND","addr":"(SH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+               "condp": [
+                {"type":"GTE","addr":"(TH)","loc":"d,25:12,25:16","dtypep":"(X)",
+                 "lhsp": [
+                  {"type":"CONST","name":"64'h4","addr":"(UH)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+                ],
+                 "rhsp": [
+                  {"type":"VARREF","name":"__Vdist_bucket0","addr":"(VH)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"RD","varp":"(MF)"}
+                ]}
+              ],
+               "thenp": [
+                {"type":"SFORMATF","name":"(__Vbv (= length %s))","addr":"(WH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+                 "exprsp": [
+                  {"type":"SFORMATF","name":"#x%x","addr":"(XH)","loc":"d,25:12,25:16","dtypep":"(HB)",
+                   "exprsp": [
+                    {"type":"ADD","addr":"(YH)","loc":"d,25:12,25:16","dtypep":"(T)",
+                     "lhsp": [
+                      {"type":"CONST","name":"32'sh2","addr":"(ZH)","loc":"d,25:27,25:28","dtypep":"(T)"}
+                    ],
+                     "rhsp": [
+                      {"type":"CCAST","addr":"(AI)","loc":"d,25:12,25:16","dtypep":"(EB)","size":32,
+                       "lhsp": [
+                        {"type":"AND","addr":"(BI)","loc":"d,25:12,25:16","dtypep":"(IF)",
+                         "lhsp": [
+                          {"type":"CONST","name":"64'h3","addr":"(CI)","loc":"d,25:12,25:16","dtypep":"(NC)"}
+                        ],
+                         "rhsp": [
+                          {"type":"RAND","addr":"(DI)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+                        ]}
+                      ]}
+                    ]}
+                  ]}
+                ]}
+              ],
+               "elsep": [
+                {"type":"COND","addr":"(EI)","loc":"d,25:12,25:16","dtypep":"(HB)",
+                 "condp": [
+                  {"type":"GTE","addr":"(FI)","loc":"d,25:12,25:16","dtypep":"(X)",
+                   "lhsp": [
+                    {"type":"CONST","name":"64'ha","addr":"(GI)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+                  ],
+                   "rhsp": [
+                    {"type":"VARREF","name":"__Vdist_bucket0","addr":"(HI)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"RD","varp":"(MF)"}
+                  ]}
+                ],
+                 "thenp": [
+                  {"type":"CONST","name":"\\\"(__Vbv (= length #x00000006))\\\"","addr":"(II)","loc":"d,25:12,25:16","dtypep":"(HB)"}
+                ],
+                 "elsep": [
+                  {"type":"COND","addr":"(JI)","loc":"d,25:12,25:16","dtypep":"(HB)",
+                   "condp": [
+                    {"type":"GTE","addr":"(KI)","loc":"d,25:12,25:16","dtypep":"(X)",
+                     "lhsp": [
+                      {"type":"CONST","name":"64'h14","addr":"(LI)","loc":"d,25:12,25:16","dtypep":"(IF)"}
+                    ],
+                     "rhsp": [
+                      {"type":"VARREF","name":"__Vdist_bucket0","addr":"(MI)","loc":"d,25:12,25:16","dtypep":"(IF)","access":"RD","varp":"(MF)"}
+                    ]}
+                  ],
+                   "thenp": [
+                    {"type":"CONST","name":"\\\"(__Vbv (= length #x00000007))\\\"","addr":"(NI)","loc":"d,25:12,25:16","dtypep":"(HB)"}
+                  ],
+                   "elsep": [
+                    {"type":"CONST","name":"\\\"(__Vbv (= length #x00000001))\\\"","addr":"(OI)","loc":"d,25:12,25:16","dtypep":"(HB)"}
+                  ]}
+                ]}
+              ]}
+            ]},
+            {"type":"CEXPR","addr":"(PI)","loc":"d,25:12,25:16","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(QI)","loc":"d,25:12,25:16","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h19","addr":"(RI)","loc":"d,25:12,25:16","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(SI)","loc":"d,25:12,25:16","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(TI)","loc":"d,25:12,25:16","text":"\"    length dist { [0:1], [2:5] :/ 2, 6 := 6, 7 := 10, 1};\""}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"ifs_setup_constraint","addr":"(UI)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"ifs_setup_constraint",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(VI)","loc":"d,29:5,29:7",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(WI)","loc":"d,29:5,29:7","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(XI)","loc":"d,29:5,29:7","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (=> (__Vbool (__Vbv (bvsgt header #x00000004))) (__Vbool (__Vbv (= if_4 #b1)))))\\\"","addr":"(YI)","loc":"d,29:5,29:7","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(ZI)","loc":"d,29:5,29:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(AJ)","loc":"d,29:5,29:7","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h1d","addr":"(BJ)","loc":"d,29:5,29:7","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(CJ)","loc":"d,29:5,29:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(DJ)","loc":"d,29:5,29:7","text":"\"    if (header > 4) {\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(EJ)","loc":"d,32:5,32:7",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(FJ)","loc":"d,32:5,32:7","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(GJ)","loc":"d,32:5,32:7","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(ite (__Vbool (bvor (__Vbv (= header #x00000005)) (__Vbv (= header #x00000006)))) (bvand (__Vbv (= iff_5_6 #b1)) (__Vbv (= iff_5_6 #b1)) (__Vbv (= iff_5_6 #b1))) (__Vbv (= iff_5_6 #b0)))\\\"","addr":"(HJ)","loc":"d,32:5,32:7","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(IJ)","loc":"d,32:5,32:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(JJ)","loc":"d,32:5,32:7","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h20","addr":"(KJ)","loc":"d,32:5,32:7","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(LJ)","loc":"d,32:5,32:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(MJ)","loc":"d,32:5,32:7","text":"\"    if (header == 5 || header == 6) {\""}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"arr_uniq_setup_constraint","addr":"(NJ)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"arr_uniq_setup_constraint",
+       "stmtsp": [
+        {"type":"BEGIN","addr":"(OJ)","loc":"d,42:5,42:12","implied":true,"unnamed":true,
+         "stmtsp": [
+          {"type":"FOREACH","addr":"(PJ)","loc":"d,42:5,42:12",
+           "headerp": [
+            {"type":"FOREACHHEADER","addr":"(QJ)","loc":"d,42:19,42:20",
+             "fromp": [
+              {"type":"VARREF","name":"array","addr":"(RJ)","loc":"d,42:14,42:19","dtypep":"(RB)","access":"RD","varp":"(QB)","classOrPackagep":"(N)"}
+            ],
+             "elementsp": [
+              {"type":"VAR","name":"i","addr":"(SJ)","loc":"d,42:20,42:21","dtypep":"(KB)","origName":"i","verilogName":"i","direction":"NONE","declDirection":"NONE","isUsedLoopIdx":true,"lifetime":"VAUTOM","varType":"BLOCKTEMP","dtypeName":"int"}
+            ]}
+          ],
+           "bodyp": [
+            {"type":"STMTEXPR","addr":"(TJ)","loc":"d,43:16,43:22",
+             "exprp": [
+              {"type":"CMETHODHARD","name":"hard","addr":"(UJ)","loc":"d,43:16,43:22","dtypep":"(FC)",
+               "fromp": [
+                {"type":"VARREF","name":"constraint","addr":"(VJ)","loc":"d,43:16,43:22","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+              ],
+               "pinsp": [
+                {"type":"SFORMATF","name":"(bvor %s %s)","addr":"(WJ)","loc":"d,43:16,43:22","dtypep":"(HB)",
+                 "exprsp": [
+                  {"type":"SFORMATF","name":"(bvor %s %s)","addr":"(XJ)","loc":"d,43:16,43:22","dtypep":"(HB)",
+                   "exprsp": [
+                    {"type":"SFORMATF","name":"(__Vbv (= %s #x00000002))","addr":"(YJ)","loc":"d,43:24,43:25","dtypep":"(HB)",
+                     "exprsp": [
+                      {"type":"SFORMATF","name":"(select array %s)","addr":"(ZJ)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                       "exprsp": [
+                        {"type":"SFORMATF","name":"#x%8x","addr":"(AK)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                         "exprsp": [
+                          {"type":"SEL","addr":"(BK)","loc":"d,43:13,43:14","dtypep":"(CK)","widthConst":1,
+                           "fromp": [
+                            {"type":"VARREF","name":"i","addr":"(DK)","loc":"d,43:13,43:14","dtypep":"(KB)","access":"RD","varp":"(SJ)"}
+                          ],
+                           "lsbp": [
+                            {"type":"CONST","name":"32'h0","addr":"(EK)","loc":"d,43:13,43:14","dtypep":"(EB)"}
+                          ]}
+                        ]}
+                      ]}
+                    ]},
+                    {"type":"SFORMATF","name":"(__Vbv (= %s #x00000004))","addr":"(FK)","loc":"d,43:27,43:28","dtypep":"(HB)",
+                     "exprsp": [
+                      {"type":"SFORMATF","name":"(select array %s)","addr":"(GK)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                       "exprsp": [
+                        {"type":"SFORMATF","name":"#x%8x","addr":"(HK)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                         "exprsp": [
+                          {"type":"SEL","addr":"(IK)","loc":"d,43:13,43:14","dtypep":"(CK)","widthConst":1,
+                           "fromp": [
+                            {"type":"VARREF","name":"i","addr":"(JK)","loc":"d,43:13,43:14","dtypep":"(KB)","access":"RD","varp":"(SJ)"}
+                          ],
+                           "lsbp": [
+                            {"type":"CONST","name":"32'h0","addr":"(KK)","loc":"d,43:13,43:14","dtypep":"(EB)"}
+                          ]}
+                        ]}
+                      ]}
+                    ]}
+                  ]},
+                  {"type":"SFORMATF","name":"(__Vbv (= %s #x00000006))","addr":"(LK)","loc":"d,43:30,43:31","dtypep":"(HB)",
+                   "exprsp": [
+                    {"type":"SFORMATF","name":"(select array %s)","addr":"(MK)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                     "exprsp": [
+                      {"type":"SFORMATF","name":"#x%8x","addr":"(NK)","loc":"d,43:12,43:13","dtypep":"(HB)",
+                       "exprsp": [
+                        {"type":"SEL","addr":"(OK)","loc":"d,43:13,43:14","dtypep":"(CK)","widthConst":1,
+                         "fromp": [
+                          {"type":"VARREF","name":"i","addr":"(PK)","loc":"d,43:13,43:14","dtypep":"(KB)","access":"RD","varp":"(SJ)"}
+                        ],
+                         "lsbp": [
+                          {"type":"CONST","name":"32'h0","addr":"(QK)","loc":"d,43:13,43:14","dtypep":"(EB)"}
+                        ]}
+                      ]}
+                    ]}
+                  ]}
+                ]},
+                {"type":"CEXPR","addr":"(RK)","loc":"d,43:16,43:22","dtypep":"(FC)","pure":true,
+                 "nodesp": [
+                  {"type":"TEXT","addr":"(SK)","loc":"d,43:16,43:22","text":"\"t/t_constraint_json_only.v\""}
+                ]},
+                {"type":"CONST","name":"32'h2b","addr":"(TK)","loc":"d,43:16,43:22","dtypep":"(EB)"},
+                {"type":"CEXPR","addr":"(UK)","loc":"d,43:16,43:22","dtypep":"(FC)","pure":true,
+                 "nodesp": [
+                  {"type":"TEXT","addr":"(VK)","loc":"d,43:16,43:22","text":"\"      array[i] inside {2, 4, 6};\""}
+                ]}
+              ]}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(WK)","loc":"d,45:5,45:11",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(XK)","loc":"d,45:5,45:11","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(YK)","loc":"d,45:5,45:11","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (not (= (select array #x00000000) (select array #x00000001))))\\\"","addr":"(ZK)","loc":"d,45:5,45:11","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(AL)","loc":"d,45:5,45:11","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(BL)","loc":"d,45:5,45:11","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h2d","addr":"(CL)","loc":"d,45:5,45:11","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(DL)","loc":"d,45:5,45:11","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(EL)","loc":"d,45:5,45:11","text":"\"    unique { array[0], array[1] };\""}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"order_setup_constraint","addr":"(FL)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"order_setup_constraint",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(GL)","loc":"d,48:22,48:27",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"solveBefore","addr":"(HL)","loc":"d,48:22,48:27","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(IL)","loc":"d,48:22,48:27","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CEXPR","addr":"(JL)","loc":"d,48:22,48:27","dtypep":"(HB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(KL)","loc":"d,48:22,48:27","text":"\"length\"s"}
+            ]},
+            {"type":"CEXPR","addr":"(LL)","loc":"d,48:22,48:27","dtypep":"(HB)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(ML)","loc":"d,48:22,48:27","text":"\"header\"s"}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"dis_setup_constraint","addr":"(NL)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"dis_setup_constraint",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(OL)","loc":"d,51:5,51:9",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"soft","addr":"(PL)","loc":"d,51:5,51:9","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(QL)","loc":"d,51:5,51:9","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (not (= sublength #x00000000)))\\\"","addr":"(RL)","loc":"d,51:10,51:19","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(SL)","loc":"d,51:5,51:9","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(TL)","loc":"d,51:5,51:9","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h33","addr":"(UL)","loc":"d,51:5,51:9","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(VL)","loc":"d,51:5,51:9","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(WL)","loc":"d,51:5,51:9","text":"\"    soft sublength;\""}
+            ]}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(XL)","loc":"d,52:5,52:12",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"disable_soft","addr":"(YL)","loc":"d,52:5,52:12","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(ZL)","loc":"d,52:5,52:12","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"sublength\\\"","addr":"(AM)","loc":"d,52:5,52:12","dtypep":"(HB)"}
+          ]}
+        ]},
+        {"type":"STMTEXPR","addr":"(BM)","loc":"d,53:15,53:17",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(CM)","loc":"d,53:15,53:17","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(DM)","loc":"d,53:15,53:17","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"CONST","name":"\\\"(__Vbv (bvsle sublength length))\\\"","addr":"(EM)","loc":"d,53:15,53:17","dtypep":"(HB)"},
+            {"type":"CEXPR","addr":"(FM)","loc":"d,53:15,53:17","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(GM)","loc":"d,53:15,53:17","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h35","addr":"(HM)","loc":"d,53:15,53:17","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(IM)","loc":"d,53:15,53:17","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(JM)","loc":"d,53:15,53:17","text":"\"    sublength <= length;\""}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"meth_setup_constraint","addr":"(KM)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"meth_setup_constraint",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(LM)","loc":"d,57:5,57:7",
+         "exprp": [
+          {"type":"CMETHODHARD","name":"hard","addr":"(MM)","loc":"d,57:5,57:7","dtypep":"(FC)",
+           "fromp": [
+            {"type":"VARREF","name":"constraint","addr":"(NM)","loc":"d,57:5,57:7","dtypep":"(JC)","access":"RW","varp":"(KC)","classOrPackagep":"(N)"}
+          ],
+           "pinsp": [
+            {"type":"SFORMATF","name":"(__Vbv (=> (__Vbool %s) (__Vbool (__Vbv (= if_state_ok #b1)))))","addr":"(OM)","loc":"d,57:5,57:7","dtypep":"(HB)",
+             "exprsp": [
+              {"type":"SFORMATF","name":"#b%b","addr":"(PM)","loc":"d,57:9,57:22","dtypep":"(HB)",
+               "exprsp": [
+                {"type":"FUNCREF","name":"strings_equal","addr":"(QM)","loc":"d,57:9,57:22","dtypep":"(X)","taskp":"(TB)","classOrPackagep":"(N)",
+                 "argsp": [
+                  {"type":"ARG","addr":"(RM)","loc":"d,57:23,57:28",
+                   "exprp": [
+                    {"type":"VARREF","name":"state","addr":"(SM)","loc":"d,57:23,57:28","dtypep":"(HB)","access":"RD","varp":"(SB)","classOrPackagep":"(N)"}
+                  ]},
+                  {"type":"ARG","addr":"(TM)","loc":"d,57:30,57:34",
+                   "exprp": [
+                    {"type":"CONST","name":"\\\"ok\\\"","addr":"(UM)","loc":"d,57:30,57:34","dtypep":"(HB)"}
+                  ]}
+                ]}
+              ]}
+            ]},
+            {"type":"CEXPR","addr":"(VM)","loc":"d,57:5,57:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(WM)","loc":"d,57:5,57:7","text":"\"t/t_constraint_json_only.v\""}
+            ]},
+            {"type":"CONST","name":"32'h39","addr":"(XM)","loc":"d,57:5,57:7","dtypep":"(EB)"},
+            {"type":"CEXPR","addr":"(YM)","loc":"d,57:5,57:7","dtypep":"(FC)","pure":true,
+             "nodesp": [
+              {"type":"TEXT","addr":"(ZM)","loc":"d,57:5,57:7","text":"\"    if (strings_equal(state, \\\"ok\\\"))\""}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"type":"TASK","name":"__Vsetup_constraints","addr":"(TE)","loc":"d,7:1,7:6","method":true,"lifetime":"NONE","cname":"__Vsetup_constraints",
+       "stmtsp": [
+        {"type":"STMTEXPR","addr":"(AN)","loc":"d,19:14,19:19",
+         "exprp": [
+          {"type":"TASKREF","name":"empty_setup_constraint","addr":"(BN)","loc":"d,19:14,19:19","dtypep":"(FC)","taskp":"(FF)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(CN)","loc":"d,21:14,21:18",
+         "exprp": [
+          {"type":"TASKREF","name":"size_setup_constraint","addr":"(DN)","loc":"d,21:14,21:18","dtypep":"(FC)","taskp":"(GF)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(EN)","loc":"d,28:14,28:17",
+         "exprp": [
+          {"type":"TASKREF","name":"ifs_setup_constraint","addr":"(FN)","loc":"d,28:14,28:17","dtypep":"(FC)","taskp":"(UI)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(GN)","loc":"d,41:14,41:22",
+         "exprp": [
+          {"type":"TASKREF","name":"arr_uniq_setup_constraint","addr":"(HN)","loc":"d,41:14,41:22","dtypep":"(FC)","taskp":"(NJ)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(IN)","loc":"d,48:14,48:19",
+         "exprp": [
+          {"type":"TASKREF","name":"order_setup_constraint","addr":"(JN)","loc":"d,48:14,48:19","dtypep":"(FC)","taskp":"(FL)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(KN)","loc":"d,50:14,50:17",
+         "exprp": [
+          {"type":"TASKREF","name":"dis_setup_constraint","addr":"(LN)","loc":"d,50:14,50:17","dtypep":"(FC)","taskp":"(NL)","classOrPackagep":"(N)"}
+        ]},
+        {"type":"STMTEXPR","addr":"(MN)","loc":"d,56:14,56:18",
+         "exprp": [
+          {"type":"TASKREF","name":"meth_setup_constraint","addr":"(NN)","loc":"d,56:14,56:18","dtypep":"(FC)","taskp":"(KM)","classOrPackagep":"(N)"}
+        ]}
+      ]},
+      {"type":"FUNC","name":"__VBasicRand","addr":"(DF)","loc":"d,7:1,7:6","dtypep":"(T)","method":true,"lifetime":"NONE","cname":"__VBasicRand",
+       "fvarp": [
+        {"type":"VAR","name":"__VBasicRand","addr":"(ON)","loc":"d,7:1,7:6","dtypep":"(T)","origName":"__VBasicRand","verilogName":"__VBasicRand","direction":"OUTPUT","declDirection":"NONE","isFuncReturn":true,"isFuncLocal":true,"lifetime":"VAUTOM","varType":"MEMBER","dtypeName":"bit"}
+      ],
+       "stmtsp": [
+        {"type":"ASSIGN","addr":"(PN)","loc":"d,7:1,7:6","dtypep":"(T)",
+         "rhsp": [
+          {"type":"CONST","name":"32'h1","addr":"(QN)","loc":"d,7:1,7:6","dtypep":"(EB)"}
+        ],
+         "lhsp": [
+          {"type":"VARREF","name":"__VBasicRand","addr":"(RN)","loc":"d,7:1,7:6","dtypep":"(T)","access":"WR","varp":"(ON)"}
+        ]}
+      ]}
     ]}
   ]}
 ],
  "miscsp": [
-  {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0","voidp":"(NB)",
+  {"type":"TYPETABLE","addr":"(C)","loc":"a,0:0,0:0","voidp":"(FC)",
    "typesp": [
-    {"type":"BASICDTYPE","name":"bit","addr":"(QB)","loc":"d,25:19,25:20","dtypep":"(QB)","keyword":"bit","range":"31:0","generic":true},
-    {"type":"BASICDTYPE","name":"string","addr":"(M)","loc":"d,73:5,73:11","dtypep":"(M)","keyword":"string","generic":true},
-    {"type":"BASICDTYPE","name":"int","addr":"(Q)","loc":"d,8:8,8:11","dtypep":"(Q)","keyword":"int","range":"31:0","generic":true,"signed":true},
-    {"type":"BASICDTYPE","name":"bit","addr":"(U)","loc":"d,11:8,11:11","dtypep":"(U)","keyword":"bit","generic":true},
-    {"type":"UNPACKARRAYDTYPE","addr":"(Y)","loc":"d,15:17,15:18","dtypep":"(Y)","declRange":"[0:1]","signed":true,"refDTypep":"(Q)",
+    {"type":"BASICDTYPE","name":"bit","addr":"(EB)","loc":"d,25:19,25:20","dtypep":"(EB)","keyword":"bit","range":"31:0","generic":true},
+    {"type":"VOIDDTYPE","addr":"(FC)","loc":"d,74:18,74:27","dtypep":"(FC)"},
+    {"type":"BASICDTYPE","name":"string","addr":"(HB)","loc":"d,75:5,75:11","dtypep":"(HB)","keyword":"string","generic":true},
+    {"type":"BASICDTYPE","name":"int","addr":"(KB)","loc":"d,8:8,8:11","dtypep":"(KB)","keyword":"int","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(X)","loc":"d,11:8,11:11","dtypep":"(X)","keyword":"bit","generic":true},
+    {"type":"UNPACKARRAYDTYPE","addr":"(RB)","loc":"d,15:17,15:18","dtypep":"(RB)","declRange":"[0:1]","signed":true,"refDTypep":"(KB)",
      "rangep": [
-      {"type":"RANGE","addr":"(RB)","loc":"d,15:17,15:18","ascending":true,"fromBracket":true,
+      {"type":"RANGE","addr":"(SN)","loc":"d,15:17,15:18","ascending":true,"fromBracket":true,
        "leftp": [
-        {"type":"CONST","name":"32'h0","addr":"(SB)","loc":"d,15:18,15:19","dtypep":"(QB)"}
+        {"type":"CONST","name":"32'h0","addr":"(TN)","loc":"d,15:18,15:19","dtypep":"(EB)"}
       ],
        "rightp": [
-        {"type":"CONST","name":"32'h1","addr":"(TB)","loc":"d,15:18,15:19","dtypep":"(QB)"}
+        {"type":"CONST","name":"32'h1","addr":"(UN)","loc":"d,15:18,15:19","dtypep":"(EB)"}
       ]}
     ]},
-    {"type":"VOIDDTYPE","addr":"(NB)","loc":"d,7:1,7:6","dtypep":"(NB)"},
-    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,69:3,69:9","dtypep":"(H)","classp":"(O)","classOrPackagep":"(O)"},
-    {"type":"BASICDTYPE","name":"VlRandomizer","addr":"(PB)","loc":"d,7:1,7:6","dtypep":"(PB)","keyword":"VlRandomizer","generic":true}
+    {"type":"BASICDTYPE","name":"logic","addr":"(CK)","loc":"d,32:16,32:18","dtypep":"(CK)","keyword":"logic","generic":true,"signed":true},
+    {"type":"CLASSREFDTYPE","name":"Packet","addr":"(H)","loc":"d,69:3,69:9","dtypep":"(H)","classp":"(N)","classOrPackagep":"(N)"},
+    {"type":"BASICDTYPE","name":"logic","addr":"(R)","loc":"d,74:9,74:11","dtypep":"(R)","keyword":"logic","range":"31:0","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(T)","loc":"d,74:12,74:13","dtypep":"(T)","keyword":"bit","range":"31:0","generic":true,"signed":true},
+    {"type":"BASICDTYPE","name":"VlRandomizer","addr":"(JC)","loc":"d,7:1,7:6","dtypep":"(JC)","keyword":"VlRandomizer","generic":true},
+    {"type":"BASICDTYPE","name":"logic","addr":"(KH)","loc":"d,25:12,25:16","dtypep":"(KH)","keyword":"logic","range":"63:0","generic":true},
+    {"type":"BASICDTYPE","name":"bit","addr":"(NC)","loc":"d,25:12,25:16","dtypep":"(NC)","keyword":"bit","range":"63:0","generic":true},
+    {"type":"BASICDTYPE","name":"QData","addr":"(IF)","loc":"d,25:12,25:16","dtypep":"(IF)","keyword":"QData","range":"63:0","generic":true}
   ]},
   {"type":"CONSTPOOL","addr":"(D)","loc":"a,0:0,0:0",
    "modulep": [
-    {"type":"MODULE","name":"@CONST-POOL@","addr":"(UB)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
+    {"type":"MODULE","name":"@CONST-POOL@","addr":"(VN)","loc":"a,0:0,0:0","origName":"@CONST-POOL@","verilogName":"@CONST-POOL@","unconnectedDrive":"DEFAULT_FALSE","lifetime":"NONE","timeunit":"NONE",
      "stmtsp": [
-      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(VB)","loc":"a,0:0,0:0","modp":"(UB)"}
+      {"type":"SCOPE","name":"@CONST-POOL@","addr":"(WN)","loc":"a,0:0,0:0","modp":"(VN)"}
     ]}
   ]}
 ]}

--- a/test_regress/t/t_constraint_json_only.v
+++ b/test_regress/t/t_constraint_json_only.v
@@ -69,7 +69,9 @@ module t;
   Packet p;
 
   initial begin
+    p = new;
     // Not testing use of constraints
+    if ($c(0)) p.randomize();
     $write("*-* All Finished *-*\n");
     $finish;
   end

--- a/test_regress/t/t_opt_dead.py
+++ b/test_regress/t/t_opt_dead.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=[test.pli_filename])
+test.compile(verilator_flags2=['--stats', test.pli_filename])
 
 test.execute()
 
@@ -22,5 +22,8 @@ test.execute()
 test.file_grep(test.obj_dir + "/V" + test.name + "__Dpi.h", r'dpii_Keep')
 test.file_grep(test.obj_dir + "/V" + test.name + "__Dpi.h", r'dpix_Keep')
 test.file_grep(test.obj_dir + "/V" + test.name + "_Pkg_public_kpt.h", r'public_int_Keep')
+
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, methods\s+(\d+)', 4)
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, non-methods\s+(\d+)', 2)
 
 test.passes()

--- a/test_regress/t/t_opt_dead.v
+++ b/test_regress/t/t_opt_dead.v
@@ -70,7 +70,18 @@ package Pkg_Keep;
   endfunction
 endpackage
 
-module t (  /*AUTOARG*/);
+class Cls_Keep;
+  task cls_task_Dead;
+  endtask
+  function void cls_func_Dead;
+  endfunction
+  static task cls_stask_Dead;
+  endtask
+  static function void cls_sfunc_Dead;
+  endfunction
+endclass
+
+module t;
 
   typedef struct {int struct_member_Dead;} struct_Dead_t;
   struct_Dead_t var_struct_Dead;
@@ -106,6 +117,8 @@ module t (  /*AUTOARG*/);
   always_comb assigned_to_Dead2 = assigned_to_Dead1;
 
   initial begin
+    Cls_Keep c;
+    c = new;
     assigned_to_Dead1 = 1;
     assigned_to_Dead1 = 2;
     $write("*-* All Finished *-*\n");

--- a/test_regress/t/t_opt_dead_task.py
+++ b/test_regress/t/t_opt_dead_task.py
@@ -14,7 +14,9 @@ test.scenarios('simulator')
 test.compile(verilator_flags2=["--stats", "--top-module t"])
 
 if test.vlt_all:
-    test.file_grep(test.stats, r'Optimizations, deadified FTasks\s+(\d+)', 6)
+    test.file_grep_not(test.stats, r'Optimizations, FTasks, deadified, methods\s+(\d+)')
+    test.file_grep(test.stats, r'Optimizations, FTasks, deadified, non-methods\s+(\d+)', 6)
+    test.file_grep(test.stats, r'Optimizations, FTasks, deadified, virtual\s+(\d+)', 1)
 
 test.execute()
 

--- a/test_regress/t/t_opt_dead_virt.py
+++ b/test_regress/t/t_opt_dead_virt.py
@@ -11,7 +11,7 @@ import vltest_bootstrap
 
 test.scenarios('simulator')
 
-test.compile(verilator_flags2=['--stats'])
+test.compile(verilator_flags2=['--stats', '--dumpi-graph 9'])
 
 test.execute()
 

--- a/test_regress/t/t_opt_dead_virt.py
+++ b/test_regress/t/t_opt_dead_virt.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+
+test.compile(verilator_flags2=['--stats'])
+
+test.execute()
+
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, methods\s+(\d+)', 1)
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, non-methods\s+(\d+)', 1)
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, virtual\s+(\d+)', 3)
+test.file_grep(test.stats, r'Optimizations, FTasks, virtual-to-nonvirtual demotion\s+(\d+)', 1)
+
+test.passes()

--- a/test_regress/t/t_opt_dead_virt.v
+++ b/test_regress/t/t_opt_dead_virt.v
@@ -1,0 +1,64 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain.
+// SPDX-FileCopyrightText: 2026 Wilson Snyder
+// SPDX-License-Identifier: CC0-1.0
+
+// verilog_format: off
+`define stop $stop
+`define checkd(gotv,expv) do if ((gotv) !== (expv)) begin $write("%%Error: %s:%0d:  got=%0d exp=%0d\n", `__FILE__,`__LINE__, (gotv), (expv)); `stop; end while(0);
+// verilog_format: on
+
+// Tests look for magic string "Dead" not to exist; V3Dead should remove these
+
+class ABase;
+  function void meth_Dead;  // Never used
+  endfunction
+  virtual function int virt_Dead;  // Never used
+    return 0;
+  endfunction
+  virtual function int virt_demote;  // Only in base, demoted
+    return 42;
+  endfunction
+  virtual function int virt_keep;
+    return 0;
+  endfunction
+endclass
+
+class AInh1 extends ABase;
+  virtual function int virt_Dead;  // Never used
+    return 1;
+  endfunction
+  virtual function int virt_keep;
+    return 1;
+  endfunction
+endclass
+
+class AInh2 extends ABase;
+  virtual function int virt_Dead;  // Never used
+    return 2;
+  endfunction
+  virtual function int virt_keep;
+    return 2;
+  endfunction
+endclass
+
+class ADead extends ABase;  // TODO not yet removed
+endclass
+
+module t;
+  function void mod_func_Dead;  // Never used
+  endfunction
+  initial begin
+    ABase i1;
+    ABase i2;
+    i1 = AInh1::new;
+    i2 = AInh2::new;
+    `checkd(i1.virt_demote(), 42);
+    `checkd(i2.virt_demote(), 42);
+    `checkd(i1.virt_keep(), 1);
+    `checkd(i2.virt_keep(), 2);
+    $write("*-* All Finished *-*\n");
+    $finish;
+  end
+endmodule

--- a/test_regress/t/t_opt_dead_virt_nodead.py
+++ b/test_regress/t/t_opt_dead_virt_nodead.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of either the GNU Lesser General Public License Version 3
+# or the Perl Artistic License Version 2.0.
+# SPDX-FileCopyrightText: 2024 Wilson Snyder
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+import vltest_bootstrap
+
+test.scenarios('simulator')
+test.top_filename = 't/t_opt_dead_virt.v'
+
+test.compile(verilator_flags2=['--stats', '-fno-dead-methods'])
+
+test.execute()
+
+test.file_grep_not(test.stats, r'Optimizations, FTasks, deadified, methods\s+(\d+)')
+test.file_grep(test.stats, r'Optimizations, FTasks, deadified, non-methods\s+(\d+)', 1)
+test.file_grep_not(test.stats, r'Optimizations, FTasks, deadified, virtual\s+(\d+)')
+test.file_grep_not(test.stats, r'Optimizations, FTasks, virtual-to-nonvirtual demotion\s+(\d+)')
+
+test.passes()


### PR DESCRIPTION
This adds dead-code elimination of class members that are not called, and also demotion of virtual functions to non-virtual when there is only a single method that could be called (to save the vtable entry). Both are mainly targeted at UVM compile-time improvement.

Also added `-fno-dead-methods` to disable these and get close to older behavior in case of bugs.

Running on test_regress/t/t_uvm_hello_all_v2020_3_2_dpi.py with empty ccache:

| Change   | Verilation | C++ output size | Exe
| -------- | ---------- | --------------- | ----------
| Baseline | 26.623 s   | 21.419 MB       | 624.704 MB
| This PR  | 23.580 s   | 15.221 MB       | 570.910 MB
| Delta    | 12% better | 29% better      | 9% better
